### PR TITLE
Refactor core monolith helpers

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -132,6 +132,7 @@ import { AutoApprovalHandler, checkAutoApproval } from "../auto-approval"
 import { MessageManager } from "../message-manager"
 import { validateAndFixToolResultIds } from "./validateToolResultIds"
 import { mergeConsecutiveApiMessages } from "./mergeConsecutiveApiMessages"
+import { prepareApiConversationMessage } from "./apiConversationHistory"
 
 const MAX_EXPONENTIAL_BACKOFF_SECONDS = 600 // 10 minutes
 const DEFAULT_USAGE_COLLECTION_TIMEOUT_MS = 5000 // 5 seconds
@@ -861,162 +862,15 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async addToApiConversationHistory(message: Anthropic.MessageParam, reasoning?: string) {
-		// Capture the encrypted_content / thought signatures from the provider (e.g., OpenAI Responses API, Google GenAI) if present.
-		// We only persist data reported by the current response body.
-		const handler = this.api as ApiHandler & {
-			getResponseId?: () => string | undefined
-			getEncryptedContent?: () => { encrypted_content: string; id?: string } | undefined
-			getThoughtSignature?: () => string | undefined
-			getSummary?: () => any[] | undefined
-			getReasoningDetails?: () => any[] | undefined
-		}
-
-		if (message.role === "assistant") {
-			const responseId = handler.getResponseId?.()
-			const reasoningData = handler.getEncryptedContent?.()
-			const thoughtSignature = handler.getThoughtSignature?.()
-			const reasoningSummary = handler.getSummary?.()
-			const reasoningDetails = handler.getReasoningDetails?.()
-
-			// Only Anthropic's API expects/validates the special `thinking` content block signature.
-			// Other providers (notably Gemini 3) use different signature semantics (e.g. `thoughtSignature`)
-			// and require round-tripping the signature in their own format.
-			const modelId = getModelId(this.apiConfiguration)
-			const apiProvider = this.apiConfiguration.apiProvider
-			const apiProtocol = getApiProtocol(
-				apiProvider && !isRetiredProvider(apiProvider) ? apiProvider : undefined,
-				modelId,
-			)
-			const isAnthropicProtocol = apiProtocol === "anthropic"
-
-			// Start from the original assistant message
-			const messageWithTs: any = {
-				...message,
-				...(responseId ? { id: responseId } : {}),
-				ts: Date.now(),
-			}
-
-			// Store reasoning_details array if present (for models like Gemini 3)
-			if (reasoningDetails) {
-				messageWithTs.reasoning_details = reasoningDetails
-			}
-
-			// Store reasoning: Anthropic thinking (with signature), plain text (most providers), or encrypted (OpenAI Native)
-			// Skip if reasoning_details already contains the reasoning (to avoid duplication)
-			if (isAnthropicProtocol && reasoning && thoughtSignature && !reasoningDetails) {
-				// Anthropic provider with extended thinking: Store as proper `thinking` block
-				// This format passes through anthropic-filter.ts and is properly round-tripped
-				// for interleaved thinking with tool use (required by Anthropic API)
-				const thinkingBlock = {
-					type: "thinking",
-					thinking: reasoning,
-					signature: thoughtSignature,
-				}
-
-				if (typeof messageWithTs.content === "string") {
-					messageWithTs.content = [
-						thinkingBlock,
-						{ type: "text", text: messageWithTs.content } satisfies Anthropic.Messages.TextBlockParam,
-					]
-				} else if (Array.isArray(messageWithTs.content)) {
-					messageWithTs.content = [thinkingBlock, ...messageWithTs.content]
-				} else if (!messageWithTs.content) {
-					messageWithTs.content = [thinkingBlock]
-				}
-			} else if (reasoning && !reasoningDetails) {
-				// Other providers (non-Anthropic): Store as generic reasoning block
-				const reasoningBlock = {
-					type: "reasoning",
-					text: reasoning,
-					summary: reasoningSummary ?? ([] as any[]),
-				}
-
-				if (typeof messageWithTs.content === "string") {
-					messageWithTs.content = [
-						reasoningBlock,
-						{ type: "text", text: messageWithTs.content } satisfies Anthropic.Messages.TextBlockParam,
-					]
-				} else if (Array.isArray(messageWithTs.content)) {
-					messageWithTs.content = [reasoningBlock, ...messageWithTs.content]
-				} else if (!messageWithTs.content) {
-					messageWithTs.content = [reasoningBlock]
-				}
-			} else if (reasoningData?.encrypted_content) {
-				// OpenAI Native encrypted reasoning
-				const reasoningBlock = {
-					type: "reasoning",
-					summary: [] as any[],
-					encrypted_content: reasoningData.encrypted_content,
-					...(reasoningData.id ? { id: reasoningData.id } : {}),
-				}
-
-				if (typeof messageWithTs.content === "string") {
-					messageWithTs.content = [
-						reasoningBlock,
-						{ type: "text", text: messageWithTs.content } satisfies Anthropic.Messages.TextBlockParam,
-					]
-				} else if (Array.isArray(messageWithTs.content)) {
-					messageWithTs.content = [reasoningBlock, ...messageWithTs.content]
-				} else if (!messageWithTs.content) {
-					messageWithTs.content = [reasoningBlock]
-				}
-			}
-
-			// For non-Anthropic providers (e.g., Gemini 3), persist the thought signature as its own
-			// content block so converters can attach it back to the correct provider-specific fields.
-			// Note: For Anthropic extended thinking, the signature is already included in the thinking block above.
-			if (thoughtSignature && !isAnthropicProtocol) {
-				const thoughtSignatureBlock = {
-					type: "thoughtSignature",
-					thoughtSignature,
-				}
-
-				if (typeof messageWithTs.content === "string") {
-					messageWithTs.content = [
-						{ type: "text", text: messageWithTs.content } satisfies Anthropic.Messages.TextBlockParam,
-						thoughtSignatureBlock,
-					]
-				} else if (Array.isArray(messageWithTs.content)) {
-					messageWithTs.content = [...messageWithTs.content, thoughtSignatureBlock]
-				} else if (!messageWithTs.content) {
-					messageWithTs.content = [thoughtSignatureBlock]
-				}
-			}
-
-			this.apiConversationHistory.push(messageWithTs)
-		} else {
-			// For user messages, validate tool_result IDs ONLY when the immediately previous *effective* message
-			// is an assistant message.
-			//
-			// If the previous effective message is also a user message (e.g., summary + a new user message),
-			// validating against any earlier assistant message can incorrectly inject placeholder tool_results.
-			const effectiveHistoryForValidation = getEffectiveApiHistory(this.apiConversationHistory)
-			const lastEffective = effectiveHistoryForValidation[effectiveHistoryForValidation.length - 1]
-			const historyForValidation = lastEffective?.role === "assistant" ? effectiveHistoryForValidation : []
-
-			// If the previous effective message is NOT an assistant, convert tool_result blocks to text blocks.
-			// This prevents orphaned tool_results from being filtered out by getEffectiveApiHistory.
-			// This can happen when condensing occurs after the assistant sends tool_uses but before
-			// the user responds - the tool_use blocks get condensed away, leaving orphaned tool_results.
-			let messageToAdd = message
-			if (lastEffective?.role !== "assistant" && Array.isArray(message.content)) {
-				messageToAdd = {
-					...message,
-					content: message.content.map((block) =>
-						block.type === "tool_result"
-							? {
-									type: "text" as const,
-									text: `Tool result:\n${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}`,
-								}
-							: block,
-					),
-				}
-			}
-
-			const validatedMessage = validateAndFixToolResultIds(messageToAdd, historyForValidation)
-			const messageWithTs = { ...validatedMessage, ts: Date.now() }
-			this.apiConversationHistory.push(messageWithTs)
-		}
+		this.apiConversationHistory.push(
+			prepareApiConversationMessage({
+				message,
+				reasoning,
+				api: this.api,
+				apiConfiguration: this.apiConfiguration,
+				apiConversationHistory: this.apiConversationHistory,
+			}),
+		)
 
 		await this.saveApiConversationHistory()
 	}

--- a/src/core/task/__tests__/apiConversationHistory.spec.ts
+++ b/src/core/task/__tests__/apiConversationHistory.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { prepareApiConversationMessage } from "../apiConversationHistory.js"
+
+describe("prepareApiConversationMessage", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2026-01-02T03:04:05.000Z"))
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("prepends Anthropic thinking blocks with thought signatures", () => {
+		const result = prepareApiConversationMessage({
+			message: { role: "assistant", content: "answer" },
+			reasoning: "private reasoning",
+			api: {
+				getResponseId: () => "response-1",
+				getThoughtSignature: () => "signature-1",
+			} as any,
+			apiConfiguration: { apiProvider: "anthropic", apiModelId: "claude-3-5-sonnet" } as any,
+			apiConversationHistory: [],
+		}) as any
+
+		expect(result).toMatchObject({
+			role: "assistant",
+			id: "response-1",
+			ts: Date.now(),
+		})
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "private reasoning", signature: "signature-1" },
+			{ type: "text", text: "answer" },
+		])
+	})
+
+	it("prepends non-Anthropic reasoning blocks without dead summary fallback", () => {
+		const result = prepareApiConversationMessage({
+			message: { role: "assistant", content: "answer" },
+			reasoning: "visible reasoning",
+			api: {} as any,
+			apiConfiguration: { apiProvider: "openrouter", openRouterModelId: "openai/gpt-4" } as any,
+			apiConversationHistory: [],
+		}) as any
+
+		expect(result.content).toEqual([
+			{ type: "reasoning", text: "visible reasoning" },
+			{ type: "text", text: "answer" },
+		])
+		expect(result.content[0]).not.toHaveProperty("summary")
+	})
+
+	it("preserves encrypted reasoning content", () => {
+		const result = prepareApiConversationMessage({
+			message: { role: "assistant", content: [{ type: "text", text: "answer" }] },
+			api: {
+				getEncryptedContent: () => ({ encrypted_content: "encrypted", id: "reasoning-1" }),
+			} as any,
+			apiConfiguration: { apiProvider: "openrouter", openRouterModelId: "openai/gpt-4" } as any,
+			apiConversationHistory: [],
+		}) as any
+
+		expect(result.content).toEqual([
+			{ type: "reasoning", summary: [], encrypted_content: "encrypted", id: "reasoning-1" },
+			{ type: "text", text: "answer" },
+		])
+	})
+
+	it("appends thought signatures for non-Anthropic protocols", () => {
+		const result = prepareApiConversationMessage({
+			message: { role: "assistant", content: "answer" },
+			api: {
+				getThoughtSignature: () => "signature-1",
+				getReasoningDetails: () => [{ type: "reasoning", text: "detail" }],
+			} as any,
+			apiConfiguration: { apiProvider: "openrouter", openRouterModelId: "openai/gpt-4" } as any,
+			apiConversationHistory: [],
+		}) as any
+
+		expect(result.reasoning_details).toEqual([{ type: "reasoning", text: "detail" }])
+		expect(result.content).toEqual([
+			{ type: "text", text: "answer" },
+			{ type: "thoughtSignature", thoughtSignature: "signature-1" },
+		])
+	})
+
+	it("validates user tool_result blocks against the last effective assistant message", () => {
+		const result = prepareApiConversationMessage({
+			message: {
+				role: "user",
+				content: [{ type: "tool_result", tool_use_id: "wrong-id", content: "done" }],
+			},
+			api: {} as any,
+			apiConfiguration: { apiProvider: "openrouter", openRouterModelId: "openai/gpt-4" } as any,
+			apiConversationHistory: [
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "tool-1", name: "read_file", input: {} }],
+				} as any,
+			],
+		}) as any
+
+		expect(result.content).toEqual([{ type: "tool_result", tool_use_id: "tool-1", content: "done" }])
+		expect(result.ts).toBe(Date.now())
+	})
+})

--- a/src/core/task/__tests__/apiConversationHistory.spec.ts
+++ b/src/core/task/__tests__/apiConversationHistory.spec.ts
@@ -50,6 +50,22 @@ describe("prepareApiConversationMessage", () => {
 		])
 	})
 
+	it("falls back to generic reasoning blocks for Anthropic messages without thought signatures", () => {
+		const result = prepareApiConversationMessage({
+			message: { role: "assistant", content: "answer" },
+			reasoning: "private reasoning",
+			api: {} as any,
+			apiConfiguration: { apiProvider: "anthropic", apiModelId: "claude-3-5-sonnet" } as any,
+			apiConversationHistory: [],
+		}) as any
+
+		expect(result.content).toEqual([
+			{ type: "reasoning", text: "private reasoning", summary: [] },
+			{ type: "text", text: "answer" },
+		])
+		expect(result.ts).toBe(Date.now())
+	})
+
 	it("preserves encrypted reasoning content", () => {
 		const result = prepareApiConversationMessage({
 			message: { role: "assistant", content: [{ type: "text", text: "answer" }] },
@@ -101,6 +117,27 @@ describe("prepareApiConversationMessage", () => {
 		}) as any
 
 		expect(result.content).toEqual([{ type: "tool_result", tool_use_id: "tool-1", content: "done" }])
+		expect(result.ts).toBe(Date.now())
+	})
+
+	it("converts user tool_result blocks to text when the last effective message is not assistant", () => {
+		const result = prepareApiConversationMessage({
+			message: {
+				role: "user",
+				content: [
+					{ type: "tool_result", tool_use_id: "tool-1", content: "done" },
+					{ type: "text", text: "next step" },
+				],
+			},
+			api: {} as any,
+			apiConfiguration: { apiProvider: "openrouter", openRouterModelId: "openai/gpt-4" } as any,
+			apiConversationHistory: [{ role: "user", content: "previous user message" } as any],
+		}) as any
+
+		expect(result.content).toEqual([
+			{ type: "text", text: "Tool result:\ndone" },
+			{ type: "text", text: "next step" },
+		])
 		expect(result.ts).toBe(Date.now())
 	})
 })

--- a/src/core/task/__tests__/apiConversationHistory.spec.ts
+++ b/src/core/task/__tests__/apiConversationHistory.spec.ts
@@ -35,7 +35,7 @@ describe("prepareApiConversationMessage", () => {
 		])
 	})
 
-	it("prepends non-Anthropic reasoning blocks without dead summary fallback", () => {
+	it("preserves non-Anthropic reasoning block shape", () => {
 		const result = prepareApiConversationMessage({
 			message: { role: "assistant", content: "answer" },
 			reasoning: "visible reasoning",
@@ -45,10 +45,9 @@ describe("prepareApiConversationMessage", () => {
 		}) as any
 
 		expect(result.content).toEqual([
-			{ type: "reasoning", text: "visible reasoning" },
+			{ type: "reasoning", text: "visible reasoning", summary: [] },
 			{ type: "text", text: "answer" },
 		])
-		expect(result.content[0]).not.toHaveProperty("summary")
 	})
 
 	it("preserves encrypted reasoning content", () => {

--- a/src/core/task/apiConversationHistory.ts
+++ b/src/core/task/apiConversationHistory.ts
@@ -77,6 +77,7 @@ function prepareAssistantMessage(
 		const reasoningBlock = {
 			type: "reasoning",
 			text: reasoning,
+			summary: [] as any[],
 		}
 
 		prependContentBlock(messageWithTs, reasoningBlock)

--- a/src/core/task/apiConversationHistory.ts
+++ b/src/core/task/apiConversationHistory.ts
@@ -1,0 +1,151 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+
+import { type ProviderSettings, getApiProtocol, getModelId, isRetiredProvider } from "@roo-code/types"
+
+import type { ApiHandler } from "../../api"
+import { getEffectiveApiHistory } from "../condense"
+import type { ApiMessage } from "../task-persistence"
+import { validateAndFixToolResultIds } from "./validateToolResultIds"
+
+type ApiHistoryHandler = ApiHandler & {
+	getResponseId?: () => string | undefined
+	getEncryptedContent?: () => { encrypted_content: string; id?: string } | undefined
+	getThoughtSignature?: () => string | undefined
+	getSummary?: () => any[] | undefined
+	getReasoningDetails?: () => any[] | undefined
+}
+
+interface PrepareApiConversationMessageOptions {
+	message: Anthropic.MessageParam
+	reasoning?: string
+	api: ApiHandler
+	apiConfiguration: ProviderSettings
+	apiConversationHistory: ApiMessage[]
+}
+
+export function prepareApiConversationMessage({
+	message,
+	reasoning,
+	api,
+	apiConfiguration,
+	apiConversationHistory,
+}: PrepareApiConversationMessageOptions): ApiMessage {
+	if (message.role === "assistant") {
+		return prepareAssistantMessage(message, reasoning, api as ApiHistoryHandler, apiConfiguration)
+	}
+
+	return prepareUserMessage(message, apiConversationHistory)
+}
+
+function prepareAssistantMessage(
+	message: Anthropic.MessageParam,
+	reasoning: string | undefined,
+	handler: ApiHistoryHandler,
+	apiConfiguration: ProviderSettings,
+): ApiMessage {
+	const responseId = handler.getResponseId?.()
+	const reasoningData = handler.getEncryptedContent?.()
+	const thoughtSignature = handler.getThoughtSignature?.()
+	const reasoningSummary = handler.getSummary?.()
+	const reasoningDetails = handler.getReasoningDetails?.()
+
+	const modelId = getModelId(apiConfiguration)
+	const apiProvider = apiConfiguration.apiProvider
+	const apiProtocol = getApiProtocol(
+		apiProvider && !isRetiredProvider(apiProvider) ? apiProvider : undefined,
+		modelId,
+	)
+	const isAnthropicProtocol = apiProtocol === "anthropic"
+
+	const messageWithTs: any = {
+		...message,
+		...(responseId ? { id: responseId } : {}),
+		ts: Date.now(),
+	}
+
+	if (reasoningDetails) {
+		messageWithTs.reasoning_details = reasoningDetails
+	}
+
+	if (isAnthropicProtocol && reasoning && thoughtSignature && !reasoningDetails) {
+		const thinkingBlock = {
+			type: "thinking",
+			thinking: reasoning,
+			signature: thoughtSignature,
+		}
+
+		prependContentBlock(messageWithTs, thinkingBlock)
+	} else if (reasoning && !reasoningDetails) {
+		const reasoningBlock = {
+			type: "reasoning",
+			text: reasoning,
+			summary: reasoningSummary ?? ([] as any[]),
+		}
+
+		prependContentBlock(messageWithTs, reasoningBlock)
+	} else if (reasoningData?.encrypted_content) {
+		const reasoningBlock = {
+			type: "reasoning",
+			summary: [] as any[],
+			encrypted_content: reasoningData.encrypted_content,
+			...(reasoningData.id ? { id: reasoningData.id } : {}),
+		}
+
+		prependContentBlock(messageWithTs, reasoningBlock)
+	}
+
+	if (thoughtSignature && !isAnthropicProtocol) {
+		const thoughtSignatureBlock = {
+			type: "thoughtSignature",
+			thoughtSignature,
+		}
+
+		appendContentBlock(messageWithTs, thoughtSignatureBlock)
+	}
+
+	return messageWithTs
+}
+
+function prepareUserMessage(message: Anthropic.MessageParam, apiConversationHistory: ApiMessage[]): ApiMessage {
+	const effectiveHistoryForValidation = getEffectiveApiHistory(apiConversationHistory)
+	const lastEffective = effectiveHistoryForValidation[effectiveHistoryForValidation.length - 1]
+	const historyForValidation = lastEffective?.role === "assistant" ? effectiveHistoryForValidation : []
+
+	let messageToAdd = message
+	if (lastEffective?.role !== "assistant" && Array.isArray(message.content)) {
+		messageToAdd = {
+			...message,
+			content: message.content.map((block) =>
+				block.type === "tool_result"
+					? {
+							type: "text" as const,
+							text: `Tool result:\n${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}`,
+						}
+					: block,
+			),
+		}
+	}
+
+	const validatedMessage = validateAndFixToolResultIds(messageToAdd, historyForValidation)
+	return { ...validatedMessage, ts: Date.now() }
+}
+
+function prependContentBlock(message: any, block: any): void {
+	if (typeof message.content === "string") {
+		message.content = [block, { type: "text", text: message.content } satisfies Anthropic.Messages.TextBlockParam]
+	} else if (Array.isArray(message.content)) {
+		message.content = [block, ...message.content]
+	} else if (!message.content) {
+		message.content = [block]
+	}
+}
+
+function appendContentBlock(message: any, block: any): void {
+	if (typeof message.content === "string") {
+		message.content = [{ type: "text", text: message.content } satisfies Anthropic.Messages.TextBlockParam, block]
+	} else if (Array.isArray(message.content)) {
+		message.content = [...message.content, block]
+	} else if (!message.content) {
+		message.content = [block]
+	}
+}

--- a/src/core/task/apiConversationHistory.ts
+++ b/src/core/task/apiConversationHistory.ts
@@ -11,7 +11,6 @@ type ApiHistoryHandler = ApiHandler & {
 	getResponseId?: () => string | undefined
 	getEncryptedContent?: () => { encrypted_content: string; id?: string } | undefined
 	getThoughtSignature?: () => string | undefined
-	getSummary?: () => any[] | undefined
 	getReasoningDetails?: () => any[] | undefined
 }
 
@@ -46,7 +45,6 @@ function prepareAssistantMessage(
 	const responseId = handler.getResponseId?.()
 	const reasoningData = handler.getEncryptedContent?.()
 	const thoughtSignature = handler.getThoughtSignature?.()
-	const reasoningSummary = handler.getSummary?.()
 	const reasoningDetails = handler.getReasoningDetails?.()
 
 	const modelId = getModelId(apiConfiguration)
@@ -79,7 +77,6 @@ function prepareAssistantMessage(
 		const reasoningBlock = {
 			type: "reasoning",
 			text: reasoning,
-			summary: reasoningSummary ?? ([] as any[]),
 		}
 
 		prependContentBlock(messageWithTs, reasoningBlock)

--- a/src/core/task/apiConversationHistory.ts
+++ b/src/core/task/apiConversationHistory.ts
@@ -74,6 +74,8 @@ function prepareAssistantMessage(
 
 		prependContentBlock(messageWithTs, thinkingBlock)
 	} else if (reasoning && !reasoningDetails) {
+		// The original Task.ts also duck-typed getSummary?.(), but no provider implements it.
+		// Keep the explicit empty summary to preserve the existing reasoning-block wire shape.
 		const reasoningBlock = {
 			type: "reasoning",
 			text: reasoning,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -103,6 +103,7 @@ import { getNonce } from "./getNonce"
 import { getUri } from "./getUri"
 import { REQUESTY_BASE_URL } from "../../shared/utils/requesty"
 import { validateAndFixToolResultIds } from "../task/validateToolResultIds"
+import { PendingEditOperationStore, type PendingEditOperationInput } from "./PendingEditOperationStore"
 
 /**
  * https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -111,16 +112,6 @@ import { validateAndFixToolResultIds } from "../task/validateToolResultIds"
 
 export type ClineProviderEvents = {
 	clineCreated: [cline: Task]
-}
-
-interface PendingEditOperation {
-	messageTs: number
-	editedContent: string
-	images?: string[]
-	messageIndex: number
-	apiConversationHistoryIndex: number
-	timeoutId: NodeJS.Timeout
-	createdAt: number
 }
 
 export class ClineProvider
@@ -154,8 +145,8 @@ export class ClineProvider
 	private taskHistoryStoreInitialized = false
 	private globalStateWriteThroughTimer: ReturnType<typeof setTimeout> | null = null
 	private static readonly GLOBAL_STATE_WRITE_THROUGH_DEBOUNCE_MS = 5000 // 5 seconds
-	private pendingOperations: Map<string, PendingEditOperation> = new Map()
 	private static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
+	private readonly pendingEditOperations: PendingEditOperationStore
 
 	private cloudOrganizationsCache: CloudOrganizationMembership[] | null = null
 	private cloudOrganizationsCacheTimestamp: number | null = null
@@ -182,6 +173,10 @@ export class ClineProvider
 	) {
 		super()
 		this.currentWorkspacePath = getWorkspacePath()
+		this.pendingEditOperations = new PendingEditOperationStore(
+			ClineProvider.PENDING_OPERATION_TIMEOUT_MS,
+			(message) => this.log(message),
+		)
 
 		ClineProvider.activeInstances.add(this)
 
@@ -524,65 +519,29 @@ export class ClineProvider
 	/**
 	 * Sets a pending edit operation with automatic timeout cleanup
 	 */
-	public setPendingEditOperation(
-		operationId: string,
-		editData: {
-			messageTs: number
-			editedContent: string
-			images?: string[]
-			messageIndex: number
-			apiConversationHistoryIndex: number
-		},
-	): void {
-		// Clear any existing operation with the same ID
-		this.clearPendingEditOperation(operationId)
-
-		// Create timeout for automatic cleanup
-		const timeoutId = setTimeout(() => {
-			this.clearPendingEditOperation(operationId)
-			this.log(`[setPendingEditOperation] Automatically cleared stale pending operation: ${operationId}`)
-		}, ClineProvider.PENDING_OPERATION_TIMEOUT_MS)
-
-		// Store the operation
-		this.pendingOperations.set(operationId, {
-			...editData,
-			timeoutId,
-			createdAt: Date.now(),
-		})
-
-		this.log(`[setPendingEditOperation] Set pending operation: ${operationId}`)
+	public setPendingEditOperation(operationId: string, editData: PendingEditOperationInput): void {
+		this.pendingEditOperations.set(operationId, editData)
 	}
 
 	/**
 	 * Gets a pending edit operation by ID
 	 */
-	private getPendingEditOperation(operationId: string): PendingEditOperation | undefined {
-		return this.pendingOperations.get(operationId)
+	private getPendingEditOperation(operationId: string) {
+		return this.pendingEditOperations.get(operationId)
 	}
 
 	/**
 	 * Clears a specific pending edit operation
 	 */
 	private clearPendingEditOperation(operationId: string): boolean {
-		const operation = this.pendingOperations.get(operationId)
-		if (operation) {
-			clearTimeout(operation.timeoutId)
-			this.pendingOperations.delete(operationId)
-			this.log(`[clearPendingEditOperation] Cleared pending operation: ${operationId}`)
-			return true
-		}
-		return false
+		return this.pendingEditOperations.clear(operationId)
 	}
 
 	/**
 	 * Clears all pending edit operations
 	 */
 	private clearAllPendingEditOperations(): void {
-		for (const [operationId, operation] of this.pendingOperations) {
-			clearTimeout(operation.timeoutId)
-		}
-		this.pendingOperations.clear()
-		this.log(`[clearAllPendingEditOperations] Cleared all pending operations`)
+		this.pendingEditOperations.clearAll()
 	}
 
 	/*

--- a/src/core/webview/PendingEditOperationStore.ts
+++ b/src/core/webview/PendingEditOperationStore.ts
@@ -29,6 +29,7 @@ export class PendingEditOperationStore {
 
 		this.operations.set(operationId, {
 			...editData,
+			images: editData.images ? [...editData.images] : undefined,
 			timeoutId,
 			createdAt: Date.now(),
 		})
@@ -45,7 +46,7 @@ export class PendingEditOperationStore {
 		return {
 			messageTs: operation.messageTs,
 			editedContent: operation.editedContent,
-			images: operation.images,
+			images: operation.images ? [...operation.images] : undefined,
 			messageIndex: operation.messageIndex,
 			apiConversationHistoryIndex: operation.apiConversationHistoryIndex,
 		}

--- a/src/core/webview/PendingEditOperationStore.ts
+++ b/src/core/webview/PendingEditOperationStore.ts
@@ -1,0 +1,62 @@
+export interface PendingEditOperation {
+	messageTs: number
+	editedContent: string
+	images?: string[]
+	messageIndex: number
+	apiConversationHistoryIndex: number
+	timeoutId: NodeJS.Timeout
+	createdAt: number
+}
+
+export type PendingEditOperationInput = Omit<PendingEditOperation, "timeoutId" | "createdAt">
+
+export class PendingEditOperationStore {
+	private readonly operations = new Map<string, PendingEditOperation>()
+
+	constructor(
+		private readonly timeoutMs: number,
+		private readonly log: (message: string) => void,
+	) {}
+
+	set(operationId: string, editData: PendingEditOperationInput): void {
+		this.clear(operationId)
+
+		const timeoutId = setTimeout(() => {
+			this.clear(operationId)
+			this.log(`[setPendingEditOperation] Automatically cleared stale pending operation: ${operationId}`)
+		}, this.timeoutMs)
+
+		this.operations.set(operationId, {
+			...editData,
+			timeoutId,
+			createdAt: Date.now(),
+		})
+
+		this.log(`[setPendingEditOperation] Set pending operation: ${operationId}`)
+	}
+
+	get(operationId: string): PendingEditOperation | undefined {
+		return this.operations.get(operationId)
+	}
+
+	clear(operationId: string): boolean {
+		const operation = this.operations.get(operationId)
+		if (!operation) {
+			return false
+		}
+
+		clearTimeout(operation.timeoutId)
+		this.operations.delete(operationId)
+		this.log(`[clearPendingEditOperation] Cleared pending operation: ${operationId}`)
+		return true
+	}
+
+	clearAll(): void {
+		for (const operation of this.operations.values()) {
+			clearTimeout(operation.timeoutId)
+		}
+
+		this.operations.clear()
+		this.log("[clearAllPendingEditOperations] Cleared all pending operations")
+	}
+}

--- a/src/core/webview/PendingEditOperationStore.ts
+++ b/src/core/webview/PendingEditOperationStore.ts
@@ -9,6 +9,7 @@ export interface PendingEditOperation {
 }
 
 export type PendingEditOperationInput = Omit<PendingEditOperation, "timeoutId" | "createdAt">
+export type PendingEditOperationView = Omit<PendingEditOperation, "timeoutId" | "createdAt">
 
 export class PendingEditOperationStore {
 	private readonly operations = new Map<string, PendingEditOperation>()
@@ -23,7 +24,7 @@ export class PendingEditOperationStore {
 
 		const timeoutId = setTimeout(() => {
 			this.clear(operationId)
-			this.log(`[setPendingEditOperation] Automatically cleared stale pending operation: ${operationId}`)
+			this.log(`[PendingEditOperationStore.set] Automatically cleared stale pending operation: ${operationId}`)
 		}, this.timeoutMs)
 
 		this.operations.set(operationId, {
@@ -32,11 +33,22 @@ export class PendingEditOperationStore {
 			createdAt: Date.now(),
 		})
 
-		this.log(`[setPendingEditOperation] Set pending operation: ${operationId}`)
+		this.log(`[PendingEditOperationStore.set] Set pending operation: ${operationId}`)
 	}
 
-	get(operationId: string): PendingEditOperation | undefined {
-		return this.operations.get(operationId)
+	get(operationId: string): PendingEditOperationView | undefined {
+		const operation = this.operations.get(operationId)
+		if (!operation) {
+			return undefined
+		}
+
+		return {
+			messageTs: operation.messageTs,
+			editedContent: operation.editedContent,
+			images: operation.images,
+			messageIndex: operation.messageIndex,
+			apiConversationHistoryIndex: operation.apiConversationHistoryIndex,
+		}
 	}
 
 	clear(operationId: string): boolean {
@@ -47,7 +59,7 @@ export class PendingEditOperationStore {
 
 		clearTimeout(operation.timeoutId)
 		this.operations.delete(operationId)
-		this.log(`[clearPendingEditOperation] Cleared pending operation: ${operationId}`)
+		this.log(`[PendingEditOperationStore.clear] Cleared pending operation: ${operationId}`)
 		return true
 	}
 
@@ -57,6 +69,6 @@ export class PendingEditOperationStore {
 		}
 
 		this.operations.clear()
-		this.log("[clearAllPendingEditOperations] Cleared all pending operations")
+		this.log("[PendingEditOperationStore.clearAll] Cleared all pending operations")
 	}
 }

--- a/src/core/webview/__tests__/PendingEditOperationStore.spec.ts
+++ b/src/core/webview/__tests__/PendingEditOperationStore.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PendingEditOperationStore, type PendingEditOperationInput } from "../PendingEditOperationStore.js"
+
+describe("PendingEditOperationStore", () => {
+	const editData: PendingEditOperationInput = {
+		messageTs: 123,
+		editedContent: "edited",
+		images: ["image.png"],
+		messageIndex: 1,
+		apiConversationHistoryIndex: 2,
+	}
+
+	let log: ReturnType<typeof vi.fn>
+	let store: PendingEditOperationStore
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		log = vi.fn()
+		store = new PendingEditOperationStore(1_000, log)
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("clears a prior operation with the same id", () => {
+		store.set("op", editData)
+		vi.advanceTimersByTime(500)
+
+		store.set("op", { ...editData, editedContent: "replacement" })
+		vi.advanceTimersByTime(500)
+
+		expect(store.get("op")).toMatchObject({ editedContent: "replacement" })
+		expect(log).toHaveBeenCalledWith("[PendingEditOperationStore.clear] Cleared pending operation: op")
+
+		vi.advanceTimersByTime(500)
+
+		expect(store.get("op")).toBeUndefined()
+	})
+
+	it("returns false on clear miss and true on hit", () => {
+		expect(store.clear("missing")).toBe(false)
+
+		store.set("op", editData)
+
+		expect(store.clear("op")).toBe(true)
+		expect(store.get("op")).toBeUndefined()
+	})
+
+	it("hides timer metadata from get results", () => {
+		store.set("op", editData)
+
+		const operation = store.get("op")
+
+		expect(operation).toEqual(editData)
+		expect(operation).not.toHaveProperty("timeoutId")
+		expect(operation).not.toHaveProperty("createdAt")
+	})
+
+	it("auto-clears after timeoutMs and logs", () => {
+		store.set("op", editData)
+
+		vi.advanceTimersByTime(1_000)
+
+		expect(store.get("op")).toBeUndefined()
+		expect(log).toHaveBeenCalledWith(
+			"[PendingEditOperationStore.set] Automatically cleared stale pending operation: op",
+		)
+	})
+
+	it("clearAll clears timers without later auto-clear logs", () => {
+		store.set("op-1", editData)
+		store.set("op-2", { ...editData, editedContent: "second" })
+
+		store.clearAll()
+		log.mockClear()
+
+		vi.advanceTimersByTime(1_000)
+
+		expect(store.get("op-1")).toBeUndefined()
+		expect(store.get("op-2")).toBeUndefined()
+		expect(log).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/webview/__tests__/PendingEditOperationStore.spec.ts
+++ b/src/core/webview/__tests__/PendingEditOperationStore.spec.ts
@@ -58,6 +58,17 @@ describe("PendingEditOperationStore", () => {
 		expect(operation).not.toHaveProperty("createdAt")
 	})
 
+	it("protects stored images from external mutation", () => {
+		const images = ["before.png"]
+		store.set("op", { ...editData, images })
+
+		images.push("input-mutation.png")
+		const operation = store.get("op")
+		operation?.images?.push("output-mutation.png")
+
+		expect(store.get("op")?.images).toEqual(["before.png"])
+	})
+
 	it("auto-clears after timeoutMs and logs", () => {
 		store.set("op", editData)
 


### PR DESCRIPTION
### Related GitHub Issue

Refs #8

### Description

Extract two low-coupling pieces from the core monolith files while preserving the existing call flow:

- Move API conversation message shaping from `Task.ts` into `src/core/task/apiConversationHistory.ts`
- Move pending edit operation timeout/state management from `ClineProvider.ts` into `src/core/webview/PendingEditOperationStore.ts`

`Task` and `ClineProvider` keep orchestrating the same operations, but the focused logic now lives in named collaborators.

### Test Procedure

- `pnpm --dir src check-types`
- `pnpm --dir src exec vitest run core/task/__tests__/reasoning-preservation.test.ts core/task/__tests__/grounding-sources.test.ts core/webview/__tests__/checkpointRestoreHandler.spec.ts`

### Notes

This is intentionally scoped to the two extraction candidates called out in #8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API conversation message preparation for consistent assistant/user messages.
  * Replaced in-provider pending-edit handling with a dedicated timed pending-edit store; provider updated to use the store.

* **Bug Fixes**
  * More reliable validation and rewriting of tool-result IDs and conditional conversion of tool-result content to plain text to preserve context.

* **Tests**
  * Added tests for conversation message preparation and pending-edit store behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->