### PR TITLE
fix: address Zoo link review comments

### DIFF
--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -249,6 +249,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -246,6 +246,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -249,6 +249,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/id/common.json
+++ b/src/i18n/locales/id/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -261,6 +261,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -259,6 +259,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -254,6 +254,6 @@
 	},
 	"docsLink": {
 		"label": "Docs",
-		"url": "https://docs.zoocode.dev"
+		"url": "https://zoocode.dev/docs"
 	}
 }

--- a/src/utils/__tests__/git.spec.ts
+++ b/src/utils/__tests__/git.spec.ts
@@ -504,7 +504,7 @@ describe("getGitRepositoryInfo", () => {
 
 		expect(result).toEqual({
 			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
-			repositoryName: "RooCodeInc/Roo-Code",
+			repositoryName: "Zoo-Code-Org/Zoo-Code",
 			defaultBranch: "main",
 		})
 
@@ -606,7 +606,7 @@ describe("getGitRepositoryInfo", () => {
 
 		expect(result).toEqual({
 			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
-			repositoryName: "RooCodeInc/Roo-Code",
+			repositoryName: "Zoo-Code-Org/Zoo-Code",
 		})
 	})
 
@@ -627,7 +627,7 @@ describe("getGitRepositoryInfo", () => {
 	filemode = true
 	bare = false
 [remote "origin"]
-	url = https://github.com/Zoo-Code-Org/Zoo-Code
+		url = git@github.com:Zoo-Code-Org/Zoo-Code.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 [branch "main"]
 	remote = origin
@@ -650,8 +650,8 @@ describe("getGitRepositoryInfo", () => {
 
 		// Verify that the SSH URL was converted to HTTPS
 		expect(result).toEqual({
-			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
-			repositoryName: "RooCodeInc/Roo-Code",
+			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code.git",
+			repositoryName: "Zoo-Code-Org/Zoo-Code",
 			defaultBranch: "main",
 		})
 	})
@@ -666,24 +666,24 @@ describe("convertGitUrlToHttps", () => {
 	})
 
 	it("should convert SSH URLs to HTTPS format", () => {
-		const url = "https://github.com/Zoo-Code-Org/Zoo-Code"
+		const url = "git@github.com:Zoo-Code-Org/Zoo-Code.git"
 		const converted = convertGitUrlToHttps(url)
 
-		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should convert SSH URLs with ssh:// prefix to HTTPS format", () => {
-		const url = "ssh://git@github.com/RooCodeInc/Roo-Code.git"
+		const url = "ssh://git@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const converted = convertGitUrlToHttps(url)
 
-		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should handle URLs without git@ prefix", () => {
-		const url = "ssh://github.com/RooCodeInc/Roo-Code.git"
+		const url = "ssh://github.com/Zoo-Code-Org/Zoo-Code.git"
 		const converted = convertGitUrlToHttps(url)
 
-		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(converted).toBe("https://github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should handle invalid URLs gracefully", () => {
@@ -696,31 +696,31 @@ describe("convertGitUrlToHttps", () => {
 
 describe("sanitizeGitUrl", () => {
 	it("should sanitize HTTPS URLs with credentials", () => {
-		const url = "https://username:password@github.com/RooCodeInc/Roo-Code.git"
+		const url = "https://username:password@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const sanitized = sanitizeGitUrl(url)
 
-		expect(sanitized).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(sanitized).toBe("https://github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should leave SSH URLs unchanged", () => {
-		const url = "https://github.com/Zoo-Code-Org/Zoo-Code"
+		const url = "git@github.com:Zoo-Code-Org/Zoo-Code.git"
 		const sanitized = sanitizeGitUrl(url)
 
-		expect(sanitized).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(sanitized).toBe("git@github.com:Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should leave SSH URLs with ssh:// prefix unchanged", () => {
-		const url = "ssh://git@github.com/RooCodeInc/Roo-Code.git"
+		const url = "ssh://git@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const sanitized = sanitizeGitUrl(url)
 
-		expect(sanitized).toBe("ssh://git@github.com/RooCodeInc/Roo-Code.git")
+		expect(sanitized).toBe("ssh://git@github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should remove tokens from other URL formats", () => {
-		const url = "https://oauth2:ghp_abcdef1234567890abcdef1234567890abcdef@github.com/RooCodeInc/Roo-Code.git"
+		const url = "https://oauth2:ghp_abcdef1234567890abcdef1234567890abcdef@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const sanitized = sanitizeGitUrl(url)
 
-		expect(sanitized).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
+		expect(sanitized).toBe("https://github.com/Zoo-Code-Org/Zoo-Code.git")
 	})
 
 	it("should handle invalid URLs gracefully", () => {
@@ -736,28 +736,28 @@ describe("extractRepositoryName", () => {
 		const url = "https://github.com/Zoo-Code-Org/Zoo-Code"
 		const repoName = extractRepositoryName(url)
 
-		expect(repoName).toBe("RooCodeInc/Roo-Code")
+		expect(repoName).toBe("Zoo-Code-Org/Zoo-Code")
 	})
 
 	it("should extract repository name from HTTPS URL without .git suffix", () => {
 		const url = "https://github.com/Zoo-Code-Org/Zoo-Code"
 		const repoName = extractRepositoryName(url)
 
-		expect(repoName).toBe("RooCodeInc/Roo-Code")
+		expect(repoName).toBe("Zoo-Code-Org/Zoo-Code")
 	})
 
 	it("should extract repository name from SSH URL", () => {
-		const url = "https://github.com/Zoo-Code-Org/Zoo-Code"
+		const url = "git@github.com:Zoo-Code-Org/Zoo-Code.git"
 		const repoName = extractRepositoryName(url)
 
-		expect(repoName).toBe("RooCodeInc/Roo-Code")
+		expect(repoName).toBe("Zoo-Code-Org/Zoo-Code")
 	})
 
 	it("should extract repository name from SSH URL with ssh:// prefix", () => {
-		const url = "ssh://git@github.com/RooCodeInc/Roo-Code.git"
+		const url = "ssh://git@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const repoName = extractRepositoryName(url)
 
-		expect(repoName).toBe("RooCodeInc/Roo-Code")
+		expect(repoName).toBe("Zoo-Code-Org/Zoo-Code")
 	})
 
 	it("should return empty string for unrecognized URL formats", () => {
@@ -768,10 +768,10 @@ describe("extractRepositoryName", () => {
 	})
 
 	it("should handle URLs with credentials", () => {
-		const url = "https://username:password@github.com/RooCodeInc/Roo-Code.git"
+		const url = "https://username:password@github.com/Zoo-Code-Org/Zoo-Code.git"
 		const repoName = extractRepositoryName(url)
 
-		expect(repoName).toBe("RooCodeInc/Roo-Code")
+		expect(repoName).toBe("Zoo-Code-Org/Zoo-Code")
 	})
 })
 
@@ -826,7 +826,7 @@ describe("getWorkspaceGitInfo", () => {
 
 		expect(result).toEqual({
 			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
-			repositoryName: "RooCodeInc/Roo-Code",
+			repositoryName: "Zoo-Code-Org/Zoo-Code",
 			defaultBranch: "main",
 		})
 

--- a/webview-ui/src/components/marketplace/IssueFooter.tsx
+++ b/webview-ui/src/components/marketplace/IssueFooter.tsx
@@ -7,7 +7,7 @@ export const IssueFooter: React.FC = () => {
 		<div className="text-xs text-vscode-descriptionForeground p-3">
 			<Trans i18nKey="marketplace:footer.issueText">
 				<VSCodeLink
-					href="https://github.com/Zoo-Code-Org/Zoo-Code"
+					href="https://github.com/Zoo-Code-Org/Zoo-Code/issues/new/choose"
 					style={{ display: "inline", fontSize: "inherit" }}>
 					Open a GitHub issue
 				</VSCodeLink>


### PR DESCRIPTION
Follow-up for #12. Updates the issue footer to the new issue template chooser, switches docs links to the live /docs route, and fixes stale Zoo Git test expectations.\n\nValidation: utils/__tests__/git.spec.ts passed.