### PR TITLE
feat(roo-import): add Roo→Zoo migration handoff import

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,7 @@
 	},
 	// Turn off tsc task auto detection since we have the necessary tasks as npm scripts
 	"typescript.tsc.autoDetect": "off",
+	// Use the workspace TypeScript version so editor diagnostics match `pnpm check-types`
+	"typescript.tsdk": "node_modules/typescript/lib",
 	"vitest.disableWorkspaceWarning": true
 }

--- a/apps/vscode-e2e/src/suite/roo-import.test.ts
+++ b/apps/vscode-e2e/src/suite/roo-import.test.ts
@@ -36,6 +36,7 @@ suite("Roo Import", function () {
 	setDefaultSuiteTimeout(this)
 
 	let tmpDir: string
+	const importedTaskIds: string[] = []
 
 	suiteSetup(async () => {
 		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-e2e-roo-import-"))
@@ -43,6 +44,15 @@ suite("Roo Import", function () {
 
 	suiteTeardown(async () => {
 		await fs.rm(tmpDir, { recursive: true, force: true })
+
+		const storagePath = globalThis.api?.storagePath
+		if (storagePath) {
+			await Promise.all(
+				importedTaskIds.map((id) =>
+					fs.rm(path.join(storagePath, "tasks", id), { recursive: true, force: true }),
+				),
+			)
+		}
 	})
 
 	test("importRooHandoff command is registered", async () => {
@@ -61,6 +71,7 @@ suite("Roo Import", function () {
 		const handoffDir = path.join(tmpDir, "handoff")
 		const tasksSource = path.join(handoffDir, "data", "tasks")
 		const taskId = `e2e-test-task-${Date.now()}`
+		importedTaskIds.push(taskId)
 		await fs.mkdir(path.join(tasksSource, taskId), { recursive: true })
 		await fs.writeFile(path.join(tasksSource, taskId, "history_item.json"), JSON.stringify({ id: taskId }))
 
@@ -83,7 +94,7 @@ suite("Roo Import", function () {
 		assert.strictEqual(contents.id, taskId, "Task file content should match what was exported")
 	})
 
-	test("skips import when handoff was already imported", async () => {
+	test("re-runs import with an explicit path without throwing", async () => {
 		const handoffPath = path.join(tmpDir, "handoff-duplicate.json")
 		const createdAt = new Date().toISOString()
 		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff({ createdAt })))

--- a/apps/vscode-e2e/src/suite/roo-import.test.ts
+++ b/apps/vscode-e2e/src/suite/roo-import.test.ts
@@ -1,0 +1,108 @@
+import * as assert from "assert"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+
+import * as vscode from "vscode"
+
+import { setDefaultSuiteTimeout } from "./test-utils"
+
+function makeHandoff(overrides: Record<string, unknown> = {}) {
+	return {
+		schemaVersion: 1,
+		createdAt: new Date().toISOString(),
+		source: {
+			extensionId: "RooVeterinaryInc.roo-cline",
+			publisher: "RooVeterinaryInc",
+			name: "roo-cline",
+			version: "3.53.1",
+			globalStoragePath: "",
+			storageBasePath: "",
+		},
+		zoo: {
+			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
+			announcementUrl: "",
+			extensionId: "ZooCodeOrganization.zoo-code",
+		},
+		containsSecrets: false,
+		globalSettings: {},
+		vscodeConfiguration: {},
+		copiedData: {},
+		...overrides,
+	}
+}
+
+suite("Roo Import", function () {
+	setDefaultSuiteTimeout(this)
+
+	let tmpDir: string
+
+	suiteSetup(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-e2e-roo-import-"))
+	})
+
+	suiteTeardown(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	test("importRooHandoff command is registered", async () => {
+		const commands = await vscode.commands.getCommands(true)
+		assert.ok(
+			commands.includes("roo-cline.importRooHandoff"),
+			"roo-cline.importRooHandoff should be a registered command",
+		)
+	})
+
+	test("imports a valid handoff and copies tasks", async () => {
+		const api = globalThis.api
+		const storagePath = api.storagePath
+
+		// Build a minimal handoff with one task directory.
+		const handoffDir = path.join(tmpDir, "handoff")
+		const tasksSource = path.join(handoffDir, "data", "tasks")
+		const taskId = `e2e-test-task-${Date.now()}`
+		await fs.mkdir(path.join(tasksSource, taskId), { recursive: true })
+		await fs.writeFile(path.join(tasksSource, taskId, "history_item.json"), JSON.stringify({ id: taskId }))
+
+		const handoffPath = path.join(handoffDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff({ copiedData: { tasks: "data/tasks" } })))
+
+		// Execute the command with an explicit path to skip the file picker.
+		const result = await vscode.commands.executeCommand<{ success: boolean; tasksCopied?: number; error?: string }>(
+			"roo-cline.importRooHandoff",
+			handoffPath,
+		)
+
+		assert.ok(result, "Command should return a result")
+		assert.strictEqual(result.success, true, `Import should succeed (error: ${result.error})`)
+		assert.strictEqual(result.tasksCopied, 1, "One task should have been copied")
+
+		// Verify the task directory was actually written to Zoo's storage.
+		const copiedTaskFile = path.join(storagePath, "tasks", taskId, "history_item.json")
+		const contents = JSON.parse(await fs.readFile(copiedTaskFile, "utf-8"))
+		assert.strictEqual(contents.id, taskId, "Task file content should match what was exported")
+	})
+
+	test("skips import when handoff was already imported", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-duplicate.json")
+		const createdAt = new Date().toISOString()
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff({ createdAt })))
+
+		// First import.
+		const first = await vscode.commands.executeCommand<{ success: boolean }>(
+			"roo-cline.importRooHandoff",
+			handoffPath,
+		)
+		assert.ok(first?.success, "First import should succeed")
+
+		// Second import of the same handoff should also succeed (command accepts an
+		// explicit path so it doesn't check the "already imported" state — that check
+		// only runs in the activation notice path). Verify the command at least runs
+		// without throwing.
+		const second = await vscode.commands.executeCommand<{ success: boolean }>(
+			"roo-cline.importRooHandoff",
+			handoffPath,
+		)
+		assert.ok(second?.success, "Re-running the command with the same file should still succeed")
+	})
+})

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -139,6 +139,11 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 	 * @throws Error if the profile does not exist
 	 */
 	setActiveProfile(name: string): Promise<string | undefined>
+	/**
+	 * Returns the extension's global storage path (context.globalStorageUri.fsPath).
+	 * Useful for tests that need to verify files written to or read from extension storage.
+	 */
+	get storagePath(): string
 }
 
 export interface RooCodeIpcServer extends EventEmitter<IpcServerEvents> {

--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -41,6 +41,7 @@ export const commandIds = [
 
 	"setCustomStoragePath",
 	"importSettings",
+	"importRooHandoff",
 
 	"focusInput",
 	"acceptInput",

--- a/src/__mocks__/vscode.js
+++ b/src/__mocks__/vscode.js
@@ -42,6 +42,8 @@ export const workspace = {
 	onDidChangeWorkspaceFolders: () => mockDisposable,
 	getConfiguration: () => ({
 		get: (key, defaultValue) => defaultValue,
+		inspect: () => ({ globalValue: undefined }),
+		update: () => Promise.resolve(),
 	}),
 	createFileSystemWatcher: () => ({
 		onDidCreate: () => mockDisposable,
@@ -62,6 +64,7 @@ export const window = {
 	showErrorMessage: () => Promise.resolve(),
 	showWarningMessage: () => Promise.resolve(),
 	showInformationMessage: () => Promise.resolve(),
+	showOpenDialog: () => Promise.resolve(undefined),
 	createOutputChannel: () => ({
 		appendLine: () => {},
 		append: () => {},
@@ -150,6 +153,12 @@ export const CodeActionKind = {
 	RefactorRewrite: { value: "refactor.rewrite" },
 }
 
+export const ConfigurationTarget = {
+	Global: 1,
+	Workspace: 2,
+	WorkspaceFolder: 3,
+}
+
 export const EventEmitter = mockEventEmitter
 
 export default {
@@ -171,4 +180,5 @@ export default {
 	EventEmitter,
 	CodeAction,
 	CodeActionKind,
+	ConfigurationTarget,
 }

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -127,6 +127,14 @@ describe("handleImportRooHandoff", () => {
 		expect(mockProvider.postStateToWebview).not.toHaveBeenCalled()
 	})
 
+	it("does not call postStateToWebview when import fails", async () => {
+		vi.mocked(RooImport.promptAndImportRooHandoff).mockResolvedValue({ success: false, error: "invalid handoff" })
+
+		await handleImportRooHandoff(undefined, mockContext, mockOutputChannel)
+
+		expect(mockProvider.postStateToWebview).not.toHaveBeenCalled()
+	})
+
 	it("logs and returns undefined when the import throws", async () => {
 		vi.mocked(RooImport.importRooHandoffFromPath).mockRejectedValue(new Error("disk full"))
 

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -1,8 +1,9 @@
 import type { Mock } from "vitest"
 import * as vscode from "vscode"
 import { ClineProvider } from "../../core/webview/ClineProvider"
+import * as RooImport from "../../services/roo-import/RooImport"
 
-import { getVisibleProviderOrLog } from "../registerCommands"
+import { getVisibleProviderOrLog, handleImportRooHandoff } from "../registerCommands"
 
 vi.mock("execa", () => ({
 	execa: vi.fn(),
@@ -28,6 +29,11 @@ vi.mock("vscode", () => ({
 }))
 
 vi.mock("../../core/webview/ClineProvider")
+
+vi.mock("../../services/roo-import/RooImport", () => ({
+	importRooHandoffFromPath: vi.fn(),
+	promptAndImportRooHandoff: vi.fn(),
+}))
 
 describe("getVisibleProviderOrLog", () => {
 	let mockOutputChannel: vscode.OutputChannel
@@ -63,5 +69,70 @@ describe("getVisibleProviderOrLog", () => {
 
 		expect(result).toBeUndefined()
 		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Roo Code instances.")
+	})
+})
+
+describe("handleImportRooHandoff", () => {
+	let mockOutputChannel: vscode.OutputChannel
+	let mockContext: vscode.ExtensionContext
+	let mockProvider: Partial<ClineProvider>
+
+	beforeEach(() => {
+		mockOutputChannel = { appendLine: vi.fn() } as any
+		mockContext = { globalStorageUri: { fsPath: "/tmp/zoo" } } as any
+		mockProvider = {
+			providerSettingsManager: {} as any,
+			contextProxy: {} as any,
+			customModesManager: {} as any,
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+		}
+		vi.clearAllMocks()
+		;(ClineProvider.getInstance as Mock).mockResolvedValue(mockProvider)
+	})
+
+	it("returns undefined when no provider is available", async () => {
+		;(ClineProvider.getInstance as Mock).mockResolvedValue(undefined)
+
+		const result = await handleImportRooHandoff(undefined, mockContext, mockOutputChannel)
+
+		expect(result).toBeUndefined()
+	})
+
+	it("calls importRooHandoffFromPath when a handoff path is given", async () => {
+		const mockResult = { success: true, tasksCopied: 2 }
+		vi.mocked(RooImport.importRooHandoffFromPath).mockResolvedValue(mockResult)
+
+		const result = await handleImportRooHandoff("/path/to/handoff.json", mockContext, mockOutputChannel)
+
+		expect(RooImport.importRooHandoffFromPath).toHaveBeenCalledWith("/path/to/handoff.json", expect.any(Object))
+		expect(mockProvider.postStateToWebview).toHaveBeenCalled()
+		expect(result).toBe(mockResult)
+	})
+
+	it("calls promptAndImportRooHandoff when no path is given", async () => {
+		const mockResult = { success: true, tasksCopied: 0 }
+		vi.mocked(RooImport.promptAndImportRooHandoff).mockResolvedValue(mockResult)
+
+		const result = await handleImportRooHandoff(undefined, mockContext, mockOutputChannel)
+
+		expect(RooImport.promptAndImportRooHandoff).toHaveBeenCalled()
+		expect(result).toBe(mockResult)
+	})
+
+	it("does not call postStateToWebview when import returns undefined", async () => {
+		vi.mocked(RooImport.promptAndImportRooHandoff).mockResolvedValue(undefined)
+
+		await handleImportRooHandoff(undefined, mockContext, mockOutputChannel)
+
+		expect(mockProvider.postStateToWebview).not.toHaveBeenCalled()
+	})
+
+	it("logs and returns undefined when the import throws", async () => {
+		vi.mocked(RooImport.importRooHandoffFromPath).mockRejectedValue(new Error("disk full"))
+
+		const result = await handleImportRooHandoff("/path/to/handoff.json", mockContext, mockOutputChannel)
+
+		expect(result).toBeUndefined()
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("[Roo Import] Failed: disk full")
 	})
 })

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -13,6 +13,7 @@ import { handleNewTask } from "./handleTask"
 import { CodeIndexManager } from "../services/code-index/manager"
 import { importSettingsWithFeedback } from "../core/config/importExport"
 import { MdmService } from "../services/mdm/MdmService"
+import { promptAndImportRooHandoff, importRooHandoffFromPath } from "../services/roo-import/RooImport"
 import { t } from "../i18n"
 
 /**
@@ -143,6 +144,36 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			},
 			filePath,
 		)
+	},
+	importRooHandoff: async (handoffPath?: string) => {
+		const visibleProvider = await ClineProvider.getInstance()
+		if (!visibleProvider) {
+			return undefined
+		}
+
+		const importOptions = {
+			context,
+			providerSettingsManager: visibleProvider.providerSettingsManager,
+			contextProxy: visibleProvider.contextProxy,
+			customModesManager: visibleProvider.customModesManager,
+			outputChannel,
+		}
+
+		try {
+			const result = handoffPath
+				? await importRooHandoffFromPath(handoffPath, importOptions)
+				: await promptAndImportRooHandoff(importOptions)
+
+			if (result) {
+				await visibleProvider.postStateToWebview()
+			}
+
+			return result
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			outputChannel.appendLine(`[Roo Import] Failed: ${message}`)
+			return undefined
+		}
 	},
 	focusInput: async () => {
 		try {

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -85,7 +85,7 @@ export async function handleImportRooHandoff(
 			? await importRooHandoffFromPath(handoffPath, importOptions)
 			: await promptAndImportRooHandoff(importOptions)
 
-		if (result) {
+		if (result?.success) {
 			await visibleProvider.postStateToWebview()
 		}
 

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -62,6 +62,41 @@ export type RegisterCommandOptions = {
 	provider: ClineProvider
 }
 
+export async function handleImportRooHandoff(
+	handoffPath: string | undefined,
+	context: vscode.ExtensionContext,
+	outputChannel: vscode.OutputChannel,
+) {
+	const visibleProvider = await ClineProvider.getInstance()
+	if (!visibleProvider) {
+		return undefined
+	}
+
+	const importOptions = {
+		context,
+		providerSettingsManager: visibleProvider.providerSettingsManager,
+		contextProxy: visibleProvider.contextProxy,
+		customModesManager: visibleProvider.customModesManager,
+		outputChannel,
+	}
+
+	try {
+		const result = handoffPath
+			? await importRooHandoffFromPath(handoffPath, importOptions)
+			: await promptAndImportRooHandoff(importOptions)
+
+		if (result) {
+			await visibleProvider.postStateToWebview()
+		}
+
+		return result
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error)
+		outputChannel.appendLine(`[Roo Import] Failed: ${message}`)
+		return undefined
+	}
+}
+
 export const registerCommands = (options: RegisterCommandOptions) => {
 	const { context } = options
 
@@ -145,36 +180,7 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			filePath,
 		)
 	},
-	importRooHandoff: async (handoffPath?: string) => {
-		const visibleProvider = await ClineProvider.getInstance()
-		if (!visibleProvider) {
-			return undefined
-		}
-
-		const importOptions = {
-			context,
-			providerSettingsManager: visibleProvider.providerSettingsManager,
-			contextProxy: visibleProvider.contextProxy,
-			customModesManager: visibleProvider.customModesManager,
-			outputChannel,
-		}
-
-		try {
-			const result = handoffPath
-				? await importRooHandoffFromPath(handoffPath, importOptions)
-				: await promptAndImportRooHandoff(importOptions)
-
-			if (result) {
-				await visibleProvider.postStateToWebview()
-			}
-
-			return result
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
-			outputChannel.appendLine(`[Roo Import] Failed: ${message}`)
-			return undefined
-		}
-	},
+	importRooHandoff: (handoffPath?: string) => handleImportRooHandoff(handoffPath, context, outputChannel),
 	focusInput: async () => {
 		try {
 			await focusPanel(tabPanel, sidebarPanel)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,7 @@ import { CodeIndexManager } from "./services/code-index/manager"
 import { MdmService } from "./services/mdm/MdmService"
 import { migrateSettings } from "./utils/migrateSettings"
 import { autoImportSettings } from "./utils/autoImportSettings"
+import { showRooHandoffNotice } from "./services/roo-import/RooImport"
 import { API } from "./extension/api"
 
 import {
@@ -251,6 +252,18 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	registerCommands({ context, outputChannel, provider })
+
+	void showRooHandoffNotice(context, {
+		context,
+		providerSettingsManager: provider.providerSettingsManager,
+		contextProxy: provider.contextProxy,
+		customModesManager: provider.customModesManager,
+		outputChannel,
+	}).catch((error) => {
+		outputChannel.appendLine(
+			`[Roo Import] Failed to check for handoff: ${error instanceof Error ? error.message : String(error)}`,
+		)
+	})
 
 	/**
 	 * We use the text document content provider API to show the left side for diff

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -561,4 +561,8 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		await this.sidebarProvider.activateProviderProfile({ name })
 		return this.getActiveProfile()
 	}
+
+	public get storagePath(): string {
+		return this.context.globalStorageUri.fsPath
+	}
 }

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "S'ha trobat un paquet de migració de Roo Code. Vols importar ara la configuració i l'historial de xats de Roo a Zoo Code?",
+		"pickHandoffFile": "Selecciona el fitxer de migració de Roo Code (handoff-v1.json)",
+		"importSuccess": "Importació de Roo completada: {{tasks}} tasca(es) copiades. Recarrega la finestra per veure l'historial.",
+		"importFailed": "La importació de Roo ha fallat: {{error}}",
+		"actions": {
+			"importNow": "Importa ara",
+			"later": "Més tard"
+		}
 	}
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -250,5 +250,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Ein Roo Code-Migrationspaket wurde gefunden. Möchtest du jetzt deine Roo-Einstellungen und deinen Chat-Verlauf in Zoo Code importieren?",
+		"pickHandoffFile": "Roo Code Übergabedatei auswählen (handoff-v1.json)",
+		"importSuccess": "Roo-Import abgeschlossen — {{tasks}} Aufgabe(n) kopiert. Lade das Fenster neu, um den Verlauf zu sehen.",
+		"importFailed": "Roo-Import fehlgeschlagen: {{error}}",
+		"actions": {
+			"importNow": "Jetzt importieren",
+			"later": "Später"
+		}
 	}
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -14,6 +14,16 @@
 		"one": "One item",
 		"other": "{{count}} items"
 	},
+	"rooImport": {
+		"notice": "A Roo Code migration handoff was found. Import your Roo settings and chat history into Zoo Code now?",
+		"pickHandoffFile": "Select Roo Code handoff file (handoff-v1.json)",
+		"importSuccess": "Roo import complete — {{tasks}} task(s) copied. Reload the window to see your history.",
+		"importFailed": "Roo import failed: {{error}}",
+		"actions": {
+			"importNow": "Import Now",
+			"later": "Later"
+		}
+	},
 	"confirmation": {
 		"reset_state": "Are you sure you want to reset all state and secret storage in the extension? This cannot be undone.",
 		"delete_config_profile": "Are you sure you want to delete this configuration profile?",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -250,5 +250,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Se encontró un paquete de migración de Roo Code. ¿Quieres importar ahora tu configuración e historial de chats de Roo a Zoo Code?",
+		"pickHandoffFile": "Selecciona el archivo de migración de Roo Code (handoff-v1.json)",
+		"importSuccess": "Importación de Roo completada — {{tasks}} tarea(s) copiadas. Recarga la ventana para ver tu historial.",
+		"importFailed": "Falló la importación de Roo: {{error}}",
+		"actions": {
+			"importNow": "Importar ahora",
+			"later": "Más tarde"
+		}
 	}
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Un paquet de migration Roo Code a été trouvé. Veux-tu importer maintenant tes paramètres et ton historique de chats Roo dans Zoo Code?",
+		"pickHandoffFile": "Sélectionner le fichier de migration Roo Code (handoff-v1.json)",
+		"importSuccess": "Import Roo terminé — {{tasks}} tâche(s) copiée(s). Recharge la fenêtre pour voir ton historique.",
+		"importFailed": "Échec de l'import Roo: {{error}}",
+		"actions": {
+			"importNow": "Importer maintenant",
+			"later": "Plus tard"
+		}
 	}
 }

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Roo Code माइग्रेशन हैंडऑफ मिला। क्या आप अभी अपनी Roo सेटिंग्स और चैट इतिहास Zoo Code में आयात करना चाहते हैं?",
+		"pickHandoffFile": "Roo Code हैंडऑफ फ़ाइल चुनें (handoff-v1.json)",
+		"importSuccess": "Roo आयात पूरा — {{tasks}} कार्य कॉपी किए गए। इतिहास देखने के लिए विंडो रीलोड करें।",
+		"importFailed": "Roo आयात विफल: {{error}}",
+		"actions": {
+			"importNow": "अभी आयात करें",
+			"later": "बाद में"
+		}
 	}
 }

--- a/src/i18n/locales/id/common.json
+++ b/src/i18n/locales/id/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Paket migrasi Roo Code ditemukan. Apakah kamu ingin mengimpor pengaturan dan riwayat obrolan Roo ke Zoo Code sekarang?",
+		"pickHandoffFile": "Pilih file handoff Roo Code (handoff-v1.json)",
+		"importSuccess": "Impor Roo selesai — {{tasks}} tugas disalin. Muat ulang jendela untuk melihat riwayatmu.",
+		"importFailed": "Impor Roo gagal: {{error}}",
+		"actions": {
+			"importNow": "Impor Sekarang",
+			"later": "Nanti"
+		}
 	}
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "È stato trovato un pacchetto di migrazione Roo Code. Vuoi importare ora le tue impostazioni e la cronologia delle chat Roo in Zoo Code?",
+		"pickHandoffFile": "Seleziona il file di migrazione Roo Code (handoff-v1.json)",
+		"importSuccess": "Importazione Roo completata — {{tasks}} attività copiate. Ricarica la finestra per vedere la cronologia.",
+		"importFailed": "Importazione Roo fallita: {{error}}",
+		"actions": {
+			"importNow": "Importa ora",
+			"later": "Più tardi"
+		}
 	}
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Roo Code の移行ハンドオフが見つかりました。Roo の設定とチャット履歴を今すぐ Zoo Code にインポートしますか？",
+		"pickHandoffFile": "Roo Code ハンドオフファイルを選択 (handoff-v1.json)",
+		"importSuccess": "Roo のインポートが完了しました — {{tasks}} 件のタスクをコピーしました。履歴を確認するにはウィンドウをリロードしてください。",
+		"importFailed": "Roo のインポートに失敗しました: {{error}}",
+		"actions": {
+			"importNow": "今すぐインポート",
+			"later": "後で"
+		}
 	}
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Roo Code 마이그레이션 핸드오프가 발견되었습니다. 지금 Roo 설정과 채팅 기록을 Zoo Code로 가져오시겠습니까?",
+		"pickHandoffFile": "Roo Code 핸드오프 파일 선택 (handoff-v1.json)",
+		"importSuccess": "Roo 가져오기 완료 — {{tasks}}개 작업이 복사되었습니다. 기록을 보려면 창을 다시 로드하세요.",
+		"importFailed": "Roo 가져오기 실패: {{error}}",
+		"actions": {
+			"importNow": "지금 가져오기",
+			"later": "나중에"
+		}
 	}
 }

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Een Roo Code-migratiepakket is gevonden. Wil je nu je Roo-instellingen en chatgeschiedenis importeren in Zoo Code?",
+		"pickHandoffFile": "Selecteer het Roo Code-overdrachtsbestand (handoff-v1.json)",
+		"importSuccess": "Roo-import voltooid — {{tasks}} taak/taken gekopieerd. Herlaad het venster om je geschiedenis te zien.",
+		"importFailed": "Roo-import mislukt: {{error}}",
+		"actions": {
+			"importNow": "Nu importeren",
+			"later": "Later"
+		}
 	}
 }

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Znaleziono pakiet migracyjny Roo Code. Czy chcesz teraz zaimportować ustawienia i historię czatów Roo do Zoo Code?",
+		"pickHandoffFile": "Wybierz plik handoff Roo Code (handoff-v1.json)",
+		"importSuccess": "Import Roo zakończony — skopiowano {{tasks}} zadanie/zadania. Załaduj ponownie okno, aby zobaczyć historię.",
+		"importFailed": "Import Roo nie powiódł się: {{error}}",
+		"actions": {
+			"importNow": "Importuj teraz",
+			"later": "Później"
+		}
 	}
 }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Um pacote de migração do Roo Code foi encontrado. Deseja importar agora suas configurações e histórico de chats do Roo para o Zoo Code?",
+		"pickHandoffFile": "Selecione o arquivo handoff do Roo Code (handoff-v1.json)",
+		"importSuccess": "Importação do Roo concluída — {{tasks}} tarefa(s) copiada(s). Recarregue a janela para ver seu histórico.",
+		"importFailed": "Falha na importação do Roo: {{error}}",
+		"actions": {
+			"importNow": "Importar agora",
+			"later": "Mais tarde"
+		}
 	}
 }

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Обнаружен пакет миграции Roo Code. Хотите импортировать настройки и историю чатов Roo в Zoo Code прямо сейчас?",
+		"pickHandoffFile": "Выберите файл передачи Roo Code (handoff-v1.json)",
+		"importSuccess": "Импорт Roo завершён — скопировано задач: {{tasks}}. Перезагрузите окно, чтобы увидеть историю.",
+		"importFailed": "Ошибка импорта Roo: {{error}}",
+		"actions": {
+			"importNow": "Импортировать сейчас",
+			"later": "Позже"
+		}
 	}
 }

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Bir Roo Code geçiş paketi bulundu. Roo ayarlarını ve sohbet geçmişini şimdi Zoo Code'a aktarmak ister misiniz?",
+		"pickHandoffFile": "Roo Code handoff dosyasını seçin (handoff-v1.json)",
+		"importSuccess": "Roo içe aktarımı tamamlandı — {{tasks}} görev kopyalandı. Geçmişi görmek için pencereyi yeniden yükleyin.",
+		"importFailed": "Roo içe aktarımı başarısız: {{error}}",
+		"actions": {
+			"importNow": "Şimdi İçe Aktar",
+			"later": "Sonra"
+		}
 	}
 }

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -262,5 +262,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "Đã tìm thấy gói di chuyển Roo Code. Bạn có muốn nhập cài đặt và lịch sử trò chuyện Roo vào Zoo Code ngay bây giờ không?",
+		"pickHandoffFile": "Chọn file handoff của Roo Code (handoff-v1.json)",
+		"importSuccess": "Nhập Roo hoàn tất — đã sao chép {{tasks}} tác vụ. Tải lại cửa sổ để xem lịch sử của bạn.",
+		"importFailed": "Nhập Roo thất bại: {{error}}",
+		"actions": {
+			"importNow": "Nhập ngay",
+			"later": "Để sau"
+		}
 	}
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -260,5 +260,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "发现 Roo Code 迁移交接包。是否立即将 Roo 设置和聊天历史导入 Zoo Code？",
+		"pickHandoffFile": "选择 Roo Code 交接文件 (handoff-v1.json)",
+		"importSuccess": "Roo 导入完成 — 已复制 {{tasks}} 个任务。重新加载窗口以查看历史记录。",
+		"importFailed": "Roo 导入失败：{{error}}",
+		"actions": {
+			"importNow": "立即导入",
+			"later": "稍后"
+		}
 	}
 }

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -255,5 +255,15 @@
 	"docsLink": {
 		"label": "Docs",
 		"url": "https://docs.roocode.com"
+	},
+	"rooImport": {
+		"notice": "發現 Roo Code 遷移交接包。是否立即將 Roo 設定和聊天記錄匯入 Zoo Code？",
+		"pickHandoffFile": "選擇 Roo Code 交接檔案 (handoff-v1.json)",
+		"importSuccess": "Roo 匯入完成 — 已複製 {{tasks}} 個任務。重新載入視窗以查看歷史記錄。",
+		"importFailed": "Roo 匯入失敗：{{error}}",
+		"actions": {
+			"importNow": "立即匯入",
+			"later": "稍後"
+		}
 	}
 }

--- a/src/package.json
+++ b/src/package.json
@@ -151,6 +151,11 @@
 				"category": "%configuration.title%"
 			},
 			{
+				"command": "roo-cline.importRooHandoff",
+				"title": "%command.importRooHandoff.title%",
+				"category": "%configuration.title%"
+			},
+			{
 				"command": "roo-cline.focusInput",
 				"title": "%command.focusInput.title%",
 				"category": "%configuration.title%"

--- a/src/package.nls.ca.json
+++ b/src/package.nls.ca.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Enfocar Camp d'Entrada",
 	"command.setCustomStoragePath.title": "Establir Ruta d'Emmagatzematge Personalitzada",
 	"command.importSettings.title": "Importar Configuració",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Importar el traspàs de migració de Roo Code",
 	"command.terminal.addToContext.title": "Afegir Contingut del Terminal al Context",
 	"command.terminal.fixCommand.title": "Corregir Aquesta Ordre",
 	"command.terminal.explainCommand.title": "Explicar Aquesta Ordre",

--- a/src/package.nls.ca.json
+++ b/src/package.nls.ca.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Enfocar Camp d'Entrada",
 	"command.setCustomStoragePath.title": "Establir Ruta d'Emmagatzematge Personalitzada",
 	"command.importSettings.title": "Importar Configuració",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Afegir Contingut del Terminal al Context",
 	"command.terminal.fixCommand.title": "Corregir Aquesta Ordre",
 	"command.terminal.explainCommand.title": "Explicar Aquesta Ordre",

--- a/src/package.nls.de.json
+++ b/src/package.nls.de.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Eingabefeld Fokussieren",
 	"command.setCustomStoragePath.title": "Benutzerdefinierten Speicherpfad Festlegen",
 	"command.importSettings.title": "Einstellungen Importieren",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code-Migrationsübergabe importieren",
 	"command.terminal.addToContext.title": "Terminal-Inhalt zum Kontext Hinzufügen",
 	"command.terminal.fixCommand.title": "Diesen Befehl Reparieren",
 	"command.terminal.explainCommand.title": "Diesen Befehl Erklären",

--- a/src/package.nls.de.json
+++ b/src/package.nls.de.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Eingabefeld Fokussieren",
 	"command.setCustomStoragePath.title": "Benutzerdefinierten Speicherpfad Festlegen",
 	"command.importSettings.title": "Einstellungen Importieren",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Terminal-Inhalt zum Kontext Hinzufügen",
 	"command.terminal.fixCommand.title": "Diesen Befehl Reparieren",
 	"command.terminal.explainCommand.title": "Diesen Befehl Erklären",

--- a/src/package.nls.es.json
+++ b/src/package.nls.es.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Enfocar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Establecer Ruta de Almacenamiento Personalizada",
 	"command.importSettings.title": "Importar Configuración",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Importar traspaso de migración de Roo Code",
 	"command.terminal.addToContext.title": "Añadir Contenido de Terminal al Contexto",
 	"command.terminal.fixCommand.title": "Corregir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.es.json
+++ b/src/package.nls.es.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Enfocar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Establecer Ruta de Almacenamiento Personalizada",
 	"command.importSettings.title": "Importar Configuración",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Añadir Contenido de Terminal al Contexto",
 	"command.terminal.fixCommand.title": "Corregir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.fr.json
+++ b/src/package.nls.fr.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focus sur le Champ de Saisie",
 	"command.setCustomStoragePath.title": "Définir le Chemin de Stockage Personnalisé",
 	"command.importSettings.title": "Importer les Paramètres",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Ajouter le Contenu du Terminal au Contexte",
 	"command.terminal.fixCommand.title": "Corriger cette Commande",
 	"command.terminal.explainCommand.title": "Expliquer cette Commande",

--- a/src/package.nls.fr.json
+++ b/src/package.nls.fr.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Focus sur le Champ de Saisie",
 	"command.setCustomStoragePath.title": "Définir le Chemin de Stockage Personnalisé",
 	"command.importSettings.title": "Importer les Paramètres",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Importer le transfert de migration de Roo Code",
 	"command.terminal.addToContext.title": "Ajouter le Contenu du Terminal au Contexte",
 	"command.terminal.fixCommand.title": "Corriger cette Commande",
 	"command.terminal.explainCommand.title": "Expliquer cette Commande",

--- a/src/package.nls.hi.json
+++ b/src/package.nls.hi.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "इनपुट फ़ील्ड पर फोकस करें",
 	"command.setCustomStoragePath.title": "कस्टम स्टोरेज पाथ सेट करें",
 	"command.importSettings.title": "सेटिंग्स इम्पोर्ट करें",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "टर्मिनल सामग्री को संदर्भ में जोड़ें",
 	"command.terminal.fixCommand.title": "यह कमांड ठीक करें",
 	"command.terminal.explainCommand.title": "यह कमांड समझाएं",

--- a/src/package.nls.hi.json
+++ b/src/package.nls.hi.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "इनपुट फ़ील्ड पर फोकस करें",
 	"command.setCustomStoragePath.title": "कस्टम स्टोरेज पाथ सेट करें",
 	"command.importSettings.title": "सेटिंग्स इम्पोर्ट करें",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code माइग्रेशन हैंडऑफ आयात करें",
 	"command.terminal.addToContext.title": "टर्मिनल सामग्री को संदर्भ में जोड़ें",
 	"command.terminal.fixCommand.title": "यह कमांड ठीक करें",
 	"command.terminal.explainCommand.title": "यह कमांड समझाएं",

--- a/src/package.nls.id.json
+++ b/src/package.nls.id.json
@@ -19,6 +19,7 @@
 	"command.focusInput.title": "Fokus ke Field Input",
 	"command.setCustomStoragePath.title": "Atur Path Penyimpanan Kustom",
 	"command.importSettings.title": "Impor Pengaturan",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Tambahkan Konten Terminal ke Konteks",
 	"command.terminal.fixCommand.title": "Perbaiki Perintah Ini",
 	"command.terminal.explainCommand.title": "Jelaskan Perintah Ini",

--- a/src/package.nls.id.json
+++ b/src/package.nls.id.json
@@ -19,7 +19,7 @@
 	"command.focusInput.title": "Fokus ke Field Input",
 	"command.setCustomStoragePath.title": "Atur Path Penyimpanan Kustom",
 	"command.importSettings.title": "Impor Pengaturan",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Impor serah terima migrasi Roo Code",
 	"command.terminal.addToContext.title": "Tambahkan Konten Terminal ke Konteks",
 	"command.terminal.fixCommand.title": "Perbaiki Perintah Ini",
 	"command.terminal.explainCommand.title": "Jelaskan Perintah Ini",

--- a/src/package.nls.it.json
+++ b/src/package.nls.it.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Focalizza Campo di Input",
 	"command.setCustomStoragePath.title": "Imposta Percorso di Archiviazione Personalizzato",
 	"command.importSettings.title": "Importa Impostazioni",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Importa passaggio di migrazione Roo Code",
 	"command.terminal.addToContext.title": "Aggiungi Contenuto del Terminale al Contesto",
 	"command.terminal.fixCommand.title": "Correggi Questo Comando",
 	"command.terminal.explainCommand.title": "Spiega Questo Comando",

--- a/src/package.nls.it.json
+++ b/src/package.nls.it.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focalizza Campo di Input",
 	"command.setCustomStoragePath.title": "Imposta Percorso di Archiviazione Personalizzato",
 	"command.importSettings.title": "Importa Impostazioni",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Aggiungi Contenuto del Terminale al Contesto",
 	"command.terminal.fixCommand.title": "Correggi Questo Comando",
 	"command.terminal.explainCommand.title": "Spiega Questo Comando",

--- a/src/package.nls.ja.json
+++ b/src/package.nls.ja.json
@@ -19,7 +19,7 @@
 	"command.focusInput.title": "入力フィールドにフォーカス",
 	"command.setCustomStoragePath.title": "カスタムストレージパスの設定",
 	"command.importSettings.title": "設定をインポート",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code移行ハンドオフをインポート",
 	"command.terminal.addToContext.title": "ターミナルの内容をコンテキストに追加",
 	"command.terminal.fixCommand.title": "このコマンドを修正",
 	"command.terminal.explainCommand.title": "このコマンドを説明",

--- a/src/package.nls.ja.json
+++ b/src/package.nls.ja.json
@@ -19,6 +19,7 @@
 	"command.focusInput.title": "入力フィールドにフォーカス",
 	"command.setCustomStoragePath.title": "カスタムストレージパスの設定",
 	"command.importSettings.title": "設定をインポート",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "ターミナルの内容をコンテキストに追加",
 	"command.terminal.fixCommand.title": "このコマンドを修正",
 	"command.terminal.explainCommand.title": "このコマンドを説明",

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -19,6 +19,7 @@
 	"command.focusInput.title": "Focus Input Field",
 	"command.setCustomStoragePath.title": "Set Custom Storage Path",
 	"command.importSettings.title": "Import Settings",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Add Terminal Content to Context",
 	"command.terminal.fixCommand.title": "Fix This Command",
 	"command.terminal.explainCommand.title": "Explain This Command",

--- a/src/package.nls.ko.json
+++ b/src/package.nls.ko.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "입력 필드 포커스",
 	"command.setCustomStoragePath.title": "사용자 지정 저장소 경로 설정",
 	"command.importSettings.title": "설정 가져오기",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code 마이그레이션 인수인계 가져오기",
 	"command.terminal.addToContext.title": "터미널 내용을 컨텍스트에 추가",
 	"command.terminal.fixCommand.title": "이 명령어 수정",
 	"command.terminal.explainCommand.title": "이 명령어 설명",

--- a/src/package.nls.ko.json
+++ b/src/package.nls.ko.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "입력 필드 포커스",
 	"command.setCustomStoragePath.title": "사용자 지정 저장소 경로 설정",
 	"command.importSettings.title": "설정 가져오기",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "터미널 내용을 컨텍스트에 추가",
 	"command.terminal.fixCommand.title": "이 명령어 수정",
 	"command.terminal.explainCommand.title": "이 명령어 설명",

--- a/src/package.nls.nl.json
+++ b/src/package.nls.nl.json
@@ -19,7 +19,7 @@
 	"command.focusInput.title": "Focus op Invoerveld",
 	"command.setCustomStoragePath.title": "Aangepast Opslagpad Instellen",
 	"command.importSettings.title": "Instellingen Importeren",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code-migratieoverdracht importeren",
 	"command.terminal.addToContext.title": "Terminalinhoud aan Context Toevoegen",
 	"command.terminal.fixCommand.title": "Repareer Dit Commando",
 	"command.terminal.explainCommand.title": "Leg Dit Commando Uit",

--- a/src/package.nls.nl.json
+++ b/src/package.nls.nl.json
@@ -19,6 +19,7 @@
 	"command.focusInput.title": "Focus op Invoerveld",
 	"command.setCustomStoragePath.title": "Aangepast Opslagpad Instellen",
 	"command.importSettings.title": "Instellingen Importeren",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Terminalinhoud aan Context Toevoegen",
 	"command.terminal.fixCommand.title": "Repareer Dit Commando",
 	"command.terminal.explainCommand.title": "Leg Dit Commando Uit",

--- a/src/package.nls.pl.json
+++ b/src/package.nls.pl.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Fokus na Pole Wprowadzania",
 	"command.setCustomStoragePath.title": "Ustaw Niestandardową Ścieżkę Przechowywania",
 	"command.importSettings.title": "Importuj Ustawienia",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Dodaj Zawartość Terminala do Kontekstu",
 	"command.terminal.fixCommand.title": "Napraw tę Komendę",
 	"command.terminal.explainCommand.title": "Wyjaśnij tę Komendę",

--- a/src/package.nls.pl.json
+++ b/src/package.nls.pl.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Fokus na Pole Wprowadzania",
 	"command.setCustomStoragePath.title": "Ustaw Niestandardową Ścieżkę Przechowywania",
 	"command.importSettings.title": "Importuj Ustawienia",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Import przekazania migracji Roo Code",
 	"command.terminal.addToContext.title": "Dodaj Zawartość Terminala do Kontekstu",
 	"command.terminal.fixCommand.title": "Napraw tę Komendę",
 	"command.terminal.explainCommand.title": "Wyjaśnij tę Komendę",

--- a/src/package.nls.pt-BR.json
+++ b/src/package.nls.pt-BR.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Definir Caminho de Armazenamento Personalizado",
 	"command.importSettings.title": "Importar Configurações",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Adicionar Conteúdo do Terminal ao Contexto",
 	"command.terminal.fixCommand.title": "Corrigir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.pt-BR.json
+++ b/src/package.nls.pt-BR.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Focar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Definir Caminho de Armazenamento Personalizado",
 	"command.importSettings.title": "Importar Configurações",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Importar transferência de migração do Roo Code",
 	"command.terminal.addToContext.title": "Adicionar Conteúdo do Terminal ao Contexto",
 	"command.terminal.fixCommand.title": "Corrigir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.ru.json
+++ b/src/package.nls.ru.json
@@ -19,7 +19,7 @@
 	"command.focusInput.title": "Фокус на поле ввода",
 	"command.setCustomStoragePath.title": "Указать путь хранения",
 	"command.importSettings.title": "Импортировать настройки",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Импорт передачи миграции Roo Code",
 	"command.terminal.addToContext.title": "Добавить содержимое терминала в контекст",
 	"command.terminal.fixCommand.title": "Исправить эту команду",
 	"command.terminal.explainCommand.title": "Объяснить эту команду",

--- a/src/package.nls.ru.json
+++ b/src/package.nls.ru.json
@@ -19,6 +19,7 @@
 	"command.focusInput.title": "Фокус на поле ввода",
 	"command.setCustomStoragePath.title": "Указать путь хранения",
 	"command.importSettings.title": "Импортировать настройки",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Добавить содержимое терминала в контекст",
 	"command.terminal.fixCommand.title": "Исправить эту команду",
 	"command.terminal.explainCommand.title": "Объяснить эту команду",

--- a/src/package.nls.tr.json
+++ b/src/package.nls.tr.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Giriş Alanına Odaklan",
 	"command.setCustomStoragePath.title": "Özel Depolama Yolunu Ayarla",
 	"command.importSettings.title": "Ayarları İçe Aktar",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Terminal İçeriğini Bağlama Ekle",
 	"command.terminal.fixCommand.title": "Bu Komutu Düzelt",
 	"command.terminal.explainCommand.title": "Bu Komutu Açıkla",

--- a/src/package.nls.tr.json
+++ b/src/package.nls.tr.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Giriş Alanına Odaklan",
 	"command.setCustomStoragePath.title": "Özel Depolama Yolunu Ayarla",
 	"command.importSettings.title": "Ayarları İçe Aktar",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Roo Code geçiş aktarımını içe aktar",
 	"command.terminal.addToContext.title": "Terminal İçeriğini Bağlama Ekle",
 	"command.terminal.fixCommand.title": "Bu Komutu Düzelt",
 	"command.terminal.explainCommand.title": "Bu Komutu Açıkla",

--- a/src/package.nls.vi.json
+++ b/src/package.nls.vi.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Tập Trung vào Trường Nhập",
 	"command.setCustomStoragePath.title": "Đặt Đường Dẫn Lưu Trữ Tùy Chỉnh",
 	"command.importSettings.title": "Nhập Cài Đặt",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "Thêm Nội Dung Terminal vào Ngữ Cảnh",
 	"command.terminal.fixCommand.title": "Sửa Lệnh Này",
 	"command.terminal.explainCommand.title": "Giải Thích Lệnh Này",

--- a/src/package.nls.vi.json
+++ b/src/package.nls.vi.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "Tập Trung vào Trường Nhập",
 	"command.setCustomStoragePath.title": "Đặt Đường Dẫn Lưu Trữ Tùy Chỉnh",
 	"command.importSettings.title": "Nhập Cài Đặt",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "Nhập bàn giao di chuyển Roo Code",
 	"command.terminal.addToContext.title": "Thêm Nội Dung Terminal vào Ngữ Cảnh",
 	"command.terminal.fixCommand.title": "Sửa Lệnh Này",
 	"command.terminal.explainCommand.title": "Giải Thích Lệnh Này",

--- a/src/package.nls.zh-CN.json
+++ b/src/package.nls.zh-CN.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "聚焦输入框",
 	"command.setCustomStoragePath.title": "设置自定义存储路径",
 	"command.importSettings.title": "导入设置",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "将终端内容添加到上下文",
 	"command.terminal.fixCommand.title": "修复此命令",
 	"command.terminal.explainCommand.title": "解释此命令",

--- a/src/package.nls.zh-CN.json
+++ b/src/package.nls.zh-CN.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "聚焦输入框",
 	"command.setCustomStoragePath.title": "设置自定义存储路径",
 	"command.importSettings.title": "导入设置",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "导入 Roo Code 迁移交接包",
 	"command.terminal.addToContext.title": "将终端内容添加到上下文",
 	"command.terminal.fixCommand.title": "修复此命令",
 	"command.terminal.explainCommand.title": "解释此命令",

--- a/src/package.nls.zh-TW.json
+++ b/src/package.nls.zh-TW.json
@@ -10,7 +10,7 @@
 	"command.focusInput.title": "聚焦輸入框",
 	"command.setCustomStoragePath.title": "設定自訂儲存路徑",
 	"command.importSettings.title": "匯入設定",
-	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
+	"command.importRooHandoff.title": "匯入 Roo Code 遷移交接包",
 	"command.terminal.addToContext.title": "將終端內容新增到上下文",
 	"command.terminal.fixCommand.title": "修復此命令",
 	"command.terminal.explainCommand.title": "解釋此命令",

--- a/src/package.nls.zh-TW.json
+++ b/src/package.nls.zh-TW.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "聚焦輸入框",
 	"command.setCustomStoragePath.title": "設定自訂儲存路徑",
 	"command.importSettings.title": "匯入設定",
+	"command.importRooHandoff.title": "Import Roo Code Migration Handoff",
 	"command.terminal.addToContext.title": "將終端內容新增到上下文",
 	"command.terminal.fixCommand.title": "修復此命令",
 	"command.terminal.explainCommand.title": "解釋此命令",

--- a/src/services/roo-import/RooImport.ts
+++ b/src/services/roo-import/RooImport.ts
@@ -241,11 +241,11 @@ export async function importRooHandoffFromPath(
 
 					const currentProviderName = merged.currentApiConfigName
 					const currentProvider = merged.apiConfigs[currentProviderName]
-					contextProxy.setValue("currentApiConfigName", currentProviderName)
+					await contextProxy.setValue("currentApiConfigName", currentProviderName)
 					if (currentProvider) {
 						await contextProxy.setProviderSettings(currentProvider)
 					}
-					contextProxy.setValue("listApiConfigMeta", await providerSettingsManager.listConfig())
+					await contextProxy.setValue("listApiConfigMeta", await providerSettingsManager.listConfig())
 
 					log("Imported provider profiles")
 				} else {

--- a/src/services/roo-import/RooImport.ts
+++ b/src/services/roo-import/RooImport.ts
@@ -1,0 +1,361 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+import * as vscode from "vscode"
+
+import type { GlobalSettings } from "@roo-code/types"
+
+import { ContextProxy } from "../../core/config/ContextProxy"
+import { CustomModesManager } from "../../core/config/CustomModesManager"
+import { ProviderSettingsManager, providerProfilesSchema } from "../../core/config/ProviderSettingsManager"
+import type { ProviderProfiles } from "../../core/config/ProviderSettingsManager"
+import { fileExistsAtPath } from "../../utils/fs"
+import { getStorageBasePath } from "../../utils/storage"
+import { Package } from "../../shared/package"
+import { t } from "../../i18n"
+
+const SUPPORTED_SCHEMA_VERSION = 1
+const ROO_EXTENSION_ID = "RooVeterinaryInc.roo-cline".toLowerCase()
+const HANDOFF_DIR = "zoo-migration"
+const HANDOFF_FILE = "handoff-v1.json"
+const TASKS_INDEX_FILE = "_index.json"
+
+type ConfigurationValue = {
+	value: unknown
+	globalValue?: unknown
+	workspaceValue?: unknown
+	workspaceFolderValue?: unknown
+}
+
+type ZooMigrationHandoff = {
+	schemaVersion: number
+	createdAt: string
+	source: {
+		extensionId: string
+		publisher: string
+		name: string
+		version: string
+		globalStoragePath: string
+		storageBasePath: string
+	}
+	zoo: {
+		repositoryUrl: string
+		announcementUrl: string
+		extensionId: string
+	}
+	containsSecrets: boolean
+	globalSettings?: GlobalSettings
+	vscodeConfiguration: Record<string, ConfigurationValue>
+	providerProfiles?: unknown
+	copiedData: {
+		settings?: string
+		tasks?: string
+	}
+}
+
+export type ImportRooHandoffOptions = {
+	context: vscode.ExtensionContext
+	providerSettingsManager: ProviderSettingsManager
+	contextProxy: ContextProxy
+	customModesManager: CustomModesManager
+	outputChannel?: vscode.OutputChannel
+}
+
+export type ImportRooHandoffResult = {
+	success: boolean
+	error?: string
+	warnings?: string[]
+	tasksCopied?: number
+}
+
+/**
+ * Returns the expected handoff file path based on Roo's standard extension storage location,
+ * which sits in the same parent directory as Zoo's global storage.
+ */
+export function findDefaultHandoffPath(context: vscode.ExtensionContext): string {
+	const parentDir = path.dirname(context.globalStorageUri.fsPath)
+	return path.join(parentDir, ROO_EXTENSION_ID, HANDOFF_DIR, HANDOFF_FILE)
+}
+
+/**
+ * Checks whether a Roo handoff exists that has not been imported yet.
+ * Returns the handoff path if found and new, otherwise undefined.
+ */
+export async function findUnimportedRooHandoff(context: vscode.ExtensionContext): Promise<string | undefined> {
+	const handoffPath = findDefaultHandoffPath(context)
+	if (!(await fileExistsAtPath(handoffPath))) {
+		return undefined
+	}
+
+	try {
+		const raw: ZooMigrationHandoff = JSON.parse(await fs.readFile(handoffPath, "utf-8"))
+		const lastImported = context.globalState.get<string>("rooHandoffImportedAt")
+		if (lastImported === raw.createdAt) {
+			return undefined
+		}
+		return handoffPath
+	} catch {
+		return undefined
+	}
+}
+
+/**
+ * Shows a notification when a new Roo handoff is detected on activation.
+ * The user can import immediately or dismiss (they can always run the command later).
+ */
+export async function showRooHandoffNotice(
+	context: vscode.ExtensionContext,
+	options: ImportRooHandoffOptions,
+): Promise<void> {
+	const handoffPath = await findUnimportedRooHandoff(context)
+	if (!handoffPath) {
+		return
+	}
+
+	const importNow = t("common:rooImport.actions.importNow")
+	const later = t("common:rooImport.actions.later")
+
+	const result = await vscode.window.showInformationMessage(t("common:rooImport.notice"), importNow, later)
+
+	if (result === importNow) {
+		await runImport(handoffPath, options)
+	}
+}
+
+/**
+ * Shows a file picker pre-seeded to Roo's expected handoff location, then imports.
+ */
+export async function promptAndImportRooHandoff(
+	options: ImportRooHandoffOptions,
+): Promise<ImportRooHandoffResult | undefined> {
+	const defaultPath = findDefaultHandoffPath(options.context)
+	options.outputChannel?.appendLine(`[Roo Import] Looking for handoff at: ${defaultPath}`)
+
+	// If the handoff already exists at the expected location, import directly.
+	if (await fileExistsAtPath(defaultPath)) {
+		return runImport(defaultPath, options)
+	}
+
+	const uris = await vscode.window.showOpenDialog({
+		filters: { JSON: ["json"] },
+		canSelectMany: false,
+		title: t("common:rooImport.pickHandoffFile"),
+	})
+
+	if (!uris || uris.length === 0) {
+		return undefined
+	}
+
+	return runImport(uris[0].fsPath, options)
+}
+
+async function runImport(handoffPath: string, options: ImportRooHandoffOptions): Promise<ImportRooHandoffResult> {
+	const result = await importRooHandoffFromPath(handoffPath, options)
+
+	if (result.success) {
+		const taskCount = result.tasksCopied ?? 0
+		let message = t("common:rooImport.importSuccess", { tasks: taskCount })
+		if (result.warnings && result.warnings.length > 0) {
+			message += ` (${result.warnings.length} warning${result.warnings.length > 1 ? "s" : ""})`
+		}
+		await vscode.window.showInformationMessage(message)
+	} else {
+		await vscode.window.showErrorMessage(t("common:rooImport.importFailed", { error: result.error ?? "" }))
+	}
+
+	return result
+}
+
+export async function importRooHandoffFromPath(
+	handoffPath: string,
+	{ context, providerSettingsManager, contextProxy, customModesManager, outputChannel }: ImportRooHandoffOptions,
+): Promise<ImportRooHandoffResult> {
+	const log = (msg: string) => outputChannel?.appendLine(`[Roo Import] ${msg}`)
+	const warnings: string[] = []
+
+	try {
+		const raw: ZooMigrationHandoff = JSON.parse(await fs.readFile(handoffPath, "utf-8"))
+
+		if (raw.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+			return {
+				success: false,
+				error: `Unsupported handoff schema version ${raw.schemaVersion} (expected ${SUPPORTED_SCHEMA_VERSION})`,
+			}
+		}
+
+		log(`Importing Roo handoff from ${handoffPath} (created ${raw.createdAt})`)
+
+		const handoffDir = path.dirname(handoffPath)
+		const zooBasePath = await getStorageBasePath(context.globalStorageUri.fsPath)
+		let tasksCopied = 0
+
+		// 1. Copy task history — merge only, never overwrite existing Zoo tasks
+		if (raw.copiedData.tasks) {
+			const tasksSource = path.join(handoffDir, raw.copiedData.tasks)
+			const tasksDest = path.join(zooBasePath, "tasks")
+			tasksCopied = await mergeTasksDirectory(tasksSource, tasksDest, log)
+			log(`Copied ${tasksCopied} task(s) from Roo`)
+		}
+
+		// 2. Copy settings files — merge only, never overwrite Zoo's existing files
+		if (raw.copiedData.settings) {
+			const settingsSource = path.join(handoffDir, raw.copiedData.settings)
+			const settingsDest = path.join(zooBasePath, "settings")
+			const copiedSettings = await mergeSettingsDirectory(settingsSource, settingsDest, log)
+			log(`Copied ${copiedSettings} settings file(s) from Roo`)
+		}
+
+		// 3. Apply globalSettings and persist custom modes through the manager so
+		//    they survive a CustomModesManager rebuild/reload cycle.
+		if (raw.globalSettings) {
+			try {
+				// Persist each imported custom mode so the manager's settings files
+				// stay in sync with global state (mirrors importSettingsFromPath).
+				await Promise.all(
+					(raw.globalSettings.customModes ?? []).map((mode) =>
+						customModesManager.updateCustomMode(mode.slug, mode),
+					),
+				)
+				await contextProxy.setValues(raw.globalSettings)
+				log("Applied globalSettings")
+			} catch (err) {
+				const msg = `Could not apply globalSettings: ${err instanceof Error ? err.message : String(err)}`
+				warnings.push(msg)
+				log(msg)
+			}
+		}
+
+		// 4. Import provider profiles — only when the user opted into secret migration.
+		//    After storing profiles, activate the imported provider in ContextProxy so
+		//    getState() reflects the new provider immediately (mirrors importSettingsFromPath).
+		if (raw.containsSecrets && raw.providerProfiles) {
+			try {
+				const parsed = providerProfilesSchema.safeParse(raw.providerProfiles)
+				if (parsed.success) {
+					const existing = await providerSettingsManager.export()
+					const merged: ProviderProfiles = {
+						currentApiConfigName: parsed.data.currentApiConfigName || existing.currentApiConfigName,
+						apiConfigs: { ...existing.apiConfigs, ...parsed.data.apiConfigs },
+						modeApiConfigs: { ...existing.modeApiConfigs, ...parsed.data.modeApiConfigs },
+					}
+					await providerSettingsManager.import(merged)
+
+					const currentProviderName = merged.currentApiConfigName
+					const currentProvider = merged.apiConfigs[currentProviderName]
+					contextProxy.setValue("currentApiConfigName", currentProviderName)
+					if (currentProvider) {
+						await contextProxy.setProviderSettings(currentProvider)
+					}
+					contextProxy.setValue("listApiConfigMeta", await providerSettingsManager.listConfig())
+
+					log("Imported provider profiles")
+				} else {
+					const issues = parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ")
+					const msg = `Provider profiles validation failed: ${issues}`
+					warnings.push(msg)
+					log(msg)
+				}
+			} catch (err) {
+				const msg = `Could not import provider profiles: ${err instanceof Error ? err.message : String(err)}`
+				warnings.push(msg)
+				log(msg)
+			}
+		}
+
+		// 5. Apply VS Code configuration — only set keys Zoo doesn't already have a global value for.
+		//    customStoragePath is intentionally excluded: tasks/settings were already copied into
+		//    zooBasePath resolved with the pre-import path. Applying Roo's custom path afterward
+		//    would make getStorageBasePath() point elsewhere and make the copied data invisible.
+		//    It also often points at Roo's own storage directory, which is wrong for Zoo.
+		const SKIP_CONFIG_KEYS = new Set(["customStoragePath"])
+		const config = vscode.workspace.getConfiguration(Package.name)
+		for (const [key, val] of Object.entries(raw.vscodeConfiguration)) {
+			if (SKIP_CONFIG_KEYS.has(key)) {
+				continue
+			}
+			if (val.globalValue === undefined) {
+				continue
+			}
+			const current = config.inspect(key)
+			if (current?.globalValue !== undefined) {
+				continue
+			}
+			try {
+				await config.update(key, val.globalValue, vscode.ConfigurationTarget.Global)
+			} catch (err) {
+				warnings.push(`Could not apply config ${key}: ${err instanceof Error ? err.message : String(err)}`)
+			}
+		}
+		log("Applied VS Code configuration")
+
+		// Record that this handoff has been imported so the activation notice won't re-prompt
+		await context.globalState.update("rooHandoffImportedAt", raw.createdAt)
+
+		return {
+			success: true,
+			warnings: warnings.length > 0 ? warnings : undefined,
+			tasksCopied,
+		}
+	} catch (err) {
+		const error = err instanceof Error ? err.message : String(err)
+		log(`Import failed: ${error}`)
+		return { success: false, error }
+	}
+}
+
+async function mergeTasksDirectory(sourceDir: string, destDir: string, log: (msg: string) => void): Promise<number> {
+	if (!(await fileExistsAtPath(sourceDir))) {
+		log(`Tasks source not found at ${sourceDir}; skipping`)
+		return 0
+	}
+
+	await fs.mkdir(destDir, { recursive: true })
+	let copied = 0
+
+	const entries = await fs.readdir(sourceDir, { withFileTypes: true })
+	for (const entry of entries) {
+		// Skip the index — Zoo's TaskHistoryStore rebuilds it from individual task files
+		if (entry.name === TASKS_INDEX_FILE) {
+			continue
+		}
+		if (!entry.isDirectory()) {
+			continue
+		}
+
+		const taskDest = path.join(destDir, entry.name)
+		// Skip tasks that already exist in Zoo's storage
+		if (await fileExistsAtPath(taskDest)) {
+			continue
+		}
+
+		await fs.cp(path.join(sourceDir, entry.name), taskDest, { recursive: true })
+		copied++
+	}
+
+	return copied
+}
+
+async function mergeSettingsDirectory(sourceDir: string, destDir: string, log: (msg: string) => void): Promise<number> {
+	if (!(await fileExistsAtPath(sourceDir))) {
+		log(`Settings source not found at ${sourceDir}; skipping`)
+		return 0
+	}
+
+	await fs.mkdir(destDir, { recursive: true })
+	let copied = 0
+
+	const entries = await fs.readdir(sourceDir, { withFileTypes: true })
+	for (const entry of entries) {
+		if (!entry.isFile()) {
+			continue
+		}
+		const destFile = path.join(destDir, entry.name)
+		// Skip files already present in Zoo's settings
+		if (await fileExistsAtPath(destFile)) {
+			continue
+		}
+		await fs.copyFile(path.join(sourceDir, entry.name), destFile)
+		copied++
+	}
+
+	return copied
+}

--- a/src/services/roo-import/__tests__/RooImport.spec.ts
+++ b/src/services/roo-import/__tests__/RooImport.spec.ts
@@ -1,0 +1,494 @@
+// pnpm --dir src exec vitest run services/roo-import/__tests__/RooImport.spec.ts
+
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import * as vscode from "vscode"
+
+import {
+	importRooHandoffFromPath,
+	findDefaultHandoffPath,
+	findUnimportedRooHandoff,
+	promptAndImportRooHandoff,
+	showRooHandoffNotice,
+} from "../RooImport"
+
+vi.mock("../../../i18n", () => ({
+	t: (key: string, opts?: Record<string, unknown>) => {
+		const suffix = opts ? ` ${JSON.stringify(opts)}` : ""
+		return `${key}${suffix}`
+	},
+}))
+
+vi.mock("../../../shared/package", () => ({
+	Package: { name: "roo-cline", publisher: "ZooCodeOrganization", version: "3.53.0" },
+}))
+
+function makeHandoff(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		schemaVersion: 1,
+		createdAt: "2026-05-09T00:00:00.000Z",
+		source: {
+			extensionId: "RooVeterinaryInc.roo-cline",
+			publisher: "RooVeterinaryInc",
+			name: "roo-cline",
+			version: "3.53.1",
+			globalStoragePath: "/tmp/roo-storage",
+			storageBasePath: "/tmp/roo-storage",
+		},
+		zoo: {
+			repositoryUrl: "https://github.com/Zoo-Code-Org/Zoo-Code",
+			announcementUrl: "https://reddit.com/...",
+			extensionId: "ZooCodeOrganization.zoo-code",
+		},
+		containsSecrets: false,
+		globalSettings: { mode: "code" },
+		vscodeConfiguration: {
+			allowedCommands: { value: ["git diff"], globalValue: ["git diff"] },
+			customStoragePath: { value: "", globalValue: undefined },
+		},
+		copiedData: {},
+		...overrides,
+	}
+}
+
+function makeContext(globalStoragePath: string): vscode.ExtensionContext {
+	return {
+		globalStorageUri: { fsPath: globalStoragePath } as vscode.Uri,
+		globalState: {
+			get: vi.fn().mockReturnValue(undefined),
+			update: vi.fn().mockResolvedValue(undefined),
+		},
+	} as any
+}
+
+function makeOptions(context: vscode.ExtensionContext) {
+	return {
+		context,
+		providerSettingsManager: {
+			export: vi.fn().mockResolvedValue({
+				currentApiConfigName: "default",
+				apiConfigs: {},
+				modeApiConfigs: {},
+			}),
+			import: vi.fn().mockResolvedValue(undefined),
+			listConfig: vi.fn().mockResolvedValue([]),
+		} as any,
+		contextProxy: {
+			setValues: vi.fn().mockResolvedValue(undefined),
+			setValue: vi.fn().mockResolvedValue(undefined),
+			setProviderSettings: vi.fn().mockResolvedValue(undefined),
+		} as any,
+		customModesManager: {
+			updateCustomMode: vi.fn().mockResolvedValue(undefined),
+		} as any,
+	}
+}
+
+describe("importRooHandoffFromPath", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-roo-import-"))
+	})
+
+	afterEach(async () => {
+		vi.restoreAllMocks()
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("rejects an unsupported schema version", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff({ schemaVersion: 99 })))
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/Unsupported handoff schema version 99/)
+	})
+
+	it("applies globalSettings via contextProxy", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+		const context = makeContext(tmpDir)
+		const options = makeOptions(context)
+
+		const result = await importRooHandoffFromPath(handoffPath, options)
+
+		expect(result.success).toBe(true)
+		expect(options.contextProxy.setValues).toHaveBeenCalledWith({ mode: "code" })
+	})
+
+	it("copies new task directories and skips existing ones", async () => {
+		const handoffDir = path.join(tmpDir, "zoo-migration")
+		const tasksSource = path.join(handoffDir, "data", "tasks")
+		const zooTasksDest = path.join(tmpDir, "tasks")
+
+		await fs.mkdir(path.join(tasksSource, "task-new"), { recursive: true })
+		await fs.writeFile(path.join(tasksSource, "task-new", "history_item.json"), '{"id":"task-new"}')
+		await fs.mkdir(path.join(tasksSource, "task-existing"), { recursive: true })
+		await fs.writeFile(path.join(tasksSource, "task-existing", "history_item.json"), '{"id":"roo"}')
+		await fs.mkdir(path.join(zooTasksDest, "task-existing"), { recursive: true })
+		await fs.writeFile(path.join(zooTasksDest, "task-existing", "history_item.json"), '{"id":"zoo"}')
+
+		const handoff = makeHandoff({ copiedData: { tasks: "data/tasks" } })
+		const handoffPath = path.join(handoffDir, "handoff-v1.json")
+		await fs.mkdir(handoffDir, { recursive: true })
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		expect(result.tasksCopied).toBe(1)
+
+		const copiedTask = await fs.readFile(path.join(zooTasksDest, "task-new", "history_item.json"), "utf-8")
+		expect(JSON.parse(copiedTask).id).toBe("task-new")
+
+		const existingTask = await fs.readFile(path.join(zooTasksDest, "task-existing", "history_item.json"), "utf-8")
+		expect(JSON.parse(existingTask).id).toBe("zoo")
+	})
+
+	it("skips the tasks index file", async () => {
+		const handoffDir = path.join(tmpDir, "zoo-migration")
+		const tasksSource = path.join(handoffDir, "data", "tasks")
+
+		await fs.mkdir(tasksSource, { recursive: true })
+		await fs.writeFile(path.join(tasksSource, "_index.json"), '{"version":1}')
+
+		const handoff = makeHandoff({ copiedData: { tasks: "data/tasks" } })
+		const handoffPath = path.join(handoffDir, "handoff-v1.json")
+		await fs.mkdir(handoffDir, { recursive: true })
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		expect(result.tasksCopied).toBe(0)
+		const zooTasksDir = path.join(tmpDir, "tasks")
+		await expect(fs.access(path.join(zooTasksDir, "_index.json"))).rejects.toThrow()
+	})
+
+	it("imports provider profiles and activates them in ContextProxy", async () => {
+		const providerProfiles = {
+			currentApiConfigName: "default",
+			apiConfigs: {
+				default: { id: "p1", apiProvider: "openai", openAiApiKey: "sk-secret" },
+			},
+			modeApiConfigs: {},
+		}
+		const handoff = makeHandoff({ containsSecrets: true, providerProfiles })
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const context = makeContext(tmpDir)
+		const options = makeOptions(context)
+
+		const result = await importRooHandoffFromPath(handoffPath, options)
+
+		expect(result.success).toBe(true)
+		expect(options.providerSettingsManager.import).toHaveBeenCalled()
+		// Active provider must be reflected in ContextProxy immediately
+		expect(options.contextProxy.setValue).toHaveBeenCalledWith("currentApiConfigName", "default")
+		expect(options.contextProxy.setProviderSettings).toHaveBeenCalled()
+		expect(options.contextProxy.setValue).toHaveBeenCalledWith("listApiConfigMeta", expect.anything())
+	})
+
+	it("persists imported custom modes through CustomModesManager", async () => {
+		const customModes = [{ slug: "my-mode", name: "My Mode", roleDefinition: "A mode", groups: [] }]
+		const handoff = makeHandoff({ globalSettings: { mode: "code", customModes } })
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const context = makeContext(tmpDir)
+		const options = makeOptions(context)
+
+		const result = await importRooHandoffFromPath(handoffPath, options)
+
+		expect(result.success).toBe(true)
+		expect(options.customModesManager.updateCustomMode).toHaveBeenCalledWith("my-mode", customModes[0])
+	})
+
+	it("skips provider profiles when containsSecrets is false", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff({ containsSecrets: false })))
+		const options = makeOptions(makeContext(tmpDir))
+
+		await importRooHandoffFromPath(handoffPath, options)
+
+		expect(options.providerSettingsManager.import).not.toHaveBeenCalled()
+	})
+
+	it("applies VS Code config global values that Zoo does not already have set", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+		const update = vi.fn().mockResolvedValue(undefined)
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn((key: string) => (key === "customStoragePath" ? "" : undefined)),
+			inspect: vi.fn(() => ({ globalValue: undefined })),
+			update,
+		} as any)
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		expect(update).toHaveBeenCalledWith("allowedCommands", ["git diff"], vscode.ConfigurationTarget.Global)
+		// customStoragePath must never be applied — it would redirect getStorageBasePath()
+		// away from the directory where tasks/settings were already copied
+		expect(update).not.toHaveBeenCalledWith("customStoragePath", expect.anything(), expect.anything())
+	})
+
+	it("never applies customStoragePath even when the handoff includes a global value for it", async () => {
+		const handoff = makeHandoff({
+			vscodeConfiguration: {
+				customStoragePath: { value: "/roo/custom/path", globalValue: "/roo/custom/path" },
+				allowedCommands: { value: [], globalValue: undefined },
+			},
+		})
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+		const update = vi.fn().mockResolvedValue(undefined)
+		vi.spyOn(vscode.workspace, "getConfiguration").mockReturnValue({
+			get: vi.fn(() => undefined),
+			inspect: vi.fn(() => ({ globalValue: undefined })),
+			update,
+		} as any)
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		expect(update).not.toHaveBeenCalledWith("customStoragePath", expect.anything(), expect.anything())
+	})
+
+	it("records the handoff createdAt so the notice does not re-prompt", async () => {
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+		const context = makeContext(tmpDir)
+
+		await importRooHandoffFromPath(handoffPath, makeOptions(context))
+
+		expect(context.globalState.update).toHaveBeenCalledWith("rooHandoffImportedAt", "2026-05-09T00:00:00.000Z")
+	})
+})
+
+describe("findDefaultHandoffPath", () => {
+	it("resolves to the Roo sibling directory (lowercase, matching VS Code storage convention)", () => {
+		const context = makeContext("/storage/ZooCodeOrganization.zoo-code")
+		const result = findDefaultHandoffPath(context)
+		expect(result).toBe(path.join("/storage", "rooveterinaryinc.roo-cline", "zoo-migration", "handoff-v1.json"))
+	})
+})
+
+describe("findUnimportedRooHandoff", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-handoff-detect-"))
+	})
+
+	afterEach(async () => {
+		vi.restoreAllMocks()
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("returns undefined when no handoff file exists", async () => {
+		const context = makeContext(path.join(tmpDir, "ZooCodeOrganization.zoo-code"))
+		const result = await findUnimportedRooHandoff(context)
+		expect(result).toBeUndefined()
+	})
+
+	it("returns the path when a new handoff is found", async () => {
+		const rooDir = path.join(tmpDir, "rooveterinaryinc.roo-cline", "zoo-migration")
+		await fs.mkdir(rooDir, { recursive: true })
+		const handoffPath = path.join(rooDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = {
+			globalStorageUri: { fsPath: path.join(tmpDir, "ZooCodeOrganization.zoo-code") } as vscode.Uri,
+			globalState: {
+				get: vi.fn().mockReturnValue(undefined),
+				update: vi.fn(),
+			},
+		} as any
+
+		const result = await findUnimportedRooHandoff(context)
+		expect(result).toBe(handoffPath)
+	})
+
+	it("returns undefined when the handoff was already imported", async () => {
+		const rooDir = path.join(tmpDir, "rooveterinaryinc.roo-cline", "zoo-migration")
+		await fs.mkdir(rooDir, { recursive: true })
+		const handoffPath = path.join(rooDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = {
+			globalStorageUri: { fsPath: path.join(tmpDir, "ZooCodeOrganization.zoo-code") } as vscode.Uri,
+			globalState: {
+				get: vi.fn().mockReturnValue("2026-05-09T00:00:00.000Z"),
+				update: vi.fn(),
+			},
+		} as any
+
+		const result = await findUnimportedRooHandoff(context)
+		expect(result).toBeUndefined()
+	})
+})
+
+describe("promptAndImportRooHandoff", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-roo-prompt-"))
+	})
+
+	afterEach(async () => {
+		vi.restoreAllMocks()
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("imports directly when handoff exists at the default path without showing the file picker", async () => {
+		const zooStorageDir = path.join(tmpDir, "ZooCodeOrganization.zoo-code")
+		const rooDir = path.join(tmpDir, "rooveterinaryinc.roo-cline", "zoo-migration")
+		await fs.mkdir(rooDir, { recursive: true })
+		const handoffPath = path.join(rooDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = makeContext(zooStorageDir)
+		const options = makeOptions(context)
+		const showOpenDialog = vi.spyOn(vscode.window, "showOpenDialog")
+
+		const result = await promptAndImportRooHandoff(options)
+
+		expect(result?.success).toBe(true)
+		expect(showOpenDialog).not.toHaveBeenCalled()
+	})
+
+	it("returns undefined when no file is selected in the picker", async () => {
+		const zooStorageDir = path.join(tmpDir, "ZooCodeOrganization.zoo-code")
+		const context = makeContext(zooStorageDir)
+		const options = makeOptions(context)
+		vi.spyOn(vscode.window, "showOpenDialog").mockResolvedValue(undefined)
+
+		const result = await promptAndImportRooHandoff(options)
+
+		expect(result).toBeUndefined()
+	})
+
+	it("imports from a user-selected file when no default handoff exists", async () => {
+		const zooStorageDir = path.join(tmpDir, "ZooCodeOrganization.zoo-code")
+		const handoffPath = path.join(tmpDir, "custom-handoff.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = makeContext(zooStorageDir)
+		const options = makeOptions(context)
+		vi.spyOn(vscode.window, "showOpenDialog").mockResolvedValue([{ fsPath: handoffPath } as vscode.Uri])
+		vi.spyOn(vscode.window, "showInformationMessage").mockResolvedValue(undefined as any)
+
+		const result = await promptAndImportRooHandoff(options)
+
+		expect(result?.success).toBe(true)
+	})
+})
+
+describe("showRooHandoffNotice", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-roo-notice-"))
+	})
+
+	afterEach(async () => {
+		vi.restoreAllMocks()
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("does nothing when no unimported handoff exists", async () => {
+		const context = makeContext(path.join(tmpDir, "ZooCodeOrganization.zoo-code"))
+		const showInformationMessage = vi.spyOn(vscode.window, "showInformationMessage")
+
+		await showRooHandoffNotice(context, makeOptions(context))
+
+		expect(showInformationMessage).not.toHaveBeenCalled()
+	})
+
+	it("runs the import when the user clicks Import Now", async () => {
+		const zooStorageDir = path.join(tmpDir, "ZooCodeOrganization.zoo-code")
+		const rooDir = path.join(tmpDir, "rooveterinaryinc.roo-cline", "zoo-migration")
+		await fs.mkdir(rooDir, { recursive: true })
+		const handoffPath = path.join(rooDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = makeContext(zooStorageDir)
+		const options = makeOptions(context)
+		vi.spyOn(vscode.window, "showInformationMessage").mockResolvedValue("common:rooImport.actions.importNow" as any)
+		vi.spyOn(vscode.window, "showInformationMessage")
+
+		await showRooHandoffNotice(context, options)
+
+		expect(context.globalState.update).toHaveBeenCalledWith("rooHandoffImportedAt", "2026-05-09T00:00:00.000Z")
+	})
+
+	it("does not import when the user dismisses the notice", async () => {
+		const zooStorageDir = path.join(tmpDir, "ZooCodeOrganization.zoo-code")
+		const rooDir = path.join(tmpDir, "rooveterinaryinc.roo-cline", "zoo-migration")
+		await fs.mkdir(rooDir, { recursive: true })
+		const handoffPath = path.join(rooDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(makeHandoff()))
+
+		const context = makeContext(zooStorageDir)
+		const options = makeOptions(context)
+		vi.spyOn(vscode.window, "showInformationMessage").mockResolvedValue("common:rooImport.actions.later" as any)
+
+		await showRooHandoffNotice(context, options)
+
+		expect(context.globalState.update).not.toHaveBeenCalled()
+	})
+})
+
+describe("importRooHandoffFromPath — warnings and settings copy", () => {
+	let tmpDir: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-roo-warn-"))
+	})
+
+	afterEach(async () => {
+		vi.restoreAllMocks()
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("copies new settings files and skips existing ones", async () => {
+		const handoffDir = path.join(tmpDir, "zoo-migration")
+		const settingsSource = path.join(handoffDir, "data", "settings")
+		const zooSettingsDest = path.join(tmpDir, "settings")
+
+		await fs.mkdir(settingsSource, { recursive: true })
+		await fs.writeFile(path.join(settingsSource, "modes.json"), '{"version":1}')
+		await fs.mkdir(zooSettingsDest, { recursive: true })
+		await fs.writeFile(path.join(zooSettingsDest, "modes.json"), '{"version":0}')
+		await fs.writeFile(path.join(settingsSource, "providers.json"), '{"p":1}')
+
+		const handoff = makeHandoff({ copiedData: { settings: "data/settings" } })
+		const handoffPath = path.join(handoffDir, "handoff-v1.json")
+		await fs.mkdir(handoffDir, { recursive: true })
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		// existing modes.json must not be overwritten
+		expect(JSON.parse(await fs.readFile(path.join(zooSettingsDest, "modes.json"), "utf-8")).version).toBe(0)
+		// new providers.json must be copied
+		expect(JSON.parse(await fs.readFile(path.join(zooSettingsDest, "providers.json"), "utf-8")).p).toBe(1)
+	})
+
+	it("records a warning when provider profile validation fails", async () => {
+		const handoff = makeHandoff({ containsSecrets: true, providerProfiles: { invalid: true } })
+		const handoffPath = path.join(tmpDir, "handoff-v1.json")
+		await fs.writeFile(handoffPath, JSON.stringify(handoff))
+
+		const result = await importRooHandoffFromPath(handoffPath, makeOptions(makeContext(tmpDir)))
+
+		expect(result.success).toBe(true)
+		expect(result.warnings?.some((w) => w.includes("Provider profiles validation failed"))).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Implements the Zoo Code import side of the Roo→Zoo migration handoff introduced in [RooCodeInc/Roo-Code#12266](https://github.com/RooCodeInc/Roo-Code/pull/12266). When a user installs Zoo Code after using Roo Code, their settings and chat history can be automatically detected and imported.

- **Auto-detection on activation** — on startup, checks for a `handoff-v1.json` in the Roo Code sibling storage directory; shows a one-time "Import Now / Later" notice if found and not yet imported
- **Command palette** — `Zoo Code: Import Roo Code Migration Handoff` auto-imports from the detected path, or falls back to a file picker if no handoff is found at the default location
- **Task history merge** — copies Roo task directories into Zoo's storage without overwriting existing tasks; skips the `_index.json` file (Zoo rebuilds it)
- **Settings merge** — copies settings files without overwriting Zoo's existing ones
- **Provider profiles** — imports API provider configs and immediately activates the current provider in `ContextProxy` so the UI reflects it without a reload
- **Custom modes** — persists imported modes through `CustomModesManager` so they survive a reload cycle
- **VS Code config** — applies Roo's global config values for keys Zoo doesn't already have set; intentionally skips `customStoragePath` to avoid redirecting storage away from where data was just copied
- **Linux/container compatibility** — lowercases the extension ID when constructing the sibling path, matching VS Code's filesystem convention on case-sensitive systems
- **i18n** — all strings translated across all 18 supported locales

## Test plan

- [x] 14 unit tests covering schema validation, task merging, settings merging, provider profile import, custom modes, VS Code config application, `customStoragePath` exclusion, and `createdAt` deduplication
- [x] 3 e2e tests: command registration, full task copy verification against real extension storage, re-import safety
- [ ] Manual: install alongside Roo Code, run export from Roo, trigger import via command palette, verify tasks and settings appear in Zoo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import Roo Code migration packages into Zoo Code, including task history and settings.
  * Automatic detection of migration handoff files with convenient user notifications.
  * Option to import migration files immediately or manually select from your file system.

* **Localization**
  * Added multilingual support for the new import feature across 17+ languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->