### PR TITLE
Remove stale organizationMcps marketplace contract

### DIFF
--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -164,7 +164,6 @@ export interface ExtensionMessage {
 	organizationAllowList?: OrganizationAllowList
 	tab?: string
 	marketplaceItems?: MarketplaceItem[]
-	organizationMcps?: MarketplaceItem[]
 	marketplaceInstalledMetadata?: MarketplaceInstalledMetadata
 	errors?: string[]
 	visibility?: ShareVisibility

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1948,7 +1948,7 @@ export class ClineProvider
 			const [marketplaceResult, marketplaceInstalledMetadata] = await Promise.all([
 				this.marketplaceManager.getMarketplaceItems().catch((error) => {
 					console.error("Failed to fetch marketplace items:", error)
-					return { organizationMcps: [], marketplaceItems: [], errors: [error.message] }
+					return { marketplaceItems: [], errors: [error.message] }
 				}),
 				this.marketplaceManager.getInstallationMetadata().catch((error) => {
 					console.error("Failed to fetch installation metadata:", error)
@@ -1959,7 +1959,6 @@ export class ClineProvider
 			// Send marketplace data separately
 			this.postMessageToWebview({
 				type: "marketplaceData",
-				organizationMcps: marketplaceResult.organizationMcps || [],
 				marketplaceItems: marketplaceResult.marketplaceItems || [],
 				marketplaceInstalledMetadata: marketplaceInstalledMetadata || { project: {}, global: {} },
 				errors: marketplaceResult.errors,
@@ -1970,7 +1969,6 @@ export class ClineProvider
 			// Send empty data on error to prevent UI from hanging
 			this.postMessageToWebview({
 				type: "marketplaceData",
-				organizationMcps: [],
 				marketplaceItems: [],
 				marketplaceInstalledMetadata: { project: {}, global: {} },
 				errors: [error instanceof Error ? error.message : String(error)],

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1948,7 +1948,8 @@ export class ClineProvider
 			const [marketplaceResult, marketplaceInstalledMetadata] = await Promise.all([
 				this.marketplaceManager.getMarketplaceItems().catch((error) => {
 					console.error("Failed to fetch marketplace items:", error)
-					return { marketplaceItems: [], errors: [error.message] }
+					const errorMessage = error instanceof Error ? error.message : String(error)
+					return { marketplaceItems: [], errors: [errorMessage] }
 				}),
 				this.marketplaceManager.getInstallationMetadata().catch((error) => {
 					console.error("Failed to fetch installation metadata:", error)

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -637,6 +637,45 @@ describe("ClineProvider", () => {
 		expect(mockPostMessage).toHaveBeenCalled()
 	})
 
+	test("fetchMarketplaceData posts marketplace items without organization MCPs", async () => {
+		await provider.resolveWebviewView(mockWebviewView)
+		;(provider as any).marketplaceManager = {
+			getMarketplaceItems: vi.fn().mockResolvedValue({
+				marketplaceItems: [
+					{
+						id: "test-mcp",
+						name: "Test MCP",
+						description: "Marketplace item",
+						type: "mcp",
+						url: "https://example.com/test-mcp",
+						content: '{"command":"node"}',
+					},
+				],
+			}),
+			getInstallationMetadata: vi.fn().mockResolvedValue({ project: {}, global: {} }),
+		}
+
+		mockPostMessage.mockClear()
+
+		await provider.fetchMarketplaceData()
+
+		expect(mockPostMessage).toHaveBeenCalledWith({
+			type: "marketplaceData",
+			marketplaceItems: [
+				{
+					id: "test-mcp",
+					name: "Test MCP",
+					description: "Marketplace item",
+					type: "mcp",
+					url: "https://example.com/test-mcp",
+					content: '{"command":"node"}',
+				},
+			],
+			marketplaceInstalledMetadata: { project: {}, global: {} },
+			errors: undefined,
+		})
+	})
+
 	test("clearTask aborts current task", async () => {
 		// Setup Cline instance with auto-mock from the top of the file
 		const mockCline = new Task(defaultTaskOptions) // Create a new mocked instance

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -676,6 +676,25 @@ describe("ClineProvider", () => {
 		})
 	})
 
+	test("fetchMarketplaceData normalizes non-Error marketplace fetch failures", async () => {
+		await provider.resolveWebviewView(mockWebviewView)
+		;(provider as any).marketplaceManager = {
+			getMarketplaceItems: vi.fn().mockRejectedValue("Marketplace unavailable"),
+			getInstallationMetadata: vi.fn().mockResolvedValue({ project: {}, global: {} }),
+		}
+
+		mockPostMessage.mockClear()
+
+		await provider.fetchMarketplaceData()
+
+		expect(mockPostMessage).toHaveBeenCalledWith({
+			type: "marketplaceData",
+			marketplaceItems: [],
+			marketplaceInstalledMetadata: { project: {}, global: {} },
+			errors: ["Marketplace unavailable"],
+		})
+	})
+
 	test("clearTask aborts current task", async () => {
 		// Setup Cline instance with auto-mock from the top of the file
 		const mockCline = new Task(defaultTaskOptions) // Create a new mocked instance

--- a/src/services/marketplace/MarketplaceManager.ts
+++ b/src/services/marketplace/MarketplaceManager.ts
@@ -4,7 +4,7 @@ import * as path from "path"
 import * as vscode from "vscode"
 import * as yaml from "yaml"
 
-import type { OrganizationSettings, MarketplaceItem, MarketplaceItemType, McpMarketplaceItem } from "@roo-code/types"
+import type { OrganizationSettings, MarketplaceItem, MarketplaceItemType } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
 import { CloudService } from "@roo-code/cloud"
 
@@ -17,7 +17,6 @@ import { RemoteConfigLoader } from "./RemoteConfigLoader"
 import { SimpleInstaller } from "./SimpleInstaller"
 
 export interface MarketplaceItemsResponse {
-	organizationMcps: MarketplaceItem[]
 	marketplaceItems: MarketplaceItem[]
 	errors?: string[]
 }
@@ -51,19 +50,9 @@ export class MarketplaceManager {
 			}
 
 			const allMarketplaceItems = await this.configLoader.loadAllItems(orgSettings?.hideMarketplaceMcps)
-			let organizationMcps: MarketplaceItem[] = []
 			let marketplaceItems = allMarketplaceItems
 
 			if (orgSettings) {
-				if (orgSettings.mcps && orgSettings.mcps.length > 0) {
-					organizationMcps = orgSettings.mcps.map(
-						(mcp: McpMarketplaceItem): MarketplaceItem => ({
-							...mcp,
-							type: "mcp" as const,
-						}),
-					)
-				}
-
 				if (orgSettings.hiddenMcps && orgSettings.hiddenMcps.length > 0) {
 					const hiddenMcpIds = new Set(orgSettings.hiddenMcps)
 					marketplaceItems = allMarketplaceItems.filter(
@@ -73,7 +62,6 @@ export class MarketplaceManager {
 			}
 
 			return {
-				organizationMcps,
 				marketplaceItems,
 				errors: errors.length > 0 ? errors : undefined,
 			}
@@ -82,7 +70,6 @@ export class MarketplaceManager {
 			console.error("Failed to load marketplace items:", error)
 
 			return {
-				organizationMcps: [],
 				marketplaceItems: [],
 				errors: [errorMessage],
 			}
@@ -91,7 +78,7 @@ export class MarketplaceManager {
 
 	async getCurrentItems(): Promise<MarketplaceItem[]> {
 		const result = await this.getMarketplaceItems()
-		return [...result.organizationMcps, ...result.marketplaceItems]
+		return result.marketplaceItems
 	}
 
 	filterItems(

--- a/src/services/marketplace/__tests__/MarketplaceManager.spec.ts
+++ b/src/services/marketplace/__tests__/MarketplaceManager.spec.ts
@@ -174,7 +174,6 @@ describe("MarketplaceManager", () => {
 
 			expect(result.marketplaceItems).toHaveLength(1)
 			expect(result.marketplaceItems[0].name).toBe("Test Mode")
-			expect(result.organizationMcps).toHaveLength(0)
 		})
 
 		it("should handle API errors gracefully", async () => {
@@ -184,11 +183,10 @@ describe("MarketplaceManager", () => {
 			const result = await manager.getMarketplaceItems()
 
 			expect(result.marketplaceItems).toHaveLength(0)
-			expect(result.organizationMcps).toHaveLength(0)
 			expect(result.errors).toEqual(["API request failed"])
 		})
 
-		it("should return organization MCPs when available", async () => {
+		it("should ignore organization MCPs when building marketplace results", async () => {
 			const { CloudService } = await import("@roo-code/cloud")
 
 			// Mock CloudService to return organization settings
@@ -226,8 +224,6 @@ describe("MarketplaceManager", () => {
 
 			const result = await manager.getMarketplaceItems()
 
-			expect(result.organizationMcps).toHaveLength(1)
-			expect(result.organizationMcps[0].name).toBe("Organization MCP")
 			expect(result.marketplaceItems).toHaveLength(1)
 			expect(result.marketplaceItems[0].name).toBe("Test MCP")
 		})
@@ -272,7 +268,6 @@ describe("MarketplaceManager", () => {
 
 			expect(result.marketplaceItems).toHaveLength(1)
 			expect(result.marketplaceItems[0].name).toBe("Visible MCP")
-			expect(result.organizationMcps).toHaveLength(0)
 		})
 
 		it("should handle CloudService not being available", async () => {
@@ -297,9 +292,47 @@ describe("MarketplaceManager", () => {
 
 			const result = await manager.getMarketplaceItems()
 
-			expect(result.organizationMcps).toHaveLength(0)
 			expect(result.marketplaceItems).toHaveLength(1)
 			expect(result.marketplaceItems[0].name).toBe("Test MCP")
+		})
+	})
+
+	describe("getCurrentItems", () => {
+		it("should exclude organization MCPs from current items", async () => {
+			const { CloudService } = await import("@roo-code/cloud")
+
+			vi.mocked(CloudService.hasInstance).mockReturnValue(true)
+			vi.mocked(CloudService.instance.isAuthenticated).mockReturnValue(true)
+			vi.mocked(CloudService.instance.getOrganizationSettings).mockReturnValue({
+				version: 1,
+				mcps: [
+					{
+						id: "org-mcp-1",
+						name: "Organization MCP",
+						description: "An organization MCP",
+						url: "https://example.com/org-mcp",
+						content: '{"command": "node", "args": ["org-server.js"]}',
+					},
+				],
+				hiddenMcps: [],
+				allowList: { allowAll: true, providers: {} },
+				defaultSettings: {},
+			})
+
+			const mockItems: MarketplaceItem[] = [
+				{
+					id: "test-mcp",
+					name: "Test MCP",
+					description: "A test MCP",
+					type: "mcp",
+					url: "https://example.com/test-mcp",
+					content: '{"command": "node", "args": ["server.js"]}',
+				},
+			]
+
+			vi.spyOn(manager["configLoader"], "loadAllItems").mockResolvedValue(mockItems)
+
+			await expect(manager.getCurrentItems()).resolves.toEqual(mockItems)
 		})
 	})
 

--- a/webview-ui/src/components/marketplace/MarketplaceListView.tsx
+++ b/webview-ui/src/components/marketplace/MarketplaceListView.tsx
@@ -22,20 +22,18 @@ export interface MarketplaceListViewProps {
 export function MarketplaceListView({ stateManager, allTags, filteredTags, filterByType }: MarketplaceListViewProps) {
 	const [state, manager] = useStateManager(stateManager)
 	const { t } = useAppTranslation()
-	const { marketplaceInstalledMetadata, cloudUserInfo } = useExtensionState()
+	const { marketplaceInstalledMetadata } = useExtensionState()
 	const [isTagPopoverOpen, setIsTagPopoverOpen] = React.useState(false)
 	const [tagSearch, setTagSearch] = React.useState("")
 	const allItems = state.displayItems || []
-	const organizationMcps = state.displayOrganizationMcps || []
 
 	// NOTE: installed metadata is already synchronized into the state manager via handleMessage("state"/"marketplaceData")
 	// in MarketplaceViewStateManager; avoid dispatching UPDATE_FILTERS here to prevent render loops.
 
 	// Filter items by type if specified
 	const items = filterByType ? allItems.filter((item) => item.type === filterByType) : allItems
-	const orgMcps = filterByType === "mcp" ? organizationMcps : []
 
-	const isEmpty = items.length === 0 && orgMcps.length === 0
+	const isEmpty = items.length === 0
 
 	return (
 		<>
@@ -220,50 +218,8 @@ export function MarketplaceListView({ stateManager, allTags, filteredTags, filte
 
 			{!state.isFetching && !isEmpty && (
 				<div className="pb-3">
-					{orgMcps.length > 0 && (
-						<div className="mb-6">
-							<div className="flex items-center gap-2 mb-3 px-1">
-								<span className="codicon codicon-organization text-lg"></span>
-								<h3 className="text-sm font-semibold text-vscode-foreground">
-									{t("marketplace:sections.organizationMcps", {
-										organization: cloudUserInfo?.organizationName,
-									})}
-								</h3>
-								<div className="flex-1 h-px bg-vscode-input-border"></div>
-							</div>
-							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
-								{orgMcps.map((item) => (
-									<MarketplaceItemCard
-										key={`org-${item.id}`}
-										item={item}
-										filters={state.filters}
-										setFilters={(filters) =>
-											manager.transition({
-												type: "UPDATE_FILTERS",
-												payload: { filters },
-											})
-										}
-										installed={{
-											project: marketplaceInstalledMetadata?.project?.[item.id],
-											global: marketplaceInstalledMetadata?.global?.[item.id],
-										}}
-									/>
-								))}
-							</div>
-						</div>
-					)}
-
 					{items.length > 0 && (
 						<div>
-							{orgMcps.length > 0 && (
-								<div className="flex items-center gap-2 mb-3 px-1">
-									<span className="codicon codicon-globe text-lg"></span>
-									<h3 className="text-sm font-semibold text-vscode-foreground">
-										{t("marketplace:sections.marketplace")}
-									</h3>
-									<div className="flex-1 h-px bg-vscode-input-border"></div>
-								</div>
-							)}
 							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
 								{items.map((item) => (
 									<MarketplaceItemCard

--- a/webview-ui/src/components/marketplace/MarketplaceViewStateManager.ts
+++ b/webview-ui/src/components/marketplace/MarketplaceViewStateManager.ts
@@ -18,9 +18,7 @@ import { WebviewMessage } from "../../../../src/shared/WebviewMessage"
 
 export interface ViewState {
 	allItems: MarketplaceItem[]
-	organizationMcps: MarketplaceItem[]
 	displayItems?: MarketplaceItem[] // Items currently being displayed (filtered or all)
-	displayOrganizationMcps?: MarketplaceItem[] // Organization MCPs currently being displayed (filtered or all)
 	isFetching: boolean
 	activeTab: "mcp" | "mode"
 	filters: {
@@ -59,9 +57,7 @@ export class MarketplaceViewStateManager {
 	private getDefaultState(): ViewState {
 		return {
 			allItems: [],
-			organizationMcps: [],
 			displayItems: [], // Always initialize as empty array, not undefined
-			displayOrganizationMcps: [], // Always initialize as empty array, not undefined
 			isFetching: true, // Start with loading state for initial load
 			activeTab: "mcp",
 			filters: {
@@ -104,22 +100,16 @@ export class MarketplaceViewStateManager {
 	public getState(): ViewState {
 		// Only create new arrays if they exist and have items
 		const allItems = this.state.allItems.length ? [...this.state.allItems] : []
-		const organizationMcps = this.state.organizationMcps.length ? [...this.state.organizationMcps] : []
 		// Ensure displayItems is always an array, never undefined
 		// If displayItems is undefined or null, fall back to allItems
 		const displayItems = this.state.displayItems ? [...this.state.displayItems] : [...allItems]
-		const displayOrganizationMcps = this.state.displayOrganizationMcps
-			? [...this.state.displayOrganizationMcps]
-			: [...organizationMcps]
 		const tags = this.state.filters.tags.length ? [...this.state.filters.tags] : []
 
 		// Create minimal new state object
 		return {
 			...this.state,
 			allItems,
-			organizationMcps,
 			displayItems,
-			displayOrganizationMcps,
 			filters: {
 				...this.state.filters,
 				tags,
@@ -190,26 +180,15 @@ export class MarketplaceViewStateManager {
 				}
 
 				// Calculate display items based on current filters
-				let newDisplayItems: MarketplaceItem[]
-				let newDisplayOrganizationMcps: MarketplaceItem[]
-				if (this.isFilterActive()) {
-					newDisplayItems = this.filterItems([...items], this.state.installedMetadata)
-					newDisplayOrganizationMcps = this.filterItems(
-						[...this.state.organizationMcps],
-						this.state.installedMetadata,
-					)
-				} else {
-					// No filters active - show all items
-					newDisplayItems = [...items]
-					newDisplayOrganizationMcps = [...this.state.organizationMcps]
-				}
+				const newDisplayItems = this.isFilterActive()
+					? this.filterItems([...items], this.state.installedMetadata)
+					: [...items]
 
 				// Update allItems as source of truth
 				this.state = {
 					...this.state,
 					allItems: [...items],
 					displayItems: newDisplayItems,
-					displayOrganizationMcps: newDisplayOrganizationMcps,
 					isFetching: false,
 				}
 
@@ -267,18 +246,13 @@ export class MarketplaceViewStateManager {
 					filters: updatedFilters,
 				}
 
-				// Apply filters to displayItems and displayOrganizationMcps with the updated filters
+				// Apply filters to displayItems with the updated filters
 				const newDisplayItems = this.filterItems(this.state.allItems, this.state.installedMetadata)
-				const newDisplayOrganizationMcps = this.filterItems(
-					this.state.organizationMcps,
-					this.state.installedMetadata,
-				)
 
 				// Update state with filtered items
 				this.state = {
 					...this.state,
 					displayItems: newDisplayItems,
-					displayOrganizationMcps: newDisplayOrganizationMcps,
 				}
 
 				// Send filter message
@@ -384,19 +358,9 @@ export class MarketplaceViewStateManager {
 				// Calculate display items based on current filters
 				// If no filters are active, show all items
 				// If filters are active, apply filtering
-				let newDisplayItems: MarketplaceItem[]
-				let newDisplayOrganizationMcps: MarketplaceItem[]
-				if (this.isFilterActive()) {
-					newDisplayItems = this.filterItems(items, this.state.installedMetadata)
-					newDisplayOrganizationMcps = this.filterItems(
-						this.state.organizationMcps,
-						this.state.installedMetadata,
-					)
-				} else {
-					// No filters active - show all items
-					newDisplayItems = items
-					newDisplayOrganizationMcps = this.state.organizationMcps
-				}
+				const newDisplayItems = this.isFilterActive()
+					? this.filterItems(items, this.state.installedMetadata)
+					: items
 
 				// Update state in a single operation
 				this.state = {
@@ -404,7 +368,6 @@ export class MarketplaceViewStateManager {
 					isFetching: false,
 					allItems: items,
 					displayItems: newDisplayItems,
-					displayOrganizationMcps: newDisplayOrganizationMcps,
 					installedMetadata: marketplaceInstalledMetadata || this.state.installedMetadata,
 				}
 				// Notification is handled below after all state parts are processed
@@ -446,14 +409,12 @@ export class MarketplaceViewStateManager {
 		// Handle marketplace data updates (fetched on demand)
 		if (message.type === "marketplaceData") {
 			const marketplaceItems = message.marketplaceItems
-			const organizationMcps = message.organizationMcps || []
 			const marketplaceInstalledMetadata = message.marketplaceInstalledMetadata
 
 			if (marketplaceItems !== undefined) {
 				// Always use the marketplace items from the extension when they're provided
 				// This ensures fresh data is always displayed
 				const items = [...marketplaceItems]
-				const orgMcps = [...organizationMcps]
 
 				// Update installed metadata if provided
 				if (marketplaceInstalledMetadata !== undefined) {
@@ -463,18 +424,13 @@ export class MarketplaceViewStateManager {
 				const newDisplayItems = this.isFilterActive()
 					? this.filterItems(items, this.state.installedMetadata)
 					: items
-				const newDisplayOrganizationMcps = this.isFilterActive()
-					? this.filterItems(orgMcps, this.state.installedMetadata)
-					: orgMcps
 
 				// Update state in a single operation
 				this.state = {
 					...this.state,
 					isFetching: false,
 					allItems: items,
-					organizationMcps: orgMcps,
 					displayItems: newDisplayItems,
-					displayOrganizationMcps: newDisplayOrganizationMcps,
 					installedMetadata: marketplaceInstalledMetadata || this.state.installedMetadata,
 				}
 			}

--- a/webview-ui/src/components/marketplace/__tests__/MarketplaceListView.spec.tsx
+++ b/webview-ui/src/components/marketplace/__tests__/MarketplaceListView.spec.tsx
@@ -18,9 +18,7 @@ vi.mock("@/i18n/TranslationContext", () => ({
 const mockTransition = vi.fn()
 const mockState: ViewState = {
 	allItems: [],
-	organizationMcps: [],
 	displayItems: [],
-	displayOrganizationMcps: [],
 	isFetching: false,
 	activeTab: "mcp",
 	filters: {
@@ -99,6 +97,25 @@ describe("MarketplaceListView", () => {
 
 		expect(screen.getByText("marketplace:items.empty.noItems")).toBeInTheDocument()
 		expect(screen.getByText("marketplace:items.empty.adjustFilters")).toBeInTheDocument()
+	})
+
+	it("renders marketplace items without organization section headings", () => {
+		mockState.displayItems = [
+			{
+				id: "test-mcp",
+				name: "Test MCP",
+				description: "Test description",
+				type: "mcp",
+				url: "https://example.com/test-mcp",
+				content: "test content",
+			},
+		]
+
+		renderWithProviders({ filterByType: "mcp" })
+
+		expect(screen.getByText("Test MCP")).toBeInTheDocument()
+		expect(screen.queryByText("marketplace:sections.organizationMcps")).not.toBeInTheDocument()
+		expect(screen.queryByText("marketplace:sections.marketplace")).not.toBeInTheDocument()
 	})
 
 	it("updates search filter when typing", () => {

--- a/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
+++ b/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
@@ -171,6 +171,18 @@ describe("MarketplaceViewStateManager", () => {
 			const finalState = stateManager.getState()
 			expect(finalState.displayItems).toEqual(mockMarketplaceItems)
 		})
+
+		it("should handle marketplaceData messages without organization MCPs", async () => {
+			await stateManager.handleMessage({
+				type: "marketplaceData",
+				marketplaceItems: mockMarketplaceItems,
+				marketplaceInstalledMetadata: { project: {}, global: {} },
+			})
+
+			const notifiedState = mockStateChangeHandler.mock.calls[0][0]
+			expect(notifiedState.allItems).toEqual(mockMarketplaceItems)
+			expect(notifiedState.displayItems).toEqual(mockMarketplaceItems)
+		})
 	})
 
 	describe("filtering behavior", () => {

--- a/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
+++ b/webview-ui/src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts
@@ -179,7 +179,8 @@ describe("MarketplaceViewStateManager", () => {
 				marketplaceInstalledMetadata: { project: {}, global: {} },
 			})
 
-			const notifiedState = mockStateChangeHandler.mock.calls[0][0]
+			expect(mockStateChangeHandler).toHaveBeenCalled()
+			const notifiedState = mockStateChangeHandler.mock.calls[mockStateChangeHandler.mock.calls.length - 1][0]
 			expect(notifiedState.allItems).toEqual(mockMarketplaceItems)
 			expect(notifiedState.displayItems).toEqual(mockMarketplaceItems)
 		})

--- a/webview-ui/src/components/marketplace/useStateManager.ts
+++ b/webview-ui/src/components/marketplace/useStateManager.ts
@@ -13,10 +13,7 @@ export function useStateManager(existingManager?: MarketplaceViewStateManager) {
 					prevState.isFetching !== newState.isFetching ||
 					prevState.activeTab !== newState.activeTab ||
 					JSON.stringify(prevState.allItems) !== JSON.stringify(newState.allItems) ||
-					JSON.stringify(prevState.organizationMcps) !== JSON.stringify(newState.organizationMcps) ||
 					JSON.stringify(prevState.displayItems) !== JSON.stringify(newState.displayItems) ||
-					JSON.stringify(prevState.displayOrganizationMcps) !==
-						JSON.stringify(newState.displayOrganizationMcps) ||
 					JSON.stringify(prevState.filters) !== JSON.stringify(newState.filters)
 
 				return hasChanged ? newState : prevState

--- a/webview-ui/src/i18n/locales/ca/marketplace.json
+++ b/webview-ui/src/i18n/locales/ca/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Cap"
 	},
-	"sections": {
-		"organizationMcps": "MCPs de {{organization}}",
-		"marketplace": "Mercat"
-	},
 	"type-group": {
 		"modes": "Modes",
 		"mcps": "Servidors MCP"

--- a/webview-ui/src/i18n/locales/de/marketplace.json
+++ b/webview-ui/src/i18n/locales/de/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Keine"
 	},
-	"sections": {
-		"organizationMcps": "MCPs von {{organization}}",
-		"marketplace": "Marktplatz"
-	},
 	"type-group": {
 		"modes": "Modi",
 		"mcps": "MCP-Server"

--- a/webview-ui/src/i18n/locales/en/marketplace.json
+++ b/webview-ui/src/i18n/locales/en/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "None"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCPs",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "Modes",
 		"mcps": "MCP Servers"

--- a/webview-ui/src/i18n/locales/es/marketplace.json
+++ b/webview-ui/src/i18n/locales/es/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Ninguno"
 	},
-	"sections": {
-		"organizationMcps": "MCPs de {{organization}}",
-		"marketplace": "Mercado"
-	},
 	"type-group": {
 		"modes": "Modos",
 		"mcps": "Servidores MCP"

--- a/webview-ui/src/i18n/locales/fr/marketplace.json
+++ b/webview-ui/src/i18n/locales/fr/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Aucun"
 	},
-	"sections": {
-		"organizationMcps": "MCPs de {{organization}}",
-		"marketplace": "Marché"
-	},
 	"type-group": {
 		"modes": "Modes",
 		"mcps": "Serveurs MCP"

--- a/webview-ui/src/i18n/locales/hi/marketplace.json
+++ b/webview-ui/src/i18n/locales/hi/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "कोई नहीं"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCPs",
-		"marketplace": "मार्केटप्लेस"
-	},
 	"type-group": {
 		"modes": "मोड",
 		"mcps": "MCP सर्वर"

--- a/webview-ui/src/i18n/locales/id/marketplace.json
+++ b/webview-ui/src/i18n/locales/id/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Tidak Ada"
 	},
-	"sections": {
-		"organizationMcps": "MCP {{organization}}",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "Mode",
 		"mcps": "Server MCP"

--- a/webview-ui/src/i18n/locales/it/marketplace.json
+++ b/webview-ui/src/i18n/locales/it/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Nessuno"
 	},
-	"sections": {
-		"organizationMcps": "MCP di {{organization}}",
-		"marketplace": "Mercato"
-	},
 	"type-group": {
 		"modes": "Modalità",
 		"mcps": "Server MCP"

--- a/webview-ui/src/i18n/locales/ja/marketplace.json
+++ b/webview-ui/src/i18n/locales/ja/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "なし"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCPs",
-		"marketplace": "マーケットプレイス"
-	},
 	"type-group": {
 		"modes": "モード",
 		"mcps": "MCPサーバー"

--- a/webview-ui/src/i18n/locales/ko/marketplace.json
+++ b/webview-ui/src/i18n/locales/ko/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "없음"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCPs",
-		"marketplace": "마켓플레이스"
-	},
 	"type-group": {
 		"modes": "모드",
 		"mcps": "MCP 서버"

--- a/webview-ui/src/i18n/locales/nl/marketplace.json
+++ b/webview-ui/src/i18n/locales/nl/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Geen"
 	},
-	"sections": {
-		"organizationMcps": "MCP's van {{organization}}",
-		"marketplace": "Marktplaats"
-	},
 	"type-group": {
 		"modes": "Modi",
 		"mcps": "MCP-servers"

--- a/webview-ui/src/i18n/locales/pl/marketplace.json
+++ b/webview-ui/src/i18n/locales/pl/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Brak"
 	},
-	"sections": {
-		"organizationMcps": "MCPs {{organization}}",
-		"marketplace": "Rynek"
-	},
 	"type-group": {
 		"modes": "Tryby",
 		"mcps": "Serwery MCP"

--- a/webview-ui/src/i18n/locales/pt-BR/marketplace.json
+++ b/webview-ui/src/i18n/locales/pt-BR/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Nenhum"
 	},
-	"sections": {
-		"organizationMcps": "MCPs da {{organization}}",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "Modos",
 		"mcps": "Servidores MCP"

--- a/webview-ui/src/i18n/locales/ru/marketplace.json
+++ b/webview-ui/src/i18n/locales/ru/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Нет"
 	},
-	"sections": {
-		"organizationMcps": "MCPs {{organization}}",
-		"marketplace": "Маркетплейс"
-	},
 	"type-group": {
 		"modes": "Режимы",
 		"mcps": "MCP серверы"

--- a/webview-ui/src/i18n/locales/tr/marketplace.json
+++ b/webview-ui/src/i18n/locales/tr/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Hiçbiri"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCP'leri",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "Modlar",
 		"mcps": "MCP Sunucuları"

--- a/webview-ui/src/i18n/locales/vi/marketplace.json
+++ b/webview-ui/src/i18n/locales/vi/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "Không có"
 	},
-	"sections": {
-		"organizationMcps": "MCP của {{organization}}",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "Chế độ",
 		"mcps": "Máy chủ MCP"

--- a/webview-ui/src/i18n/locales/zh-CN/marketplace.json
+++ b/webview-ui/src/i18n/locales/zh-CN/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "无"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} MCPs",
-		"marketplace": "Marketplace"
-	},
 	"type-group": {
 		"modes": "模式",
 		"mcps": "MCP 服务"

--- a/webview-ui/src/i18n/locales/zh-TW/marketplace.json
+++ b/webview-ui/src/i18n/locales/zh-TW/marketplace.json
@@ -41,10 +41,6 @@
 		},
 		"none": "無"
 	},
-	"sections": {
-		"organizationMcps": "{{organization}} 的 MCP 伺服器",
-		"marketplace": "市集"
-	},
 	"type-group": {
 		"modes": "模式",
 		"mcps": "MCP 伺服器"


### PR DESCRIPTION
## Summary
- remove the stale `organizationMcps` field from the marketplace extension/webview contract
- simplify marketplace state and list rendering to use only `marketplaceItems`
- update marketplace tests to cover the contract cleanup and UI behavior

## Validation
- `cd src && npx vitest run services/marketplace/__tests__/MarketplaceManager.spec.ts -t "exclude organization MCPs from current items" && npx vitest run core/webview/__tests__/ClineProvider.spec.ts -t "fetchMarketplaceData posts marketplace items without organization MCPs"`
- `cd webview-ui && npx vitest run src/components/marketplace/__tests__/MarketplaceListView.spec.tsx src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts`
- `cd src && npx eslint services/marketplace/MarketplaceManager.ts services/marketplace/__tests__/MarketplaceManager.spec.ts core/webview/ClineProvider.ts core/webview/__tests__/ClineProvider.spec.ts ../packages/types/src/vscode-extension-host.ts && npm run check-types`
- `cd webview-ui && npx eslint src/components/marketplace/MarketplaceViewStateManager.ts src/components/marketplace/useStateManager.ts src/components/marketplace/MarketplaceListView.tsx src/components/marketplace/__tests__/MarketplaceListView.spec.tsx src/components/marketplace/__tests__/MarketplaceViewStateManager.spec.ts && npm run check-types`
- `git push -u origin cleanup/remove-organization-mcps`

## References
- Follow-up to PR #11
- Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed organization MCPs section from the marketplace view to streamline marketplace display across all supported languages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->