### PR TITLE
fix: simplify bundled marketplace loader

### DIFF
--- a/src/__tests__/dist_assets.spec.ts
+++ b/src/__tests__/dist_assets.spec.ts
@@ -6,7 +6,7 @@ import * as yaml from "yaml"
 
 describe("dist assets", () => {
 	const distPath = path.join(__dirname, "../dist")
-	const marketplaceAssetsPath = path.join(__dirname, "../assets/marketplace")
+	const marketplaceAssetsPath = path.join(distPath, "assets/marketplace")
 
 	describe("tiktoken", () => {
 		it("should have tiktoken wasm file", () => {

--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -73,6 +73,7 @@ async function main() {
 							["../.env", ".env", { optional: true }],
 							["node_modules/vscode-material-icons/generated", "assets/vscode-material-icons"],
 							["../webview-ui/audio", "webview-ui/audio"],
+							["assets/marketplace", "dist/assets/marketplace"],
 						],
 						srcDir,
 						buildDir,

--- a/src/services/marketplace/ConfigLoader.ts
+++ b/src/services/marketplace/ConfigLoader.ts
@@ -18,10 +18,8 @@ const mcpMarketplaceResponse = z.object({
 	items: z.array(mcpMarketplaceItemSchema),
 })
 
-export class RemoteConfigLoader {
+export class ConfigLoader {
 	private readonly marketplacePath: string
-	private cache: Map<string, { data: MarketplaceItem[]; timestamp: number }> = new Map()
-	private cacheDuration = 5 * 60 * 1000 // 5 minutes
 
 	constructor(extensionPath: string) {
 		this.marketplacePath = path.join(extensionPath, "assets", "marketplace")
@@ -33,13 +31,6 @@ export class RemoteConfigLoader {
 	}
 
 	private async fetchModes(): Promise<MarketplaceItem[]> {
-		const cacheKey = "modes"
-		const cached = this.getFromCache(cacheKey)
-
-		if (cached) {
-			return cached
-		}
-
 		const data = await this.readMarketplaceFile("modes.yml")
 
 		const yamlData = yaml.parse(data)
@@ -50,18 +41,10 @@ export class RemoteConfigLoader {
 			...item,
 		}))
 
-		this.setCache(cacheKey, items)
 		return items
 	}
 
 	private async fetchMcps(): Promise<MarketplaceItem[]> {
-		const cacheKey = "mcps"
-		const cached = this.getFromCache(cacheKey)
-
-		if (cached) {
-			return cached
-		}
-
 		const data = await this.readMarketplaceFile("mcps.yml")
 
 		const yamlData = yaml.parse(data)
@@ -72,7 +55,6 @@ export class RemoteConfigLoader {
 			...item,
 		}))
 
-		this.setCache(cacheKey, items)
 		return items
 	}
 
@@ -83,29 +65,5 @@ export class RemoteConfigLoader {
 	async getItem(id: string, type: MarketplaceItemType): Promise<MarketplaceItem | null> {
 		const items = await this.loadAllItems()
 		return items.find((item) => item.id === id && item.type === type) || null
-	}
-
-	private getFromCache(key: string): MarketplaceItem[] | null {
-		const cached = this.cache.get(key)
-		if (!cached) return null
-
-		const now = Date.now()
-		if (now - cached.timestamp > this.cacheDuration) {
-			this.cache.delete(key)
-			return null
-		}
-
-		return cached.data
-	}
-
-	private setCache(key: string, data: MarketplaceItem[]): void {
-		this.cache.set(key, {
-			data,
-			timestamp: Date.now(),
-		})
-	}
-
-	clearCache(): void {
-		this.cache.clear()
 	}
 }

--- a/src/services/marketplace/MarketplaceManager.ts
+++ b/src/services/marketplace/MarketplaceManager.ts
@@ -12,7 +12,7 @@ import { ensureSettingsDirectoryExists } from "../../utils/globalContext"
 import { t } from "../../i18n"
 import type { CustomModesManager } from "../../core/config/CustomModesManager"
 
-import { RemoteConfigLoader } from "./RemoteConfigLoader"
+import { ConfigLoader } from "./ConfigLoader"
 import { SimpleInstaller } from "./SimpleInstaller"
 
 export interface MarketplaceItemsResponse {
@@ -22,14 +22,14 @@ export interface MarketplaceItemsResponse {
 }
 
 export class MarketplaceManager {
-	private configLoader: RemoteConfigLoader
+	private configLoader: ConfigLoader
 	private installer: SimpleInstaller
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
 		private readonly customModesManager?: CustomModesManager,
 	) {
-		this.configLoader = new RemoteConfigLoader(context.extensionUri.fsPath)
+		this.configLoader = new ConfigLoader(context.extensionUri.fsPath)
 		this.installer = new SimpleInstaller(context, customModesManager)
 	}
 
@@ -180,8 +180,7 @@ export class MarketplaceManager {
 	}
 
 	async cleanup(): Promise<void> {
-		// Clear API cache if needed
-		this.configLoader.clearCache()
+		// Bundled marketplace config has no runtime resources to release.
 	}
 
 	/**

--- a/src/services/marketplace/__tests__/ConfigLoader.spec.ts
+++ b/src/services/marketplace/__tests__/ConfigLoader.spec.ts
@@ -1,9 +1,9 @@
-// npx vitest services/marketplace/__tests__/RemoteConfigLoader.spec.ts
+// npx vitest services/marketplace/__tests__/ConfigLoader.spec.ts
 
 import * as fs from "fs/promises"
 import * as path from "path"
 
-import { RemoteConfigLoader } from "../RemoteConfigLoader"
+import { ConfigLoader } from "../ConfigLoader"
 import type { MarketplaceItemType } from "@roo-code/types"
 
 vi.mock("fs/promises", () => ({
@@ -12,14 +12,13 @@ vi.mock("fs/promises", () => ({
 
 const mockedReadFile = vi.mocked(fs.readFile)
 
-describe("RemoteConfigLoader", () => {
-	let loader: RemoteConfigLoader
+describe("ConfigLoader", () => {
+	let loader: ConfigLoader
 	const extensionPath = path.join("/test", "extension")
 
 	beforeEach(() => {
-		loader = new RemoteConfigLoader(extensionPath)
+		loader = new ConfigLoader(extensionPath)
 		vi.clearAllMocks()
-		loader.clearCache()
 	})
 
 	describe("loadAllItems", () => {
@@ -101,7 +100,7 @@ describe("RemoteConfigLoader", () => {
 			})
 		})
 
-		it("should use cache on subsequent calls", async () => {
+		it("should read bundled files on each load", async () => {
 			const mockModesYaml = `items:
   - id: "test-mode"
     name: "Test Mode"
@@ -129,7 +128,7 @@ describe("RemoteConfigLoader", () => {
 			expect(mockedReadFile).toHaveBeenCalledTimes(2)
 
 			const items2 = await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(2)
+			expect(mockedReadFile).toHaveBeenCalledTimes(4)
 
 			expect(items1).toEqual(items2)
 		})
@@ -210,76 +209,4 @@ describe("RemoteConfigLoader", () => {
 		})
 	})
 
-	describe("clearCache", () => {
-		it("should clear cache and force fresh API calls", async () => {
-			const mockModesYaml = `items:
-  - id: "test-mode"
-    name: "Test Mode"
-    description: "A test mode"
-    content: "test content"`
-
-			const mockMcpsYaml = `items: []`
-
-			mockedReadFile.mockImplementation(async (filePath) => {
-				if (String(filePath).endsWith("modes.yml")) {
-					return mockModesYaml
-				}
-				if (String(filePath).endsWith("mcps.yml")) {
-					return mockMcpsYaml
-				}
-				throw new Error(`Unknown file: ${String(filePath)}`)
-			})
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(2)
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(2)
-
-			loader.clearCache()
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(4)
-		})
-	})
-
-	describe("cache expiration", () => {
-		it("should expire cache after 5 minutes", async () => {
-			const mockModesYaml = `items:
-  - id: "test-mode"
-    name: "Test Mode"
-    description: "A test mode"
-    content: "test content"`
-
-			const mockMcpsYaml = `items: []`
-
-			mockedReadFile.mockImplementation(async (filePath) => {
-				if (String(filePath).endsWith("modes.yml")) {
-					return mockModesYaml
-				}
-				if (String(filePath).endsWith("mcps.yml")) {
-					return mockMcpsYaml
-				}
-				throw new Error(`Unknown file: ${String(filePath)}`)
-			})
-
-			const originalDateNow = Date.now
-			let currentTime = 1000000
-
-			Date.now = vi.fn(() => currentTime)
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(2)
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(2)
-
-			currentTime += 6 * 60 * 1000
-
-			await loader.loadAllItems()
-			expect(mockedReadFile).toHaveBeenCalledTimes(4)
-
-			Date.now = originalDateNow
-		})
-	})
 })

--- a/src/services/marketplace/__tests__/MarketplaceManager.spec.ts
+++ b/src/services/marketplace/__tests__/MarketplaceManager.spec.ts
@@ -309,13 +309,8 @@ describe("MarketplaceManager", () => {
 	})
 
 	describe("cleanup", () => {
-		it("should clear API cache", async () => {
-			// Mock the clearCache method
-			vi.spyOn(manager["configLoader"], "clearCache")
-
-			await manager.cleanup()
-
-			expect(manager["configLoader"].clearCache).toHaveBeenCalled()
+		it("should complete without runtime cleanup for bundled config", async () => {
+			await expect(manager.cleanup()).resolves.toBeUndefined()
 		})
 	})
 })


### PR DESCRIPTION
Follow-up for #11. Renames RemoteConfigLoader to ConfigLoader, removes the stale cache path, updates cleanup tests, and makes the dist asset test verify copied bundled marketplace assets.\n\nValidation: ConfigLoader.spec.ts passed. dist_assets requires a bundle first; bundle could not run in this linked worktree because @roo-code/build/dist was missing.