### PR TITLE
DeepSeek V4 Support

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -42,6 +42,7 @@ export const dynamicProviders = [
 	"roo",
 	"unbound",
 	"poe",
+	"deepseek",
 ] as const
 
 export type DynamicProvider = (typeof dynamicProviders)[number]

--- a/packages/types/src/providers/deepseek.ts
+++ b/packages/types/src/providers/deepseek.ts
@@ -6,9 +6,39 @@ import type { ModelInfo } from "../model.js"
 // continuation within the same turn. See: https://api-docs.deepseek.com/guides/thinking_mode
 export type DeepSeekModelId = keyof typeof deepSeekModels
 
-export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat"
+export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-v4-flash"
 
 export const deepSeekModels = {
+	"deepseek-v4-flash": {
+		maxTokens: 384_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["disable", "low", "medium", "high", "xhigh"],
+		preserveReasoning: true,
+		reasoningEffort: "high",
+		inputPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated Apr 29, 2026
+		outputPrice: 0.28, // $0.28 per million tokens - Updated Apr 29, 2026
+		cacheWritesPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated Apr 29, 2026
+		cacheReadsPrice: 0.0028, // $0.0028 per million tokens (cache hit) - Updated Apr 29, 2026
+		description: `DeepSeek-V4-Flash is DeepSeek's fast, cost-efficient V4 model. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
+	},
+	"deepseek-v4-pro": {
+		maxTokens: 384_000,
+		contextWindow: 1_000_000,
+		supportsImages: false,
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["disable", "low", "medium", "high", "xhigh"],
+		preserveReasoning: true,
+		reasoningEffort: "high",
+		// TODO(deepseek): Re-check V4 Pro discounted prices after DeepSeek's 2026-05-31 discount end date.
+		inputPrice: 0.435, // $0.435 per million tokens (cache miss, discounted) - Updated Apr 29, 2026
+		outputPrice: 0.87, // $0.87 per million tokens (discounted) - Updated Apr 29, 2026
+		cacheWritesPrice: 0.435, // $0.435 per million tokens (cache miss, discounted) - Updated Apr 29, 2026
+		cacheReadsPrice: 0.003625, // $0.003625 per million tokens (cache hit, discounted) - Updated Apr 29, 2026
+		description: `DeepSeek-V4-Pro is DeepSeek's strongest V4 model for reasoning, coding, long-context, and agentic workloads. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
+	},
+	// TODO(deepseek): Remove this compatibility alias after DeepSeek's 2026-07-24 retirement date.
 	"deepseek-chat": {
 		maxTokens: 8192, // 8K max output
 		contextWindow: 128_000,
@@ -18,8 +48,9 @@ export const deepSeekModels = {
 		outputPrice: 0.42, // $0.42 per million tokens - Updated Dec 9, 2025
 		cacheWritesPrice: 0.28, // $0.28 per million tokens (cache miss) - Updated Dec 9, 2025
 		cacheReadsPrice: 0.028, // $0.028 per million tokens (cache hit) - Updated Dec 9, 2025
-		description: `DeepSeek-V3.2 (Non-thinking Mode) achieves a significant breakthrough in inference speed over previous models. It tops the leaderboard among open-source models and rivals the most advanced closed-source models globally. Supports JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta).`,
+		description: `Legacy compatibility alias for the non-thinking mode of deepseek-v4-flash. DeepSeek plans to deprecate this model name on 2026-07-24.`,
 	},
+	// TODO(deepseek): Remove this compatibility alias after DeepSeek's 2026-07-24 retirement date.
 	"deepseek-reasoner": {
 		maxTokens: 8192, // 8K max output
 		contextWindow: 128_000,
@@ -30,7 +61,7 @@ export const deepSeekModels = {
 		outputPrice: 0.42, // $0.42 per million tokens - Updated Dec 9, 2025
 		cacheWritesPrice: 0.28, // $0.28 per million tokens (cache miss) - Updated Dec 9, 2025
 		cacheReadsPrice: 0.028, // $0.028 per million tokens (cache hit) - Updated Dec 9, 2025
-		description: `DeepSeek-V3.2 (Thinking Mode) achieves performance comparable to OpenAI-o1 across math, code, and reasoning tasks. Supports Chain of Thought reasoning with up to 8K output tokens. Supports JSON output, tool calls, and chat prefix completion (beta).`,
+		description: `Legacy compatibility alias for the thinking mode of deepseek-v4-flash. DeepSeek plans to deprecate this model name on 2026-07-24.`,
 	},
 } as const satisfies Record<string, ModelInfo>
 

--- a/src/api/providers/__tests__/deepseek.spec.ts
+++ b/src/api/providers/__tests__/deepseek.spec.ts
@@ -29,15 +29,15 @@ vi.mock("openai", () => {
 							}
 						}
 
-						// Check if this is a reasoning_content test by looking at model
-						const isReasonerModel = options.model?.includes("deepseek-reasoner")
+						// Check if this is a reasoning_content test by looking at thinking mode
+						const isThinkingModel = options.thinking?.type === "enabled"
 						const isToolCallTest = options.tools?.length > 0
 
 						// Return async iterator for streaming
 						return {
 							[Symbol.asyncIterator]: async function* () {
-								// For reasoner models, emit reasoning_content first
-								if (isReasonerModel) {
+								// For thinking models, emit reasoning_content first
+								if (isThinkingModel) {
 									yield {
 										choices: [
 											{
@@ -58,8 +58,8 @@ vi.mock("openai", () => {
 									}
 								}
 
-								// For tool call tests with reasoner, emit tool call
-								if (isReasonerModel && isToolCallTest) {
+								// For tool call tests with thinking mode, emit tool call
+								if (isThinkingModel && isToolCallTest) {
 									yield {
 										choices: [
 											{
@@ -206,10 +206,24 @@ describe("DeepSeekHandler", () => {
 			const model = handler.getModel()
 			expect(model.id).toBe(mockOptions.apiModelId)
 			expect(model.info).toBeDefined()
-			expect(model.info.maxTokens).toBe(8192) // deepseek-chat has 8K max
+			expect(model.info.maxTokens).toBe(8192) // deepseek-chat legacy alias has 8K max
 			expect(model.info.contextWindow).toBe(128_000)
 			expect(model.info.supportsImages).toBe(false)
 			expect(model.info.supportsPromptCache).toBe(true) // Should be true now
+			expect((model.info as ModelInfo).preserveReasoning).toBeUndefined()
+		})
+
+		it("should use deepseek-v4-flash as the default model ID for new configs", () => {
+			const handlerWithoutModel = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: undefined,
+			})
+			const model = handlerWithoutModel.getModel()
+			expect(model.id).toBe(deepSeekDefaultModelId)
+			expect(model.id).toBe("deepseek-v4-flash")
+			expect(model.info.maxTokens).toBe(384_000)
+			expect(model.info.contextWindow).toBe(1_000_000)
+			expect((model.info as ModelInfo).supportsReasoningEffort).toContain("xhigh")
 		})
 
 		it("should return correct model info for deepseek-reasoner", () => {
@@ -224,6 +238,21 @@ describe("DeepSeekHandler", () => {
 			expect(model.info.contextWindow).toBe(128_000)
 			expect(model.info.supportsImages).toBe(false)
 			expect(model.info.supportsPromptCache).toBe(true)
+		})
+
+		it("should return correct model info for deepseek-v4-pro", () => {
+			const handlerWithV4Pro = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-v4-pro",
+			})
+			const model = handlerWithV4Pro.getModel()
+			expect(model.id).toBe("deepseek-v4-pro")
+			expect(model.info).toBeDefined()
+			expect(model.info.maxTokens).toBe(384_000)
+			expect(model.info.contextWindow).toBe(1_000_000)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect((model.info as ModelInfo).preserveReasoning).toBe(true)
+			expect((model.info as ModelInfo).reasoningEffort).toBe("high")
 		})
 
 		it("should have preserveReasoning enabled for deepseek-reasoner to support interleaved thinking", () => {
@@ -242,7 +271,11 @@ describe("DeepSeekHandler", () => {
 
 		it("should NOT have preserveReasoning enabled for deepseek-chat", () => {
 			// deepseek-chat doesn't use thinking mode, so no need to preserve reasoning
-			const model = handler.getModel()
+			const chatHandler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-chat",
+			})
+			const model = chatHandler.getModel()
 			// Cast to ModelInfo to access preserveReasoning which is an optional property
 			expect((model.info as ModelInfo).preserveReasoning).toBeUndefined()
 		})
@@ -252,13 +285,17 @@ describe("DeepSeekHandler", () => {
 				...mockOptions,
 				apiModelId: "invalid-model",
 			})
+			const defaultHandler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: undefined,
+			})
 			const model = handlerWithInvalidModel.getModel()
 			expect(model.id).toBe("invalid-model") // Returns provided ID
 			expect(model.info).toBeDefined()
 			// With the current implementation, it's the same object reference when using default model info
-			expect(model.info).toBe(handler.getModel().info)
+			expect(model.info).toBe(defaultHandler.getModel().info)
 			// Should have the same base properties
-			expect(model.info.contextWindow).toBe(handler.getModel().info.contextWindow)
+			expect(model.info.contextWindow).toBe(defaultHandler.getModel().info.contextWindow)
 			// And should have supportsPromptCache set to true
 			expect(model.info.supportsPromptCache).toBe(true)
 		})
@@ -457,6 +494,100 @@ describe("DeepSeekHandler", () => {
 				}),
 				{}, // Empty path options for non-Azure URLs
 			)
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.reasoning_effort).toBeUndefined()
+		})
+
+		it("should enable thinking by default for deepseek-v4-flash", async () => {
+			const v4Handler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-v4-flash",
+			})
+
+			const stream = v4Handler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+				// Consume the stream
+			}
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					thinking: { type: "enabled" },
+					reasoning_effort: "high",
+					max_completion_tokens: 200_000,
+				}),
+				{},
+			)
+		})
+
+		it("should respect user max token override for deepseek-v4 models", async () => {
+			const v4Handler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-v4-flash",
+				modelMaxTokens: 32_000,
+			})
+
+			const stream = v4Handler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+				// Consume the stream
+			}
+
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.max_completion_tokens).toBe(32_000)
+		})
+
+		it("should map xhigh reasoning effort to DeepSeek max effort", async () => {
+			const v4Handler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-v4-pro",
+				reasoningEffort: "xhigh",
+			})
+
+			const stream = v4Handler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+				// Consume the stream
+			}
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					thinking: { type: "enabled" },
+					reasoning_effort: "max",
+				}),
+				{},
+			)
+		})
+
+		it("should disable thinking for deepseek-v4 models when reasoning is disabled", async () => {
+			const v4Handler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "deepseek-v4-pro",
+				enableReasoningEffort: false,
+			})
+
+			const stream = v4Handler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+				// Consume the stream
+			}
+
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.thinking).toEqual({ type: "disabled" })
+			expect(callArgs.reasoning_effort).toBeUndefined()
+		})
+
+		it("should not send V4 thinking parameters for unknown model IDs", async () => {
+			const customHandler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: "custom-deepseek-model",
+			})
+
+			const stream = customHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+				// Consume the stream
+			}
+
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.thinking).toBeUndefined()
+			expect(callArgs.reasoning_effort).toBeUndefined()
+			expect(callArgs.temperature).toBe(DEEP_SEEK_DEFAULT_TEMPERATURE)
 		})
 
 		it("should NOT pass thinking parameter for deepseek-chat model", async () => {

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -24,7 +24,8 @@ type DeepSeekChatCompletionParams = Omit<OpenAI.Chat.ChatCompletionCreateParamsS
 	reasoning_effort?: "high" | "max"
 }
 
-const supportsDeepSeekThinkingToggle = (modelId: string) => modelId.startsWith("deepseek-v4-")
+const deepSeekV4ThinkingModels = new Set(["deepseek-v4-flash", "deepseek-v4-pro"])
+const supportsDeepSeekThinkingToggle = (modelId: string) => deepSeekV4ThinkingModels.has(modelId)
 
 // Only known V4 models and the legacy reasoner alias support DeepSeek's
 // thinking fields. Custom model IDs still fall back to default metadata, but
@@ -34,7 +35,7 @@ const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions, 
 		return false
 	}
 
-	return modelId.includes("deepseek-reasoner") || supportsDeepSeekThinkingToggle(modelId)
+	return modelId === "deepseek-reasoner" || supportsDeepSeekThinkingToggle(modelId)
 }
 
 const normalizeDeepSeekReasoningEffort = (reasoningEffort?: string): "high" | "max" | undefined => {

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -30,7 +30,7 @@ const supportsDeepSeekThinkingToggle = (modelId: string) => deepSeekV4ThinkingMo
 // Only known V4 models and the legacy reasoner alias support DeepSeek's
 // thinking fields. Custom model IDs still fall back to default metadata, but
 // should not receive V4-only request parameters.
-const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions, reasoningEffort?: string) => {
+const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions) => {
 	if (options.enableReasoningEffort === false || options.reasoningEffort === "disable") {
 		return false
 	}
@@ -93,7 +93,7 @@ export class DeepSeekHandler extends OpenAiHandler {
 		const modelId = this.options.apiModelId ?? deepSeekDefaultModelId
 		const { info: modelInfo, temperature, reasoningEffort, maxTokens } = this.getModel()
 
-		const isThinkingModel = isDeepSeekThinkingEnabled(modelId, this.options, reasoningEffort)
+		const isThinkingModel = isDeepSeekThinkingEnabled(modelId, this.options)
 		const thinking = supportsDeepSeekThinkingToggle(modelId)
 			? ({ type: isThinkingModel ? "enabled" : "disabled" } as const)
 			: isThinkingModel

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -6,6 +6,7 @@ import {
 	deepSeekDefaultModelId,
 	DEEP_SEEK_DEFAULT_TEMPERATURE,
 	OPENAI_AZURE_AI_INFERENCE_PATH,
+	type ModelInfo,
 } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
@@ -18,8 +19,44 @@ import { OpenAiHandler } from "./openai"
 import type { ApiHandlerCreateMessageMetadata } from "../index"
 
 // Custom interface for DeepSeek params to support thinking mode
-type DeepSeekChatCompletionParams = OpenAI.Chat.ChatCompletionCreateParamsStreaming & {
+type DeepSeekChatCompletionParams = Omit<OpenAI.Chat.ChatCompletionCreateParamsStreaming, "reasoning_effort"> & {
 	thinking?: { type: "enabled" | "disabled" }
+	reasoning_effort?: "high" | "max"
+}
+
+const supportsDeepSeekThinkingToggle = (modelId: string) => modelId.startsWith("deepseek-v4-")
+
+// Only known V4 models and the legacy reasoner alias support DeepSeek's
+// thinking fields. Custom model IDs still fall back to default metadata, but
+// should not receive V4-only request parameters.
+const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions, reasoningEffort?: string) => {
+	if (options.enableReasoningEffort === false || options.reasoningEffort === "disable") {
+		return false
+	}
+
+	return modelId.includes("deepseek-reasoner") || supportsDeepSeekThinkingToggle(modelId)
+}
+
+const normalizeDeepSeekReasoningEffort = (reasoningEffort?: string): "high" | "max" | undefined => {
+	if (!reasoningEffort || reasoningEffort === "disable") {
+		return undefined
+	}
+
+	// DeepSeek currently maps low/medium to high and xhigh to max in thinking mode.
+	return reasoningEffort === "xhigh" ? "max" : "high"
+}
+
+// Use the computed maxTokens from getModelParams rather than raw model metadata.
+// V4 advertises a 384K maximum output, but the project convention caps most
+// models to 20% of context unless the user explicitly overrides modelMaxTokens.
+const addDeepSeekMaxTokensIfNeeded = (
+	requestOptions: DeepSeekChatCompletionParams,
+	options: ApiHandlerOptions,
+	computedMaxTokens?: number,
+) => {
+	if (options.includeMaxTokens === true) {
+		requestOptions.max_completion_tokens = options.modelMaxTokens || computedMaxTokens
+	}
 }
 
 export class DeepSeekHandler extends OpenAiHandler {
@@ -53,14 +90,19 @@ export class DeepSeekHandler extends OpenAiHandler {
 		metadata?: ApiHandlerCreateMessageMetadata,
 	): ApiStream {
 		const modelId = this.options.apiModelId ?? deepSeekDefaultModelId
-		const { info: modelInfo } = this.getModel()
+		const { info: modelInfo, temperature, reasoningEffort, maxTokens } = this.getModel()
 
-		// Check if this is a thinking-enabled model (deepseek-reasoner)
-		const isThinkingModel = modelId.includes("deepseek-reasoner")
+		const isThinkingModel = isDeepSeekThinkingEnabled(modelId, this.options, reasoningEffort)
+		const thinking = supportsDeepSeekThinkingToggle(modelId)
+			? ({ type: isThinkingModel ? "enabled" : "disabled" } as const)
+			: isThinkingModel
+				? ({ type: "enabled" } as const)
+				: undefined
+		const deepSeekReasoningEffort = isThinkingModel ? normalizeDeepSeekReasoningEffort(reasoningEffort) : undefined
 
 		// Convert messages to R1 format (merges consecutive same-role messages)
 		// This is required for DeepSeek which does not support successive messages with the same role
-		// For thinking models (deepseek-reasoner), enable mergeToolResultText to preserve reasoning_content
+		// For thinking models, enable mergeToolResultText to preserve reasoning_content
 		// during tool call sequences. Without this, environment_details text after tool_results would
 		// create user messages that cause DeepSeek to drop all previous reasoning_content.
 		// See: https://api-docs.deepseek.com/guides/thinking_mode
@@ -70,19 +112,18 @@ export class DeepSeekHandler extends OpenAiHandler {
 
 		const requestOptions: DeepSeekChatCompletionParams = {
 			model: modelId,
-			temperature: this.options.modelTemperature ?? DEEP_SEEK_DEFAULT_TEMPERATURE,
+			...(!isThinkingModel && { temperature: temperature ?? DEEP_SEEK_DEFAULT_TEMPERATURE }),
 			messages: convertedMessages,
 			stream: true as const,
 			stream_options: { include_usage: true },
-			// Enable thinking mode for deepseek-reasoner or when tools are used with thinking model
-			...(isThinkingModel && { thinking: { type: "enabled" } }),
+			...(thinking && { thinking }),
+			...(deepSeekReasoningEffort && { reasoning_effort: deepSeekReasoningEffort }),
 			tools: this.convertToolsForOpenAI(metadata?.tools),
 			tool_choice: metadata?.tool_choice,
 			parallel_tool_calls: metadata?.parallelToolCalls ?? true,
 		}
 
-		// Add max_tokens if needed
-		this.addMaxTokensIfNeeded(requestOptions, modelInfo)
+		addDeepSeekMaxTokensIfNeeded(requestOptions, this.options, maxTokens)
 
 		// Check if base URL is Azure AI Inference (for DeepSeek via Azure)
 		const isAzureAiInference = this._isAzureAiInference(this.options.deepSeekBaseUrl)
@@ -90,7 +131,7 @@ export class DeepSeekHandler extends OpenAiHandler {
 		let stream
 		try {
 			stream = await this.client.chat.completions.create(
-				requestOptions,
+				requestOptions as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
 				isAzureAiInference ? { path: OPENAI_AZURE_AI_INFERENCE_PATH } : {},
 			)
 		} catch (error) {

--- a/src/api/providers/fetchers/deepseek.ts
+++ b/src/api/providers/fetchers/deepseek.ts
@@ -1,0 +1,91 @@
+import type { ModelRecord } from "@roo-code/types"
+import { deepSeekModels, DEEP_SEEK_DEFAULT_TEMPERATURE } from "@roo-code/types"
+
+import { DEFAULT_HEADERS } from "../constants"
+
+/**
+ * Fetches available models from the DeepSeek API and merges them with known specs.
+ *
+ * The DeepSeek /models endpoint only returns basic model IDs without pricing
+ * or context window info, so we merge the API response with the static
+ * `deepSeekModels` map for known models. Unknown models get sensible defaults.
+ */
+export async function getDeepSeekModels(baseUrl?: string, apiKey?: string): Promise<ModelRecord> {
+	const normalizedBase = (baseUrl || "https://api.deepseek.com").replace(/\/?v1\/?$/, "")
+	const url = `${normalizedBase}/models`
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		...DEFAULT_HEADERS,
+	}
+
+	if (apiKey) {
+		headers["Authorization"] = `Bearer ${apiKey}`
+	}
+
+	const controller = new AbortController()
+	const timeoutId = setTimeout(() => controller.abort(), 10000)
+
+	try {
+		const response = await fetch(url, {
+			headers,
+			signal: controller.signal,
+		})
+
+		if (!response.ok) {
+			let errorBody = ""
+			try {
+				errorBody = await response.text()
+			} catch {
+				errorBody = "(unable to read response body)"
+			}
+
+			console.error(`[getDeepSeekModels] HTTP error:`, {
+				status: response.status,
+				statusText: response.statusText,
+				url,
+				body: errorBody,
+			})
+
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+		}
+
+		const data = await response.json()
+
+		if (!data?.data || !Array.isArray(data.data)) {
+			console.error("[getDeepSeekModels] Unexpected response format:", data)
+			throw new Error("Failed to fetch DeepSeek models: Unexpected response format.")
+		}
+
+		// Use null-prototype object to prevent prototype pollution
+		const models: ModelRecord = Object.create(null)
+
+		for (const model of data.data) {
+			const modelId = typeof model.id === "string" && model.id ? model.id : null
+			if (!modelId) continue
+
+			const knownSpecs = deepSeekModels[modelId as keyof typeof deepSeekModels]
+
+			if (knownSpecs) {
+				models[modelId] = { ...knownSpecs }
+			} else {
+				models[modelId] = {
+					maxTokens: 8192,
+					contextWindow: 128_000,
+					supportsImages: false,
+					supportsPromptCache: true,
+					inputPrice: 0.28,
+					outputPrice: 0.42,
+					cacheWritesPrice: 0.28,
+					cacheReadsPrice: 0.028,
+					defaultTemperature: DEEP_SEEK_DEFAULT_TEMPERATURE,
+					description: `DeepSeek model: ${modelId}`,
+				}
+			}
+		}
+
+		return models
+	} finally {
+		clearTimeout(timeoutId)
+	}
+}

--- a/src/api/providers/fetchers/modelCache.ts
+++ b/src/api/providers/fetchers/modelCache.ts
@@ -26,6 +26,7 @@ import { getOllamaModels } from "./ollama"
 import { getLMStudioModels } from "./lmstudio"
 import { getPoeModels } from "./poe"
 import { getRooModels } from "./roo"
+import { getDeepSeekModels } from "./deepseek"
 
 const memoryCache = new NodeCache({ stdTTL: 5 * 60, checkperiod: 5 * 60 })
 
@@ -94,6 +95,9 @@ async function fetchModelsFromProvider(options: GetModelsOptions): Promise<Model
 		}
 		case "poe":
 			models = await getPoeModels(options.apiKey, options.baseUrl)
+			break
+		case "deepseek":
+			models = await getDeepSeekModels(options.baseUrl, options.apiKey)
 			break
 		default: {
 			// Ensures router is exhaustively checked if RouterName is a strict union.

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -956,6 +956,7 @@ export const webviewMessageHandler = async (
 						lmstudio: {},
 						roo: {},
 						poe: {},
+						deepseek: {},
 					}
 
 			const safeGetModels = async (options: GetModelsOptions): Promise<ModelRecord> => {
@@ -1031,6 +1032,21 @@ export const webviewMessageHandler = async (
 				candidates.push({
 					key: "poe",
 					options: { provider: "poe", apiKey: poeApiKey, baseUrl: poeBaseUrl },
+				})
+			}
+
+			// DeepSeek is conditional on apiKey
+			const deepSeekApiKey = apiConfiguration.deepSeekApiKey || message?.values?.deepSeekApiKey
+			const deepSeekBaseUrl = apiConfiguration.deepSeekBaseUrl || message?.values?.deepSeekBaseUrl
+
+			if (deepSeekApiKey) {
+				if (message?.values?.deepSeekApiKey || message?.values?.deepSeekBaseUrl) {
+					await flushModels({ provider: "deepseek", apiKey: deepSeekApiKey, baseUrl: deepSeekBaseUrl }, true)
+				}
+
+				candidates.push({
+					key: "deepseek",
+					options: { provider: "deepseek", apiKey: deepSeekApiKey, baseUrl: deepSeekBaseUrl },
 				})
 			}
 

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1036,8 +1036,8 @@ export const webviewMessageHandler = async (
 			}
 
 			// DeepSeek is conditional on apiKey
-			const deepSeekApiKey = apiConfiguration.deepSeekApiKey || message?.values?.deepSeekApiKey
-			const deepSeekBaseUrl = apiConfiguration.deepSeekBaseUrl || message?.values?.deepSeekBaseUrl
+			const deepSeekApiKey = message?.values?.deepSeekApiKey ?? apiConfiguration.deepSeekApiKey
+			const deepSeekBaseUrl = message?.values?.deepSeekBaseUrl ?? apiConfiguration.deepSeekBaseUrl
 
 			if (deepSeekApiKey) {
 				if (message?.values?.deepSeekApiKey || message?.values?.deepSeekBaseUrl) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -178,6 +178,7 @@ const dynamicProviderExtras = {
 	lmstudio: {} as {}, // eslint-disable-line @typescript-eslint/no-empty-object-type
 	roo: {} as { apiKey?: string; baseUrl?: string },
 	poe: {} as { apiKey?: string; baseUrl?: string },
+	deepseek: {} as { apiKey?: string; baseUrl?: string },
 } as const satisfies Record<RouterName, object>
 
 // Build the dynamic options union from the map, intersected with CommonFetchParams

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -624,7 +624,10 @@ const ApiOptions = ({
 						<DeepSeek
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
+							routerModels={routerModels}
 							simplifySettings={fromWelcomeView}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={modelValidationError}
 						/>
 					)}
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -624,10 +624,6 @@ const ApiOptions = ({
 						<DeepSeek
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
-							routerModels={routerModels}
-							simplifySettings={fromWelcomeView}
-							organizationAllowList={organizationAllowList}
-							modelValidationError={modelValidationError}
 						/>
 					)}
 

--- a/webview-ui/src/components/settings/providers/DeepSeek.tsx
+++ b/webview-ui/src/components/settings/providers/DeepSeek.tsx
@@ -1,20 +1,32 @@
 import { useCallback } from "react"
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
-import type { ProviderSettings } from "@roo-code/types"
+import type { ProviderSettings, OrganizationAllowList, RouterModels } from "@roo-code/types"
+import { deepSeekDefaultModelId } from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
 
 import { inputEventTransform } from "../transforms"
+import { ModelPicker } from "../ModelPicker"
 
 type DeepSeekProps = {
 	apiConfiguration: ProviderSettings
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
+	routerModels?: RouterModels
 	simplifySettings?: boolean
+	organizationAllowList: OrganizationAllowList
+	modelValidationError?: string
 }
 
-export const DeepSeek = ({ apiConfiguration, setApiConfigurationField }: DeepSeekProps) => {
+export const DeepSeek = ({
+	apiConfiguration,
+	setApiConfigurationField,
+	routerModels,
+	simplifySettings,
+	organizationAllowList,
+	modelValidationError,
+}: DeepSeekProps) => {
 	const { t } = useAppTranslation()
 
 	const handleInputChange = useCallback(
@@ -46,6 +58,18 @@ export const DeepSeek = ({ apiConfiguration, setApiConfigurationField }: DeepSee
 					{t("settings:providers.getDeepSeekApiKey")}
 				</VSCodeButtonLink>
 			)}
+			<ModelPicker
+				apiConfiguration={apiConfiguration}
+				setApiConfigurationField={setApiConfigurationField}
+				defaultModelId={deepSeekDefaultModelId}
+				models={routerModels?.deepseek ?? {}}
+				modelIdKey="apiModelId"
+				serviceName="DeepSeek"
+				serviceUrl="https://platform.deepseek.com"
+				organizationAllowList={organizationAllowList}
+				errorMessage={modelValidationError}
+				simplifySettings={simplifySettings}
+			/>
 		</>
 	)
 }

--- a/webview-ui/src/components/settings/providers/DeepSeek.tsx
+++ b/webview-ui/src/components/settings/providers/DeepSeek.tsx
@@ -1,32 +1,19 @@
 import { useCallback } from "react"
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
-import type { ProviderSettings, OrganizationAllowList, RouterModels } from "@roo-code/types"
-import { deepSeekDefaultModelId } from "@roo-code/types"
+import type { ProviderSettings } from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
 
 import { inputEventTransform } from "../transforms"
-import { ModelPicker } from "../ModelPicker"
 
 type DeepSeekProps = {
 	apiConfiguration: ProviderSettings
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
-	routerModels?: RouterModels
-	simplifySettings?: boolean
-	organizationAllowList: OrganizationAllowList
-	modelValidationError?: string
 }
 
-export const DeepSeek = ({
-	apiConfiguration,
-	setApiConfigurationField,
-	routerModels,
-	simplifySettings,
-	organizationAllowList,
-	modelValidationError,
-}: DeepSeekProps) => {
+export const DeepSeek = ({ apiConfiguration, setApiConfigurationField }: DeepSeekProps) => {
 	const { t } = useAppTranslation()
 
 	const handleInputChange = useCallback(
@@ -58,18 +45,6 @@ export const DeepSeek = ({
 					{t("settings:providers.getDeepSeekApiKey")}
 				</VSCodeButtonLink>
 			)}
-			<ModelPicker
-				apiConfiguration={apiConfiguration}
-				setApiConfigurationField={setApiConfigurationField}
-				defaultModelId={deepSeekDefaultModelId}
-				models={routerModels?.deepseek ?? {}}
-				modelIdKey="apiModelId"
-				serviceName="DeepSeek"
-				serviceUrl="https://platform.deepseek.com"
-				organizationAllowList={organizationAllowList}
-				errorMessage={modelValidationError}
-				simplifySettings={simplifySettings}
-			/>
 		</>
 	)
 }

--- a/webview-ui/src/components/settings/utils/providerModelConfig.ts
+++ b/webview-ui/src/components/settings/utils/providerModelConfig.ts
@@ -127,6 +127,7 @@ export const PROVIDERS_WITH_CUSTOM_MODEL_UI: ProviderName[] = [
 	"ollama",
 	"lmstudio",
 	"vscode-lm",
+	"deepseek",
 ]
 
 /**

--- a/webview-ui/src/components/settings/utils/providerModelConfig.ts
+++ b/webview-ui/src/components/settings/utils/providerModelConfig.ts
@@ -127,7 +127,6 @@ export const PROVIDERS_WITH_CUSTOM_MODEL_UI: ProviderName[] = [
 	"ollama",
 	"lmstudio",
 	"vscode-lm",
-	"deepseek",
 ]
 
 /**

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -232,7 +232,10 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case "deepseek": {
-			const id = getValidatedModelId(apiConfiguration.apiModelId, routerModels.deepseek, defaultModelId)
+			const availableModels = routerModels.deepseek
+				? { ...deepSeekModels, ...routerModels.deepseek }
+				: deepSeekModels
+			const id = getValidatedModelId(apiConfiguration.apiModelId, availableModels, defaultModelId)
 			const routerInfo = routerModels.deepseek?.[id]
 			const staticInfo = deepSeekModels[id as keyof typeof deepSeekModels]
 			return { id, info: routerInfo ?? staticInfo }

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -232,9 +232,10 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case "deepseek": {
-			const id = apiConfiguration.apiModelId ?? defaultModelId
-			const info = deepSeekModels[id as keyof typeof deepSeekModels]
-			return { id, info }
+			const id = getValidatedModelId(apiConfiguration.apiModelId, routerModels.deepseek, defaultModelId)
+			const routerInfo = routerModels.deepseek?.[id]
+			const staticInfo = deepSeekModels[id as keyof typeof deepSeekModels]
+			return { id, info: routerInfo ?? staticInfo }
 		}
 		case "moonshot": {
 			const id = apiConfiguration.apiModelId ?? defaultModelId

--- a/webview-ui/src/utils/__tests__/validate.spec.ts
+++ b/webview-ui/src/utils/__tests__/validate.spec.ts
@@ -46,6 +46,7 @@ describe("Model Validation Functions", () => {
 		"vercel-ai-gateway": {},
 		roo: {},
 		poe: {},
+		deepseek: {},
 	}
 
 	const allowAllOrganization: OrganizationAllowList = {


### PR DESCRIPTION
### Related GitHub Issue

Closes #12173 #12174 #12177 #12203


### Description

Add first-class DeepSeek V4 model metadata for deepseek-v4-flash and deepseek-v4-pro, and make deepseek-v4-flash the default model for new DeepSeek provider configs.

Update DeepSeek request construction for V4 thinking mode:
- send the thinking toggle only for known V4 models or legacy deepseek-reasoner
- map xhigh reasoning effort to DeepSeek's max effort
- preserve legacy deepseek-chat non-thinking behavior
- avoid sending V4-only thinking params to unknown/custom model IDs
- use the computed max-token cap instead of raw model metadata so V4 does not default to max_completion_tokens=384000


### Test Procedure

Add tests covering V4 model metadata, new default behavior, legacy alias compatibility, thinking-mode request params, max-token overrides, and unknown model fallback behavior.

### Pre-Submission Checklist

- [x ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x ] **Self-Review**: I have performed a thorough self-review of my code.
- [x ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos


### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ x] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

Keep deepseek-chat and deepseek-reasoner available as compatibility aliases until DeepSeek's published 2026-07-24 retirement date. Add TODOs for removing those aliases after the cutoff, without marking them as deprecated in metadata so existing users can continue selecting and using them during the transition.

### Additional Notes


### Get in Touch

pixe1forge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek V4 models (v4-flash and v4-pro)
  * Enabled dynamic model discovery from the DeepSeek API

* **Updates**
  * Changed default DeepSeek model to v4-flash
  * Marked deepseek-chat and deepseek-reasoner as legacy compatibility aliases (deprecated 2026-07-24)
  * Improved reasoning and thinking parameter handling across model variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->