### PR TITLE
[ENHANCEMENT] Add compact slash commands

### DIFF
--- a/src/services/command/__tests__/built-in-commands.spec.ts
+++ b/src/services/command/__tests__/built-in-commands.spec.ts
@@ -5,8 +5,8 @@ describe("Built-in Commands", () => {
 		it("should return all built-in commands", async () => {
 			const commands = await getBuiltInCommands()
 
-			expect(commands).toHaveLength(1)
-			expect(commands.map((cmd) => cmd.name)).toEqual(expect.arrayContaining(["init"]))
+			expect(commands).toHaveLength(3)
+			expect(commands.map((cmd) => cmd.name)).toEqual(expect.arrayContaining(["init", "compact", "compact-and"]))
 
 			// Verify all commands have required properties
 			commands.forEach((command) => {
@@ -63,10 +63,10 @@ describe("Built-in Commands", () => {
 		it("should return all built-in command names", async () => {
 			const names = await getBuiltInCommandNames()
 
-			expect(names).toHaveLength(1)
-			expect(names).toEqual(expect.arrayContaining(["init"]))
+			expect(names).toHaveLength(3)
+			expect(names).toEqual(expect.arrayContaining(["init", "compact", "compact-and"]))
 			// Order doesn't matter since it's based on filesystem order
-			expect(names.sort()).toEqual(["init"])
+			expect(names.sort()).toEqual(["compact", "compact-and", "init"])
 		})
 
 		it("should return array of strings", async () => {

--- a/src/services/command/built-in-commands.ts
+++ b/src/services/command/built-in-commands.ts
@@ -8,6 +8,17 @@ interface BuiltInCommandDefinition {
 }
 
 const BUILT_IN_COMMANDS: Record<string, BuiltInCommandDefinition> = {
+	compact: {
+		name: "compact",
+		description: "Manually condense the current task context to free up tokens",
+		content: "",
+	},
+	"compact-and": {
+		name: "compact-and",
+		description: "Condense context, then send the following message",
+		argumentHint: "<message to send after condensing>",
+		content: "",
+	},
 	init: {
 		name: "init",
 		description: "Analyze codebase and create concise AGENTS.md files for AI assistants",

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -217,6 +217,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const [playProgressLoop] = useSound(`${audioBaseUri}/progress_loop.wav`, { volume, soundEnabled, interrupt: true })
 
 	const lastPlayedRef = useRef<Record<string, number>>({})
+	const pendingPostCompactRef = useRef<{ text: string; images: string[] } | null>(null)
 
 	const playSound = useCallback(
 		(audioType: AudioType) => {
@@ -575,6 +576,18 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		// setSecondaryButtonText(undefined)
 	}, [])
 
+	const handleCondenseContext = useCallback(
+		(taskId: string) => {
+			if (isCondensing || sendingDisabled) {
+				return
+			}
+			setIsCondensing(true)
+			setSendingDisabled(true)
+			vscode.postMessage({ type: "condenseTaskContextRequest", text: taskId })
+		},
+		[isCondensing, sendingDisabled],
+	)
+
 	/**
 	 * Handles sending messages to the extension
 	 * @param text - The message text to send
@@ -585,6 +598,32 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			text = text.trim()
 
 			if (text || images.length > 0) {
+				// Intercept /compact and /compact-and before any other processing.
+				// /compact triggers the same context-condensing used by auto-condense.
+				// /compact-and <msg> condenses, then sends <msg> once condensing completes.
+				const compactMatch = /^\/compact(-and)?(?:\s+([\s\S]+))?$/.exec(text)
+				if (compactMatch) {
+					const taskId = currentTaskItem?.id
+					if (!taskId || messagesRef.current.length === 0 || isCondensing || sendingDisabled) {
+						// Nothing to condense, or a condense is already in flight.
+						setInputValue("")
+						setSelectedImages([])
+						return
+					}
+
+					const followUp = (compactMatch[2] ?? "").trim()
+					if (compactMatch[1] && followUp) {
+						pendingPostCompactRef.current = { text: followUp, images }
+					}
+
+					setIsCondensing(true)
+					setSendingDisabled(true)
+					vscode.postMessage({ type: "condenseTaskContextRequest", text: taskId })
+					setInputValue("")
+					setSelectedImages([])
+					return
+				}
+
 				// Intercept when the active provider is retired — show a
 				// WarningRow instead of sending anything to the backend.
 				if (apiConfiguration?.apiProvider && isRetiredProvider(apiConfiguration.apiProvider)) {
@@ -663,8 +702,26 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			isStreaming,
 			messageQueue.length,
 			apiConfiguration?.apiProvider,
+			currentTaskItem?.id,
+			isCondensing,
 		], // messagesRef and clineAskRef are stable
 	)
+
+	// After /compact-and completes, dispatch the follow-up message stashed
+	// when the user submitted the command.
+	useEffect(() => {
+		if (isCondensing || sendingDisabled) {
+			return
+		}
+
+		const pending = pendingPostCompactRef.current
+		if (!pending) {
+			return
+		}
+
+		pendingPostCompactRef.current = null
+		handleSendMessage(pending.text, pending.images)
+	}, [isCondensing, sendingDisabled, handleSendMessage])
 
 	const handleSetChatBoxMessage = useCallback(
 		(text: string, images: string[]) => {
@@ -1538,15 +1595,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			}
 		},
 	}))
-
-	const handleCondenseContext = (taskId: string) => {
-		if (isCondensing || sendingDisabled) {
-			return
-		}
-		setIsCondensing(true)
-		setSendingDisabled(true)
-		vscode.postMessage({ type: "condenseTaskContextRequest", text: taskId })
-	}
 
 	const areButtonsVisible = showScrollToBottom || primaryButtonText || secondaryButtonText
 


### PR DESCRIPTION
### Related GitHub Issue

Closes: #127

### Description

This PR adds `/compact` and `/compact-and` slash commands so users can manually trigger context condensation for the current task.

Key changes:

- Registers `compact` and `compact-and` as built-in slash commands so they appear in the command picker with descriptions.
- Intercepts `/compact` in the chat send path and dispatches the existing `condenseTaskContextRequest` for the current task.
- Implements `/compact-and <message>` by condensing first, then sending the provided follow-up message after condensation finishes.
- Guards against duplicate or invalid condense requests when there is no current task, no messages, sending is disabled, or a condense is already in flight.
- Updates command tests to cover the new built-in commands.

Reviewer focus:

- Whether the command names and descriptions fit Zoo Code's command style.
- Whether `/compact-and` waits for condensation to finish before sending the follow-up.
- Whether existing automatic condense behavior and ordinary slash commands remain unchanged.

This PR was prepared with agentic AI assistance, then reviewed by a human. The underlying feature has been tested in production business use for several weeks in the contributor's fork.

This is opened as a draft until the linked issue is approved/assigned per Zoo Code's contribution process.

### Test Procedure

From the Zoo Code worktree:

```bash
pnpm lint
pnpm check-types
pnpm --filter zoo-code test -- services/command/__tests__/built-in-commands.spec.ts
pnpm --filter @roo-code/vscode-webview test -- src/components/chat/__tests__/ChatView.spec.tsx
```

Manual verification recommended:

- Open the slash command picker in chat.
- Confirm `/compact` and `/compact-and` appear with clear descriptions.
- Run `/compact` in an active task and confirm it triggers context condensation.
- Run `/compact-and continue with the next step` and confirm Zoo Code condenses first, then sends the follow-up message.
- Confirm existing slash commands still work.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

TODO: Attach a screenshot of the slash command picker showing `/compact` and `/compact-and`.

### Documentation Updates

- [ ] Yes, documentation updates are required if Zoo docs list slash commands.

### Additional Notes

No duplicate issue found in Zoo's tracker.

### Get in Touch

Discord: `coorbin`
