### PR TITLE
fix: upgrade isbinaryfile to 5.0.7

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,8 +905,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.4
       isbinaryfile:
-        specifier: ^5.0.2
-        version: 5.0.4
+        specifier: ^5.0.7
+        version: 5.0.7
       json-stream-stringify:
         specifier: ^3.1.6
         version: 3.1.6
@@ -7659,8 +7659,8 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  isbinaryfile@5.0.4:
-    resolution: {integrity: sha512-YKBKVkKhty7s8rxddb40oOkuP0NbaeXrQvLin6QMHL7Ypiy2RW9LwOVrVgZRyOrhQlayMd9t+D8yDy8MKFTSDQ==}
+  isbinaryfile@5.0.7:
+    resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
     engines: {node: '>= 18.0.0'}
 
   isexe@2.0.0:
@@ -18312,7 +18312,7 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  isbinaryfile@5.0.4: {}
+  isbinaryfile@5.0.7: {}
 
   isexe@2.0.0: {}
 

--- a/src/package.json
+++ b/src/package.json
@@ -481,7 +481,7 @@
 		"gray-matter": "^4.0.3",
 		"i18next": "^25.0.0",
 		"ignore": "^7.0.3",
-		"isbinaryfile": "^5.0.2",
+		"isbinaryfile": "^5.0.7",
 		"json-stream-stringify": "^3.1.6",
 		"jwt-decode": "^4.0.0",
 		"lodash.debounce": "^4.0.8",


### PR DESCRIPTION
### Related GitHub Issue

This PR addresses the same root cause as the following Roo Code issues (inherited bug, still present in Zoo Code):
- RooCodeInc/Roo-Code#8109 — Markdown with non-ASCII characters can't be read; extension becomes unresponsive
- RooCodeInc/Roo-Code#6242 — Extension freezes with `RangeError: Invalid array length`

### Roo Code Task Context (Optional)

N/A

### Description

This PR upgrades the `isbinaryfile` dependency from `^5.0.2` (resolving to buggy `5.0.4`) to `^5.0.7` to fix a crash when processing files containing multibyte UTF-8 characters (Chinese, Japanese, Korean, emoji, etc.).

**Problem**

When Zoo Code processes a file whose UTF-8 multibyte sequence falls across the 512-byte buffer boundary used for binary detection, the extension crashes with:

```
RangeError: Invalid array length
    at isbinaryfile@5.0.4/lib/index.js:36:16
    at readProtoMessage (isbinaryfile@5.0.4/lib/index.js:68:20)
    at isBinaryProto (isbinaryfile@5.0.4/lib/index.js:82:14)
    at isBinaryCheck (isbinaryfile@5.0.4/lib/index.js:228:32)
```

**Version history of `isbinaryfile`**
- `5.0.4` — Crashes on certain UTF-8 files ❌
- `5.0.7` — Comprehensive fix for both issues ✅

**Changes**

```diff
# src/package.json
- "isbinaryfile": "^5.0.2",
+ "isbinaryfile": "^5.0.7"
```

`pnpm-lock.yaml` is updated accordingly (`5.0.4` → `5.0.7`).

### Test Procedure

1. Download the test fixture: [utf8-boundary-truncation_case.py](https://github.com/gjtorikian/isBinaryFile/blob/main/test/fixtures/utf8-boundary-truncation_case.py) (contains Chinese comments positioned exactly at the 510–512 byte boundary).
2. Open it in a workspace and ask Zoo Code to read/analyze the file.
3. **Before this PR**: extension crashes with `RangeError: Invalid array length` (see screenshot below).
4. **After this PR**: file is correctly identified as a Python text file and processed normally.

The fixture is also part of the upstream test suite to prevent regression.

### Pre-Submission Checklist

- [x] **Issue Linked**: References original Roo Code issues #8109 and #6242
- [x] **Scope**: Focused dependency bump only
- [x] **Self-Review**: Reviewed (two-line dependency update + lockfile)
- [x] **Testing**: Reproduced the crash on `5.0.4` and verified the fix on `5.0.7`
- [x] **Documentation Impact**: None required
- [x] **Contribution Guidelines**: Read and agreed

### Screenshots / Videos

**Crash reproduced on Zoo Code (with `isbinaryfile@5.0.4`):**

<img width="4052" height="1662" alt="zoo_crash" src="https://github.com/user-attachments/assets/5dd58ebc-58f8-4fe2-b1e0-1611cb9cef2d" />

*Error*: `RangeError: Invalid array length` when reading a UTF-8 file with Chinese characters at the buffer boundary. The extension becomes unresponsive.

After applying this PR (`isbinaryfile@5.0.7`), the same file is processed without error. Verification can be reproduced via the test procedure above.

### Documentation Updates

- [x] No documentation updates are required.

### Get in Touch

**GitHub**: @f14XuanLv
**Discord**: f14xuanlv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to improve stability and compatibility. This brings in upstream fixes and reduces potential runtime issues without changing any user-facing APIs or workflows. No additional configuration is required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/88)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->