### PR TITLE
chore: disable automatic deploy workflows

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,52 +1,51 @@
 name: Nightly Publish
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch: # Allows manual triggering.
+    # Temporarily disabled automatic nightly publishes on pushes to main.
+    workflow_dispatch: # Allows manual triggering.
 
 jobs:
-  publish-nightly:
-    runs-on: ubuntu-latest
+    publish-nightly:
+        runs-on: ubuntu-latest
 
-    permissions:
-      contents: read # No tags pushed → read is enough.
+        permissions:
+            contents: read # No tags pushed → read is enough.
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-node-pnpm
-        with:
-          install-args: '--frozen-lockfile'
-      - name: Forge numeric Nightly version
-        id: version
-        env:
-          RUN_NUMBER: ${{ github.run_number }}
-        run: echo "number=$(( 5500 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
-      - name: Patch package.json version
-        env:
-          VERSION_NUMBER: ${{ steps.version.outputs.number }}
-        run: |
-          node <<'EOF'
-            const fs = require('fs');
-            const path = require('path');
-            const pkgPath = path.join(__dirname, 'apps', 'vscode-nightly', 'package.nightly.json');
-            const pkg = JSON.parse(fs.readFileSync(pkgPath,'utf8'));
-            const [maj, min] = pkg.version.split('.');
-            pkg.version = `${maj}.${min}.${process.env.VERSION_NUMBER}`;
-            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-            console.log(`🔖 Nightly version set to ${pkg.version}`);
-          EOF
-      - name: Build VSIX
-        run: pnpm vsix:nightly # Produces bin/roo-code-nightly-0.0.[count].vsix
-      - name: Publish to VS Code Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx vsce publish --packagePath "bin/$(/bin/ls bin | head -n1)"
-      - name: Publish to Open VSX Registry
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: npx ovsx publish "bin/$(ls bin | head -n1)"
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Setup Node.js and pnpm
+              uses: ./.github/actions/setup-node-pnpm
+              with:
+                  install-args: "--frozen-lockfile"
+            - name: Forge numeric Nightly version
+              id: version
+              env:
+                  RUN_NUMBER: ${{ github.run_number }}
+              run: echo "number=$(( 5500 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
+            - name: Patch package.json version
+              env:
+                  VERSION_NUMBER: ${{ steps.version.outputs.number }}
+              run: |
+                  node <<'EOF'
+                    const fs = require('fs');
+                    const path = require('path');
+                    const pkgPath = path.join(__dirname, 'apps', 'vscode-nightly', 'package.nightly.json');
+                    const pkg = JSON.parse(fs.readFileSync(pkgPath,'utf8'));
+                    const [maj, min] = pkg.version.split('.');
+                    pkg.version = `${maj}.${min}.${process.env.VERSION_NUMBER}`;
+                    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+                    console.log(`🔖 Nightly version set to ${pkg.version}`);
+                  EOF
+            - name: Build VSIX
+              run: pnpm vsix:nightly # Produces bin/roo-code-nightly-0.0.[count].vsix
+            - name: Publish to VS Code Marketplace
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+              run: npx vsce publish --packagePath "bin/$(/bin/ls bin | head -n1)"
+            - name: Publish to Open VSX Registry
+              env:
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+              run: npx ovsx publish "bin/$(ls bin | head -n1)"

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,51 +1,52 @@
 name: Nightly Publish
 
 on:
-    # Temporarily disabled automatic nightly publishes on pushes to main.
-    workflow_dispatch: # Allows manual triggering.
+  push:
+    branches: [main]
+  workflow_dispatch: # Allows manual triggering.
 
 jobs:
-    publish-nightly:
-        runs-on: ubuntu-latest
+  publish-nightly:
+    runs-on: ubuntu-latest
 
-        permissions:
-            contents: read # No tags pushed → read is enough.
+    permissions:
+      contents: read # No tags pushed → read is enough.
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - name: Setup Node.js and pnpm
-              uses: ./.github/actions/setup-node-pnpm
-              with:
-                  install-args: "--frozen-lockfile"
-            - name: Forge numeric Nightly version
-              id: version
-              env:
-                  RUN_NUMBER: ${{ github.run_number }}
-              run: echo "number=$(( 5500 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
-            - name: Patch package.json version
-              env:
-                  VERSION_NUMBER: ${{ steps.version.outputs.number }}
-              run: |
-                  node <<'EOF'
-                    const fs = require('fs');
-                    const path = require('path');
-                    const pkgPath = path.join(__dirname, 'apps', 'vscode-nightly', 'package.nightly.json');
-                    const pkg = JSON.parse(fs.readFileSync(pkgPath,'utf8'));
-                    const [maj, min] = pkg.version.split('.');
-                    pkg.version = `${maj}.${min}.${process.env.VERSION_NUMBER}`;
-                    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-                    console.log(`🔖 Nightly version set to ${pkg.version}`);
-                  EOF
-            - name: Build VSIX
-              run: pnpm vsix:nightly # Produces bin/roo-code-nightly-0.0.[count].vsix
-            - name: Publish to VS Code Marketplace
-              env:
-                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
-              run: npx vsce publish --packagePath "bin/$(/bin/ls bin | head -n1)"
-            - name: Publish to Open VSX Registry
-              env:
-                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
-              run: npx ovsx publish "bin/$(ls bin | head -n1)"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          install-args: '--frozen-lockfile'
+      - name: Forge numeric Nightly version
+        id: version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: echo "number=$(( 5500 + ${RUN_NUMBER} ))" >> $GITHUB_OUTPUT
+      - name: Patch package.json version
+        env:
+          VERSION_NUMBER: ${{ steps.version.outputs.number }}
+        run: |
+          node <<'EOF'
+            const fs = require('fs');
+            const path = require('path');
+            const pkgPath = path.join(__dirname, 'apps', 'vscode-nightly', 'package.nightly.json');
+            const pkg = JSON.parse(fs.readFileSync(pkgPath,'utf8'));
+            const [maj, min] = pkg.version.split('.');
+            pkg.version = `${maj}.${min}.${process.env.VERSION_NUMBER}`;
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+            console.log(`🔖 Nightly version set to ${pkg.version}`);
+          EOF
+      - name: Build VSIX
+        run: pnpm vsix:nightly # Produces bin/roo-code-nightly-0.0.[count].vsix
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx vsce publish --packagePath "bin/$(/bin/ls bin | head -n1)"
+      - name: Publish to Open VSX Registry
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: npx ovsx publish "bin/$(ls bin | head -n1)"

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -1,8 +1,9 @@
 name: Nightly Publish
 
 on:
-  push:
-    branches: [main]
+  # Temporarily disabled automatic nightly publishes on pushes to main.
+  # push:
+  #   branches: [main]
   workflow_dispatch: # Allows manual triggering.
 
 jobs:

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,7 +1,11 @@
 name: Deploy roocode.com
 
 on:
-    # Temporarily disabled automatic production website deploys.
+    push:
+        branches:
+            - main
+        paths:
+            - 'apps/web-roo-code/**'
     workflow_dispatch:
 
 concurrency:
@@ -21,11 +25,11 @@ jobs:
             - name: Check if VERCEL_TOKEN exists
               id: check
               run: |
-                  if [ -n "${{ secrets.VERCEL_TOKEN }}" ]; then
-                    echo "has-vercel-token=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "has-vercel-token=false" >> $GITHUB_OUTPUT
-                  fi
+                if [ -n "${{ secrets.VERCEL_TOKEN }}" ]; then
+                  echo "has-vercel-token=true" >> $GITHUB_OUTPUT
+                else
+                  echo "has-vercel-token=false" >> $GITHUB_OUTPUT
+                fi
 
     deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,11 +1,7 @@
 name: Deploy roocode.com
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - 'apps/web-roo-code/**'
+    # Temporarily disabled automatic production website deploys.
     workflow_dispatch:
 
 concurrency:
@@ -25,11 +21,11 @@ jobs:
             - name: Check if VERCEL_TOKEN exists
               id: check
               run: |
-                if [ -n "${{ secrets.VERCEL_TOKEN }}" ]; then
-                  echo "has-vercel-token=true" >> $GITHUB_OUTPUT
-                else
-                  echo "has-vercel-token=false" >> $GITHUB_OUTPUT
-                fi
+                  if [ -n "${{ secrets.VERCEL_TOKEN }}" ]; then
+                    echo "has-vercel-token=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "has-vercel-token=false" >> $GITHUB_OUTPUT
+                  fi
 
     deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,11 +1,12 @@
 name: Deploy roocode.com
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - 'apps/web-roo-code/**'
+    # Temporarily disabled automatic production website deploys.
+    # push:
+    #     branches:
+    #         - main
+    #     paths:
+    #         - 'apps/web-roo-code/**'
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,14 +1,15 @@
 name: Preview roocode.com
 
 on:
-    push:
-        branches-ignore:
-            - main
-        paths:
-            - "apps/web-roo-code/**"
-    pull_request:
-        paths:
-            - "apps/web-roo-code/**"
+    # Temporarily disabled automatic preview website deploys.
+    # push:
+    #     branches-ignore:
+    #         - main
+    #     paths:
+    #         - "apps/web-roo-code/**"
+    # pull_request:
+    #     paths:
+    #         - "apps/web-roo-code/**"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,14 +1,7 @@
 name: Preview roocode.com
 
 on:
-    push:
-        branches-ignore:
-            - main
-        paths:
-            - "apps/web-roo-code/**"
-    pull_request:
-        paths:
-            - "apps/web-roo-code/**"
+    # Temporarily disabled automatic preview website deploys.
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -1,7 +1,14 @@
 name: Preview roocode.com
 
 on:
-    # Temporarily disabled automatic preview website deploys.
+    push:
+        branches-ignore:
+            - main
+        paths:
+            - "apps/web-roo-code/**"
+    pull_request:
+        paths:
+            - "apps/web-roo-code/**"
     workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Temporarily disables automatic publishing and website deployment workflows while keeping manual dispatch available.

### Disabled automatic triggers

- Nightly extension publishes on pushes to `main`
- Production website deploys on `main` changes under `apps/web-roo-code/**`
- Website preview deploys for PRs and non-`main` branches touching `apps/web-roo-code/**`

### Still available

- Manual runs via `workflow_dispatch` remain enabled for all three workflows.

## Validation

- `pnpm lint`
- `pnpm check-types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic deployment triggers; deployments and previews now require manual start.
  * Updated publishing workflows to separate pre-release and stable publish paths and adjusted packaging/publishing behavior.
  * Renamed product identity and output channels from "Roo" to "Zoo" across packaging and build config.

* **Documentation**
  * Updated changelog and CLI README to reflect new release/versioning and build instructions.

* **Tests**
  * Adjusted tests to match renamed nightly identity and added telemetry assertion for release channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->