### PR TITLE
[ENHANCEMENT] Persist local chat prompt and draft history across webview sessions

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -44,6 +44,7 @@ import { QueuedMessages } from "./QueuedMessages"
 import { WorktreeSelector } from "./WorktreeSelector"
 import FileChangesPanel from "./FileChangesPanel"
 import { useScrollLifecycle } from "@src/hooks/useScrollLifecycle"
+import { recordPromptHistorySend } from "./utils/promptHistory"
 
 export interface ChatViewProps {
 	isHidden: boolean
@@ -86,6 +87,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		soundVolume,
 		messageQueue = [],
 		showWorktreesInHomeScreen,
+		cwd,
 	} = useExtensionState()
 
 	// Show a WarningRow when the user sends a message with a retired provider.
@@ -591,6 +593,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					setShowRetiredProviderWarning(true)
 					return
 				}
+				recordPromptHistorySend(text, cwd)
 
 				// Queue message if:
 				// - Task is busy (sendingDisabled)
@@ -663,6 +666,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			isStreaming,
 			messageQueue.length,
 			apiConfiguration?.apiProvider,
+			cwd,
 		], // messagesRef and clineAskRef are stable
 	)
 
@@ -696,6 +700,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const handleEnqueueCurrentMessage = useCallback(() => {
 		const text = inputValue.trim()
 		if (text || selectedImages.length > 0) {
+			if (text) {
+				recordPromptHistorySend(text, cwd)
+			}
 			vscode.postMessage({
 				type: "queueMessage",
 				text,
@@ -704,7 +711,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			setInputValue("")
 			setSelectedImages([])
 		}
-	}, [inputValue, selectedImages])
+	}, [inputValue, selectedImages, cwd])
 
 	// This logic depends on the useEffect[messages] above to set clineAsk,
 	// after which buttons are shown and we then send an askResponse to the
@@ -724,6 +731,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				case "mistake_limit_reached":
 					// Only send text/images if they exist
 					if (trimmedInput || (images && images.length > 0)) {
+						if (trimmedInput) {
+							recordPromptHistorySend(trimmedInput, cwd)
+						}
 						vscode.postMessage({
 							type: "askResponse",
 							askResponse: "yesButtonClicked",
@@ -750,6 +760,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					} else {
 						// Only send text/images if they exist
 						if (trimmedInput || (images && images.length > 0)) {
+							if (trimmedInput) {
+								recordPromptHistorySend(trimmedInput, cwd)
+							}
 							vscode.postMessage({
 								type: "askResponse",
 								askResponse: "yesButtonClicked",
@@ -780,7 +793,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			setPrimaryButtonText(undefined)
 			setSecondaryButtonText(undefined)
 		},
-		[clineAsk, startNewTask, currentTaskItem?.parentTaskId],
+		[clineAsk, startNewTask, currentTaskItem?.parentTaskId, cwd],
 	)
 
 	const handleSecondaryButtonClick = useCallback(
@@ -807,6 +820,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				case "use_mcp_server":
 					// Only send text/images if they exist
 					if (trimmedInput || (images && images.length > 0)) {
+						if (trimmedInput) {
+							recordPromptHistorySend(trimmedInput, cwd)
+						}
 						vscode.postMessage({
 							type: "askResponse",
 							askResponse: "noButtonClicked",
@@ -829,7 +845,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			setClineAsk(undefined)
 			setEnableButtons(false)
 		},
-		[clineAsk, startNewTask, isStreaming, setDidClickCancel],
+		[clineAsk, startNewTask, isStreaming, setDidClickCancel, cwd],
 	)
 
 	const { info: model } = useSelectedModel(apiConfiguration)
@@ -1520,12 +1536,16 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	useImperativeHandle(ref, () => ({
 		acceptInput: () => {
-			const hasInput = inputValue.trim() || selectedImages.length > 0
+			const trimmedInput = inputValue.trim()
+			const hasInput = trimmedInput || selectedImages.length > 0
 
 			// Special case: during command_output, queue the message instead of
 			// triggering the primary button action (which would lose the message)
 			if (clineAskRef.current === "command_output" && hasInput) {
-				vscode.postMessage({ type: "queueMessage", text: inputValue.trim(), images: selectedImages })
+				if (trimmedInput) {
+					recordPromptHistorySend(trimmedInput, cwd)
+				}
+				vscode.postMessage({ type: "queueMessage", text: trimmedInput, images: selectedImages })
 				setInputValue("")
 				setSelectedImages([])
 				return

--- a/webview-ui/src/components/chat/hooks/usePromptHistory.ts
+++ b/webview-ui/src/components/chat/hooks/usePromptHistory.ts
@@ -1,5 +1,13 @@
 import { ClineMessage, HistoryItem } from "@roo-code/types"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import {
+	PROMPT_HISTORY_AUTOSAVE_INTERVAL_MS,
+	PROMPT_HISTORY_CHANGED_EVENT,
+	PROMPT_HISTORY_STORAGE_KEY,
+	autosavePromptHistoryDraft,
+	readPersistedPromptHistoryTexts,
+} from "../utils/promptHistory"
 
 interface UsePromptHistoryProps {
 	clineMessages: ClineMessage[] | undefined
@@ -38,6 +46,74 @@ export const usePromptHistory = ({
 	const [historyIndex, setHistoryIndex] = useState(-1)
 	const [tempInput, setTempInput] = useState("")
 	const [promptHistory, setPromptHistory] = useState<string[]>([])
+	const [persistedPromptHistory, setPersistedPromptHistory] = useState<string[]>(() =>
+		readPersistedPromptHistoryTexts(cwd),
+	)
+	const inputValueRef = useRef(inputValue)
+	const cwdRef = useRef(cwd)
+
+	useEffect(() => {
+		inputValueRef.current = inputValue
+	}, [inputValue])
+
+	useEffect(() => {
+		cwdRef.current = cwd
+	}, [cwd])
+
+	const refreshPersistedPromptHistory = useCallback(() => {
+		setPersistedPromptHistory(readPersistedPromptHistoryTexts(cwdRef.current))
+	}, [])
+
+	useEffect(() => {
+		refreshPersistedPromptHistory()
+	}, [cwd, refreshPersistedPromptHistory])
+
+	useEffect(() => {
+		const handlePromptHistoryChanged = () => refreshPersistedPromptHistory()
+		const handleStorage = (event: StorageEvent) => {
+			if (event.key === PROMPT_HISTORY_STORAGE_KEY) {
+				refreshPersistedPromptHistory()
+			}
+		}
+
+		window.addEventListener(PROMPT_HISTORY_CHANGED_EVENT, handlePromptHistoryChanged)
+		window.addEventListener("storage", handleStorage)
+
+		return () => {
+			window.removeEventListener(PROMPT_HISTORY_CHANGED_EVENT, handlePromptHistoryChanged)
+			window.removeEventListener("storage", handleStorage)
+		}
+	}, [refreshPersistedPromptHistory])
+
+	useEffect(() => {
+		const interval = setInterval(() => {
+			if (autosavePromptHistoryDraft(inputValueRef.current, cwdRef.current)) {
+				refreshPersistedPromptHistory()
+			}
+		}, PROMPT_HISTORY_AUTOSAVE_INTERVAL_MS)
+
+		return () => clearInterval(interval)
+	}, [refreshPersistedPromptHistory])
+
+	const mergePromptHistories = useCallback((...histories: Array<string[] | undefined>) => {
+		const seen = new Set<string>()
+		const merged: string[] = []
+
+		for (const history of histories) {
+			for (const prompt of history ?? []) {
+				const key = prompt.trim()
+
+				if (!key || seen.has(key)) {
+					continue
+				}
+
+				seen.add(key)
+				merged.push(prompt)
+			}
+		}
+
+		return merged.slice(0, MAX_PROMPT_HISTORY_SIZE)
+	}, [])
 
 	// Initialize prompt history with hybrid approach: conversation messages if in task, otherwise task history
 	const filteredPromptHistory = useMemo(() => {
@@ -47,27 +123,31 @@ export const usePromptHistory = ({
 			.map((message) => message.text!)
 
 		// If we have conversation messages, use those (newest first when navigating up)
-		if (conversationPrompts?.length) {
-			return conversationPrompts.slice(-MAX_PROMPT_HISTORY_SIZE).reverse()
+		if (conversationPrompts?.length || persistedPromptHistory.length) {
+			const activeConversationHistory = (conversationPrompts ?? []).slice(-MAX_PROMPT_HISTORY_SIZE).reverse()
+
+			return mergePromptHistories(persistedPromptHistory, activeConversationHistory)
 		}
 
 		// If we have clineMessages array (meaning we're in an active task), don't fall back to task history
 		// Only use task history when starting fresh (no active conversation)
 		if (clineMessages?.length) {
-			return []
+			return persistedPromptHistory
 		}
 
 		// Fall back to task history only when starting fresh (no active conversation)
 		if (!taskHistory?.length || !cwd) {
-			return []
+			return persistedPromptHistory
 		}
 
 		// Extract user prompts from task history for the current workspace only
-		return taskHistory
+		const taskHistoryPrompts = taskHistory
 			.filter((item) => item.task?.trim() && (!item.workspace || item.workspace === cwd))
 			.map((item) => item.task)
 			.slice(0, MAX_PROMPT_HISTORY_SIZE)
-	}, [clineMessages, taskHistory, cwd])
+
+		return mergePromptHistories(persistedPromptHistory, taskHistoryPrompts)
+	}, [clineMessages, persistedPromptHistory, taskHistory, cwd, mergePromptHistories])
 
 	// Update prompt history when filtered history changes and reset navigation
 	useEffect(() => {

--- a/webview-ui/src/components/chat/utils/__tests__/promptHistory.spec.ts
+++ b/webview-ui/src/components/chat/utils/__tests__/promptHistory.spec.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+	PROMPT_HISTORY_STORAGE_KEY,
+	autosavePromptHistoryDraft,
+	readPersistedPromptHistory,
+	readPersistedPromptHistoryTexts,
+	recordPromptHistorySend,
+	resetActivePromptHistoryDraft,
+} from "../promptHistory"
+
+const createMemoryStorage = (): Storage => {
+	const entries = new Map<string, string>()
+
+	return {
+		get length() {
+			return entries.size
+		},
+		clear: () => entries.clear(),
+		getItem: (key: string) => entries.get(key) ?? null,
+		key: (index: number) => Array.from(entries.keys())[index] ?? null,
+		removeItem: (key: string) => entries.delete(key),
+		setItem: (key: string, value: string) => entries.set(key, String(value)),
+	}
+}
+
+describe("promptHistory", () => {
+	beforeEach(() => {
+		Object.defineProperty(window, "localStorage", {
+			value: createMemoryStorage(),
+			configurable: true,
+		})
+		window.localStorage.clear()
+		resetActivePromptHistoryDraft()
+	})
+
+	it("autosaves one active draft and updates it in place", () => {
+		expect(autosavePromptHistoryDraft("first draft", "/repo-a")).toBe(true)
+		expect(autosavePromptHistoryDraft("updated draft", "/repo-a")).toBe(true)
+
+		const entries = readPersistedPromptHistory()
+		expect(entries).toHaveLength(1)
+		expect(entries[0]).toMatchObject({
+			text: "updated draft",
+			source: "draft",
+			workspace: "/repo-a",
+		})
+	})
+
+	it("records sent prompts and filters by workspace", () => {
+		recordPromptHistorySend("repo a prompt", "/repo-a")
+		recordPromptHistorySend("repo b prompt", "/repo-b")
+
+		expect(readPersistedPromptHistoryTexts("/repo-a")).toEqual(["repo a prompt"])
+		expect(readPersistedPromptHistoryTexts("/repo-b")).toEqual(["repo b prompt"])
+		expect(readPersistedPromptHistoryTexts()).toEqual(expect.arrayContaining(["repo a prompt", "repo b prompt"]))
+	})
+
+	it("ignores invalid persisted storage", () => {
+		window.localStorage.setItem(PROMPT_HISTORY_STORAGE_KEY, JSON.stringify({ bad: true }))
+
+		expect(readPersistedPromptHistory()).toEqual([])
+	})
+})

--- a/webview-ui/src/components/chat/utils/promptHistory.ts
+++ b/webview-ui/src/components/chat/utils/promptHistory.ts
@@ -1,0 +1,199 @@
+const MAX_PROMPT_HISTORY_SIZE = 100
+
+export const PROMPT_HISTORY_AUTOSAVE_INTERVAL_MS = 5_000
+export const PROMPT_HISTORY_CHANGED_EVENT = "zoo:prompt-history-changed"
+export const PROMPT_HISTORY_STORAGE_KEY = "zoo.chatPromptHistory.v1"
+
+export interface PersistedPromptHistoryEntry {
+	id: string
+	text: string
+	createdAt: number
+	updatedAt: number
+	source: "draft" | "sent"
+	workspace?: string
+}
+
+let activeDraftId: string | null = null
+
+const getStorage = (): Storage | undefined => {
+	try {
+		return typeof window !== "undefined" ? window.localStorage : undefined
+	} catch {
+		return undefined
+	}
+}
+
+const getNow = () => Date.now()
+
+const createId = () => {
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID()
+	}
+
+	return `${getNow()}-${Math.random().toString(36).slice(2)}`
+}
+
+const normalizeWorkspace = (workspace?: string) => {
+	const trimmed = workspace?.trim()
+	return trimmed ? trimmed : undefined
+}
+
+const normalizeEntry = (entry: unknown): PersistedPromptHistoryEntry | undefined => {
+	if (!entry || typeof entry !== "object") {
+		return undefined
+	}
+
+	const candidate = entry as Partial<PersistedPromptHistoryEntry>
+	const text = typeof candidate.text === "string" ? candidate.text : ""
+
+	if (!text.trim()) {
+		return undefined
+	}
+
+	const createdAt = typeof candidate.createdAt === "number" ? candidate.createdAt : getNow()
+	const updatedAt = typeof candidate.updatedAt === "number" ? candidate.updatedAt : createdAt
+
+	return {
+		id: typeof candidate.id === "string" && candidate.id ? candidate.id : createId(),
+		text,
+		createdAt,
+		updatedAt,
+		source: candidate.source === "sent" ? "sent" : "draft",
+		workspace: normalizeWorkspace(candidate.workspace),
+	}
+}
+
+const notifyPromptHistoryChanged = () => {
+	try {
+		window.dispatchEvent(new Event(PROMPT_HISTORY_CHANGED_EVENT))
+	} catch {
+		// Ignore event dispatch failures in non-browser test environments.
+	}
+}
+
+export const readPersistedPromptHistory = (): PersistedPromptHistoryEntry[] => {
+	const storage = getStorage()
+
+	if (!storage) {
+		return []
+	}
+
+	try {
+		const raw = storage.getItem(PROMPT_HISTORY_STORAGE_KEY)
+		const parsed = raw ? JSON.parse(raw) : []
+
+		if (!Array.isArray(parsed)) {
+			return []
+		}
+
+		return parsed
+			.map(normalizeEntry)
+			.filter((entry): entry is PersistedPromptHistoryEntry => entry !== undefined)
+			.sort((a, b) => b.updatedAt - a.updatedAt)
+			.slice(0, MAX_PROMPT_HISTORY_SIZE)
+	} catch {
+		return []
+	}
+}
+
+const writePersistedPromptHistory = (entries: PersistedPromptHistoryEntry[]) => {
+	const storage = getStorage()
+
+	if (!storage) {
+		return false
+	}
+
+	try {
+		storage.setItem(PROMPT_HISTORY_STORAGE_KEY, JSON.stringify(entries.slice(0, MAX_PROMPT_HISTORY_SIZE)))
+		notifyPromptHistoryChanged()
+		return true
+	} catch {
+		return false
+	}
+}
+
+export const readPersistedPromptHistoryTexts = (workspace?: string): string[] => {
+	const normalizedWorkspace = normalizeWorkspace(workspace)
+
+	return readPersistedPromptHistory()
+		.filter((entry) => !normalizedWorkspace || !entry.workspace || entry.workspace === normalizedWorkspace)
+		.map((entry) => entry.text)
+}
+
+export const autosavePromptHistoryDraft = (text: string, workspace?: string): boolean => {
+	const normalizedWorkspace = normalizeWorkspace(workspace)
+
+	if (!text.trim()) {
+		activeDraftId = null
+		return false
+	}
+
+	const entries = readPersistedPromptHistory()
+	const now = getNow()
+	const activeDraftIndex = activeDraftId ? entries.findIndex((entry) => entry.id === activeDraftId) : -1
+
+	if (activeDraftIndex !== -1) {
+		const existing = entries[activeDraftIndex]
+
+		if (existing.workspace !== normalizedWorkspace) {
+			activeDraftId = null
+			return autosavePromptHistoryDraft(text, normalizedWorkspace)
+		}
+
+		if (existing.text === text && existing.source === "draft") {
+			return false
+		}
+
+		entries[activeDraftIndex] = {
+			...existing,
+			text,
+			updatedAt: now,
+			source: "draft",
+			workspace: normalizedWorkspace,
+		}
+
+		return writePersistedPromptHistory(entries)
+	}
+
+	const entry: PersistedPromptHistoryEntry = {
+		id: createId(),
+		text,
+		createdAt: now,
+		updatedAt: now,
+		source: "draft",
+		workspace: normalizedWorkspace,
+	}
+
+	activeDraftId = entry.id
+	return writePersistedPromptHistory([entry, ...entries])
+}
+
+export const recordPromptHistorySend = (text: string, workspace?: string): boolean => {
+	const trimmedText = text.trim()
+	const normalizedWorkspace = normalizeWorkspace(workspace)
+
+	if (!trimmedText) {
+		activeDraftId = null
+		return false
+	}
+
+	const entries = readPersistedPromptHistory()
+	const now = getNow()
+
+	activeDraftId = null
+
+	const entry: PersistedPromptHistoryEntry = {
+		id: createId(),
+		text: trimmedText,
+		createdAt: now,
+		updatedAt: now,
+		source: "sent",
+		workspace: normalizedWorkspace,
+	}
+
+	return writePersistedPromptHistory([entry, ...entries])
+}
+
+export const resetActivePromptHistoryDraft = () => {
+	activeDraftId = null
+}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #130

### Description

This PR adds local webview persistence for chat prompt history and active prompt drafts.

Key changes:

- Adds `webview-ui/src/components/chat/utils/promptHistory.ts` with localStorage read/write helpers, entry normalization, workspace filtering, a custom history-changed event, and a 100-entry cap.
- Autosaves the current non-empty draft every 5 seconds, updating one active draft entry in place until the user sends or clears it.
- Records sent prompts from normal message send, queued message send, primary/secondary ask responses, and `acceptInput` command-output queueing.
- Updates `usePromptHistory` to merge persisted history with active conversation prompts and task-history prompts while deduplicating displayed entries by trimmed prompt text.
- Adds unit tests for draft autosave, workspace filtering, sent prompt recording, and invalid storage handling.

Reviewer focus:

- Whether localStorage is the right persistence layer for this local-only behavior.
- Whether workspace filtering should include or exclude workspace-less entries.
- Whether storage-level deduplication is desired in addition to the current display-level deduplication.
- Whether all send/queue/ask-response paths that should record prompt history are covered.

### Test Procedure

From the Zoo Code worktree:

```bash
pnpm lint
pnpm check-types
pnpm --filter @roo-code/vscode-webview test -- src/components/chat/utils/__tests__/promptHistory.spec.ts src/components/chat/__tests__/ChatView.spec.tsx
```

Manual verification recommended:

- Send several prompts.
- Use prompt-history keyboard navigation.
- Reload the webview or restart the extension host.
- Confirm recent prompts remain available and duplicate entries are not repeated in the displayed history.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [ ] **Scope**: My changes are focused on the linked issue.
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates.
- [ ] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshots / Videos

Not required unless maintainers want a short video of keyboard prompt-history navigation.

### Documentation Updates

No documentation update appears required; this is an incremental local persistence improvement to existing prompt-history behavior.

### Additional Notes

No duplicate issue found in Zoo's tracker. This PR is local-only and does not add cloud sync or new user-facing announcement surfaces.

### Get in Touch

Discord: `coorbin`
