### PR TITLE
[ENHANCEMENT] Add queue and steer delivery modes for running conversations

### DIFF
--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -294,11 +294,18 @@ export type TokenUsage = z.infer<typeof tokenUsageSchema>
  * QueuedMessage
  */
 
+export const queuedMessageDeliveryModeSchema = z.enum(["queue", "steer"])
+
+export type QueuedMessageDeliveryMode = z.infer<typeof queuedMessageDeliveryModeSchema>
+
 export const queuedMessageSchema = z.object({
 	timestamp: z.number(),
+	createdAt: z.number(),
+	updatedAt: z.number(),
 	id: z.string(),
 	text: z.string(),
 	images: z.array(z.string()).optional(),
+	deliveryMode: queuedMessageDeliveryModeSchema.default("queue"),
 })
 
 export type QueuedMessage = z.infer<typeof queuedMessageSchema>

--- a/packages/types/src/task.ts
+++ b/packages/types/src/task.ts
@@ -22,7 +22,7 @@ export interface TaskProviderLike {
 		options?: CreateTaskOptions,
 		configuration?: RooCodeSettings,
 	): Promise<TaskLike>
-	cancelTask(): Promise<void>
+	cancelTask(taskId?: string): Promise<void>
 	clearTask(): Promise<void>
 	resumeTask(taskId: string): void
 
@@ -94,6 +94,8 @@ export interface CreateTaskOptions {
 	consecutiveMistakeLimit?: number
 	experiments?: Record<string, boolean>
 	initialTodos?: TodoItem[]
+	/** Whether the task should become the visible task in the UI (default: true). */
+	focus?: boolean
 	/** Initial status for the task's history item (e.g., "active" for child tasks) */
 	initialStatus?: "active" | "delegated" | "completed"
 	/** Whether to start the task loop immediately (default: true).

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -424,7 +424,7 @@ export interface UpdateTodoListPayload {
 	todos: any[]
 }
 
-export type EditQueuedMessagePayload = Pick<QueuedMessage, "id" | "text" | "images">
+export type EditQueuedMessagePayload = Pick<QueuedMessage, "id" | "text" | "images" | "deliveryMode">
 
 export interface WebviewMessage {
 	type:
@@ -609,6 +609,7 @@ export interface WebviewMessage {
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ProviderSettings
 	images?: string[]
+	deliveryMode?: QueuedMessage["deliveryMode"]
 	bool?: boolean
 	value?: number
 	stepIndex?: number

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -245,6 +245,18 @@ export interface OpenAiCodexRateLimitsMessage {
 	error?: string
 }
 
+export interface ActiveConversationSummary {
+	rootTaskId: string
+	activeTaskId: string
+	rootTask: string
+	activeTask: string
+	ts: number
+	status: "running" | "interactive" | "resumable" | "idle" | "none"
+	parentTaskId?: string
+	queuedMessageCount: number
+	steerMessageCount: number
+}
+
 export type ExtensionState = Pick<
 	GlobalSettings,
 	| "currentApiConfigName"
@@ -315,6 +327,7 @@ export type ExtensionState = Pick<
 	apiConfiguration: ProviderSettings
 	uriScheme?: string
 	shouldShowAnnouncement: boolean
+	activeConversations?: ActiveConversationSummary[]
 
 	taskHistory: HistoryItem[]
 

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -932,6 +932,22 @@ export async function presentAssistantMessage(cline: Task) {
 	// locked.
 	cline.presentAssistantMessageLocked = false
 
+	const completedToolBoundary =
+		(block.type === "tool_use" || block.type === "mcp_tool_use") &&
+		!block.partial &&
+		!cline.didRejectTool &&
+		!cline.didAlreadyUseTool
+
+	if (completedToolBoundary) {
+		const didInterruptForSteer = await cline.maybeInterruptForPendingSteerAtToolBoundary(
+			cline.currentStreamingContentIndex,
+		)
+
+		if (didInterruptForSteer) {
+			return
+		}
+	}
+
 	// NOTE: When tool is rejected, iterator stream is interrupted and it waits
 	// for `userMessageContentReady` to be true. Future calls to present will
 	// skip execution since `didRejectTool` and iterate until `contentIndex` is

--- a/src/core/message-queue/MessageQueueService.ts
+++ b/src/core/message-queue/MessageQueueService.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events"
 
 import { v4 as uuidv4 } from "uuid"
 
-import { QueuedMessage } from "@roo-code/types"
+import { QueuedMessage, QueuedMessageDeliveryMode } from "@roo-code/types"
 
 export interface MessageQueueState {
 	messages: QueuedMessage[]
@@ -15,84 +15,222 @@ export interface QueueEvents {
 }
 
 export class MessageQueueService extends EventEmitter<QueueEvents> {
-	private _messages: QueuedMessage[]
+	private readonly lanes: Record<QueuedMessageDeliveryMode, QueuedMessage[]>
 
 	constructor() {
 		super()
 
-		this._messages = []
+		this.lanes = {
+			queue: [],
+			steer: [],
+		}
+	}
+
+	private normalizeMessage(
+		message: Pick<QueuedMessage, "id" | "text"> & Partial<Omit<QueuedMessage, "id" | "text">>,
+	): QueuedMessage {
+		const createdAt = message.createdAt ?? message.timestamp ?? Date.now()
+		const updatedAt = message.updatedAt ?? message.timestamp ?? createdAt
+
+		return {
+			timestamp: message.timestamp ?? updatedAt,
+			createdAt,
+			updatedAt,
+			id: message.id,
+			text: message.text,
+			images: message.images ? [...message.images] : undefined,
+			deliveryMode: message.deliveryMode ?? "queue",
+		}
+	}
+
+	private emitStateChanged(): void {
+		this.emit("stateChanged", this.messages)
+	}
+
+	private getLane(deliveryMode: QueuedMessageDeliveryMode): QueuedMessage[] {
+		return this.lanes[deliveryMode]
 	}
 
 	private findMessage(id: string) {
-		const index = this._messages.findIndex((msg) => msg.id === id)
+		for (const deliveryMode of ["steer", "queue"] as const) {
+			const lane = this.getLane(deliveryMode)
+			const index = lane.findIndex((message) => message.id === id)
 
-		if (index === -1) {
-			return { index, message: undefined }
+			if (index !== -1) {
+				return {
+					deliveryMode,
+					index,
+					message: lane[index],
+				}
+			}
 		}
 
-		return { index, message: this._messages[index] }
+		return {
+			deliveryMode: undefined,
+			index: -1,
+			message: undefined,
+		}
 	}
 
-	public addMessage(text: string, images?: string[]): QueuedMessage | undefined {
+	public addMessage(
+		text: string,
+		images?: string[],
+		deliveryMode: QueuedMessageDeliveryMode = "queue",
+	): QueuedMessage | undefined {
 		if (!text && !images?.length) {
 			return undefined
 		}
 
+		const now = Date.now()
 		const message: QueuedMessage = {
-			timestamp: Date.now(),
+			timestamp: now,
+			createdAt: now,
+			updatedAt: now,
 			id: uuidv4(),
 			text,
 			images,
+			deliveryMode,
 		}
 
-		this._messages.push(message)
-		this.emit("stateChanged", this._messages)
+		this.getLane(deliveryMode).push(message)
+		this.emitStateChanged()
 
 		return message
 	}
 
 	public removeMessage(id: string): boolean {
-		const { index, message } = this.findMessage(id)
+		const { deliveryMode, index, message } = this.findMessage(id)
 
-		if (!message) {
+		if (!message || !deliveryMode) {
 			return false
 		}
 
-		this._messages.splice(index, 1)
-		this.emit("stateChanged", this._messages)
+		this.getLane(deliveryMode).splice(index, 1)
+		this.emitStateChanged()
 		return true
 	}
 
-	public updateMessage(id: string, text: string, images?: string[]): boolean {
+	public updateMessage(
+		id: string,
+		text: string,
+		images?: string[],
+		deliveryMode?: QueuedMessageDeliveryMode,
+	): boolean {
+		const now = Date.now()
 		const { message } = this.findMessage(id)
 
 		if (!message) {
 			return false
 		}
 
-		message.timestamp = Date.now()
+		const nextDeliveryMode = deliveryMode ?? message.deliveryMode
+
+		if (nextDeliveryMode !== message.deliveryMode) {
+			return this.setDeliveryMode(id, nextDeliveryMode, { text, images, updatedAt: now })
+		}
+
+		message.timestamp = now
+		message.updatedAt = now
 		message.text = text
 		message.images = images
-		this.emit("stateChanged", this._messages)
+		this.emitStateChanged()
 		return true
 	}
 
 	public dequeueMessage(): QueuedMessage | undefined {
-		const message = this._messages.shift()
-		this.emit("stateChanged", this._messages)
+		return this.dequeueNextMessage(["steer", "queue"])
+	}
+
+	public dequeueMessageByMode(deliveryMode: QueuedMessageDeliveryMode): QueuedMessage | undefined {
+		const message = this.getLane(deliveryMode).shift()
+
+		if (message) {
+			this.emitStateChanged()
+		}
+
 		return message
 	}
 
-	public get messages(): QueuedMessage[] {
-		return this._messages
+	public dequeueNextMessage(priority: QueuedMessageDeliveryMode[] = ["steer", "queue"]): QueuedMessage | undefined {
+		for (const deliveryMode of priority) {
+			const message = this.dequeueMessageByMode(deliveryMode)
+
+			if (message) {
+				return message
+			}
+		}
+
+		return undefined
 	}
 
-	public isEmpty(): boolean {
-		return this._messages.length === 0
+	public setDeliveryMode(
+		id: string,
+		deliveryMode: QueuedMessageDeliveryMode,
+		overrides?: { text?: string; images?: string[]; updatedAt?: number },
+	): boolean {
+		const { deliveryMode: currentDeliveryMode, index, message } = this.findMessage(id)
+
+		if (!message || !currentDeliveryMode) {
+			return false
+		}
+
+		const now = overrides?.updatedAt ?? Date.now()
+		const nextMessage: QueuedMessage = {
+			...message,
+			timestamp: now,
+			updatedAt: now,
+			text: overrides?.text ?? message.text,
+			images: overrides?.images ?? message.images,
+			deliveryMode,
+		}
+
+		if (currentDeliveryMode === deliveryMode) {
+			this.getLane(currentDeliveryMode)[index] = nextMessage
+			this.emitStateChanged()
+			return true
+		}
+
+		this.getLane(currentDeliveryMode).splice(index, 1)
+		this.getLane(deliveryMode).push(nextMessage)
+		this.emitStateChanged()
+		return true
+	}
+
+	public restoreMessages(messages: QueuedMessage[]): void {
+		this.lanes.queue = []
+		this.lanes.steer = []
+
+		for (const message of messages) {
+			const normalized = this.normalizeMessage(message)
+			this.getLane(normalized.deliveryMode).push(normalized)
+		}
+
+		this.emitStateChanged()
+	}
+
+	public get messages(): QueuedMessage[] {
+		return [...this.lanes.steer, ...this.lanes.queue]
+	}
+
+	public getMessagesByMode(deliveryMode: QueuedMessageDeliveryMode): QueuedMessage[] {
+		return [...this.getLane(deliveryMode)]
+	}
+
+	public hasMessages(deliveryMode?: QueuedMessageDeliveryMode): boolean {
+		if (deliveryMode) {
+			return this.getLane(deliveryMode).length > 0
+		}
+
+		return this.messages.length > 0
+	}
+
+	public isEmpty(deliveryMode?: QueuedMessageDeliveryMode): boolean {
+		return !this.hasMessages(deliveryMode)
 	}
 
 	public dispose(): void {
-		this._messages = []
+		this.lanes.queue = []
+		this.lanes.steer = []
 		this.removeAllListeners()
 	}
 }

--- a/src/core/message-queue/__tests__/MessageQueueService.spec.ts
+++ b/src/core/message-queue/__tests__/MessageQueueService.spec.ts
@@ -1,0 +1,37 @@
+import { MessageQueueService } from "../MessageQueueService"
+
+describe("MessageQueueService", () => {
+	it("keeps queue and steer lanes separate while exposing steer-first ordering", () => {
+		const service = new MessageQueueService()
+
+		const queued = service.addMessage("queued", undefined, "queue")
+		const steer = service.addMessage("steer", undefined, "steer")
+
+		expect(service.messages.map((message) => message.text)).toEqual(["steer", "queued"])
+		expect(service.getMessagesByMode("queue")).toEqual([queued])
+		expect(service.getMessagesByMode("steer")).toEqual([steer])
+
+		expect(service.dequeueMessageByMode("queue")?.text).toBe("queued")
+		expect(service.dequeueMessageByMode("steer")?.text).toBe("steer")
+		expect(service.isEmpty()).toBe(true)
+	})
+
+	it("can move messages between lanes without losing timestamps or images", () => {
+		const service = new MessageQueueService()
+		const message = service.addMessage("queued", ["image.png"], "queue")
+
+		expect(message).toBeDefined()
+		expect(service.updateMessage(message!.id, "steer now", ["image.png"], "steer")).toBe(true)
+
+		expect(service.getMessagesByMode("queue")).toEqual([])
+		expect(service.getMessagesByMode("steer")).toEqual([
+			expect.objectContaining({
+				id: message!.id,
+				text: "steer now",
+				images: ["image.png"],
+				deliveryMode: "steer",
+				createdAt: message!.createdAt,
+			}),
+		])
+	})
+})

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -335,6 +335,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	// Message Queue Service
 	public readonly messageQueueService: MessageQueueService
 	private messageQueueStateChangedHandler: (() => void) | undefined
+	private deferQueuedMessageDrainUntilResume = false
+	private didSteerCurrentTurn = false
+	private interruptedAssistantText?: string
 
 	// Streaming
 	isWaitingForFirstChunk = false
@@ -1429,11 +1432,12 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// The state is mutable if the message is complete and the task will
 		// block (via the `pWaitFor`).
 		const isBlocking = !(this.askResponse !== undefined || this.lastMessageTs !== askTs)
-		const isMessageQueued = !this.messageQueueService.isEmpty()
-		// Keep queued user messages intact during command_output asks. Those asks
-		// are terminal flow-control, not conversational turns.
-		const shouldDrainQueuedMessageForAsk = type !== "command_output"
-		const isStatusMutable = !partial && isBlocking && !isMessageQueued && approval.decision === "ask"
+		const hasDeferredMessage = !this.messageQueueService.isEmpty()
+		const shouldPauseQueuedDrainForAsk = this.deferQueuedMessageDrainUntilResume && isResumableAsk(type)
+		const shouldAutoDispatchDeferredMessageForAsk =
+			this.canAutoDispatchDeferredMessageForAsk(type) && !shouldPauseQueuedDrainForAsk
+		const hasAutoDispatchCandidate = hasDeferredMessage && shouldAutoDispatchDeferredMessageForAsk
+		const isStatusMutable = !partial && isBlocking && !hasAutoDispatchCandidate && approval.decision === "ask"
 
 		if (isStatusMutable) {
 			const statusMutationTimeout = 2_000
@@ -1473,50 +1477,35 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					}, statusMutationTimeout),
 				)
 			}
-		} else if (isMessageQueued && shouldDrainQueuedMessageForAsk) {
-			const message = this.messageQueueService.dequeueMessage()
-
-			if (message) {
-				// Check if this is a tool approval ask that needs to be handled.
-				if (type === "tool" || type === "command" || type === "use_mcp_server") {
-					// For tool approvals, we need to approve first, then send
-					// the message if there's text/images.
-					this.handleWebviewAskResponse("yesButtonClicked", message.text, message.images)
-				} else {
-					// For other ask types (like followup or command_output), fulfill the ask
-					// directly.
-					this.handleWebviewAskResponse("messageResponse", message.text, message.images)
-				}
-			}
+		} else if (hasAutoDispatchCandidate) {
+			this.consumeDeferredMessageForAsk(type)
 		}
 
 		// Wait for askResponse to be set
 		await pWaitFor(
 			() => {
+				if (this.abort) {
+					return true
+				}
 				if (this.askResponse !== undefined || this.lastMessageTs !== askTs) {
 					return true
 				}
 
-				// If a queued message arrives while we're blocked on an ask (e.g. a follow-up
-				// suggestion click that was incorrectly queued due to UI state), consume it
-				// immediately so the task doesn't hang.
-				if (shouldDrainQueuedMessageForAsk && !this.messageQueueService.isEmpty()) {
-					const message = this.messageQueueService.dequeueMessage()
-					if (message) {
-						// If this is a tool approval ask, we need to approve first (yesButtonClicked)
-						// and include any queued text/images.
-						if (type === "tool" || type === "command" || type === "use_mcp_server") {
-							this.handleWebviewAskResponse("yesButtonClicked", message.text, message.images)
-						} else {
-							this.handleWebviewAskResponse("messageResponse", message.text, message.images)
-						}
-					}
+				// If a deferred message arrives while we're blocked on a handoff ask (for example
+				// a follow-up suggestion click that was queued while the agent still owned the turn),
+				// consume it immediately so the task doesn't hang.
+				if (shouldAutoDispatchDeferredMessageForAsk && !this.messageQueueService.isEmpty()) {
+					this.consumeDeferredMessageForAsk(type)
 				}
 
 				return false
 			},
 			{ interval: 100 },
 		)
+
+		if (this.abort) {
+			throw new Error(`[RooCode#ask] task ${this.taskId}.${this.instanceId} aborted`)
+		}
 
 		if (this.lastMessageTs !== askTs) {
 			// Could happen if we send multiple asks in a row i.e. with
@@ -1605,6 +1594,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		}
 	}
 
+	public setDeferQueuedMessageDrainUntilResume(value: boolean): void {
+		this.deferQueuedMessageDrainUntilResume = value
+	}
+
 	public approveAsk({ text, images }: { text?: string; images?: string[] } = {}) {
 		this.handleWebviewAskResponse("yesButtonClicked", text, images)
 	}
@@ -1673,6 +1666,152 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		} catch (error) {
 			console.error("[Task#submitUserMessage] Failed to submit user message:", error)
 		}
+	}
+
+	private canAutoDispatchDeferredMessageForAsk(type: ClineAsk): boolean {
+		return type === "followup" || isIdleAsk(type)
+	}
+
+	private dequeueNextDeferredMessageForHandoff(): QueuedMessage | undefined {
+		return this.messageQueueService.dequeueNextMessage(["steer", "queue"])
+	}
+
+	private createUserMessageBlocks(
+		text?: string,
+		images?: string[],
+	): Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> {
+		const blocks: Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> = []
+
+		if (text) {
+			blocks.push({
+				type: "text",
+				text: `<user_message>\n${text}\n</user_message>`,
+			})
+		}
+
+		if (images?.length) {
+			blocks.push(...formatResponse.imageBlocks(images))
+		}
+
+		return blocks
+	}
+
+	private appendDeferredMessageToUserContent(message: Pick<QueuedMessage, "text" | "images">): void {
+		this.userMessageContent.push(...this.createUserMessageBlocks(message.text, message.images))
+	}
+
+	private consumeDeferredMessageForAsk(type: ClineAsk): boolean {
+		if (!this.canAutoDispatchDeferredMessageForAsk(type)) {
+			return false
+		}
+
+		const message = this.dequeueNextDeferredMessageForHandoff()
+
+		if (!message) {
+			return false
+		}
+
+		this.handleWebviewAskResponse("messageResponse", message.text, message.images)
+		return true
+	}
+
+	private getAssistantTextUpToContentIndex(contentIndex: number): string {
+		let interruptedAssistantText = ""
+
+		for (let index = 0; index <= Math.min(contentIndex, this.assistantMessageContent.length - 1); index++) {
+			const block = this.assistantMessageContent[index]
+
+			if (block?.type === "text" && typeof block.content === "string") {
+				interruptedAssistantText = block.content
+			}
+		}
+
+		return interruptedAssistantText
+	}
+
+	private appendSyntheticToolResultsForSkippedBlocks(startingAfterIndex: number): void {
+		for (const block of this.assistantMessageContent.slice(startingAfterIndex + 1)) {
+			if ((block.type === "tool_use" || block.type === "mcp_tool_use") && !block.partial && "id" in block) {
+				const toolCallId = block.id
+
+				if (toolCallId) {
+					this.pushToolResultToUserContent({
+						type: "tool_result",
+						tool_use_id: sanitizeToolUseId(toolCallId),
+						content: "Task was interrupted before this tool call could be completed.",
+					})
+				}
+			}
+		}
+	}
+
+	private async appendUserFeedbackToLatestUserMessage(text?: string, images?: string[]): Promise<void> {
+		const feedbackBlocks = this.createUserMessageBlocks(text, images)
+
+		if (feedbackBlocks.length === 0) {
+			return
+		}
+
+		const lastUserMessageIndex = findLastIndex(
+			this.apiConversationHistory,
+			(message) => !message.isSummary && message.role === "user",
+		)
+
+		if (lastUserMessageIndex === -1) {
+			await this.addToApiConversationHistory({ role: "user", content: feedbackBlocks })
+			return
+		}
+
+		const lastUserMessage = this.apiConversationHistory[lastUserMessageIndex]
+		const currentContent: Anthropic.Messages.ContentBlockParam[] = Array.isArray(lastUserMessage.content)
+			? [...lastUserMessage.content]
+			: [{ type: "text", text: lastUserMessage.content }]
+
+		const environmentDetailsIndex = currentContent.findIndex(
+			(block) =>
+				block.type === "text" &&
+				block.text.trim().startsWith("<environment_details>") &&
+				block.text.trim().endsWith("</environment_details>"),
+		)
+
+		if (environmentDetailsIndex === -1) {
+			currentContent.push(...feedbackBlocks)
+		} else {
+			currentContent.splice(environmentDetailsIndex, 0, ...feedbackBlocks)
+		}
+
+		lastUserMessage.content = currentContent
+		await this.saveApiConversationHistory()
+	}
+
+	public async maybeInterruptForPendingSteerAtToolBoundary(completedContentIndex: number): Promise<boolean> {
+		const message = this.messageQueueService.dequeueMessageByMode("steer")
+
+		if (!message) {
+			return false
+		}
+
+		await this.say("user_feedback", message.text, message.images)
+		this.interruptedAssistantText = this.getAssistantTextUpToContentIndex(completedContentIndex)
+		this.appendSyntheticToolResultsForSkippedBlocks(completedContentIndex)
+		this.appendDeferredMessageToUserContent(message)
+		this.currentStreamingContentIndex = this.assistantMessageContent.length
+		this.userMessageContentReady = true
+		this.didSteerCurrentTurn = true
+
+		return true
+	}
+
+	public async consumePendingSteerAtApiBoundary(): Promise<boolean> {
+		const message = this.messageQueueService.dequeueMessageByMode("steer")
+
+		if (!message) {
+			return false
+		}
+
+		await this.say("user_feedback", message.text, message.images)
+		this.appendDeferredMessageToUserContent(message)
+		return true
 	}
 
 	async handleTerminalOperation(terminalOperation: "continue" | "abort") {
@@ -1794,9 +1933,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			{ isNonInteractive: true } /* options */,
 			contextCondense,
 		)
-
-		// Process any queued messages after condensing completes
-		this.processQueuedMessages()
 	}
 
 	async say(
@@ -2113,14 +2249,32 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			this.isInitialized = true
 
 			const { response, text, images } = await this.ask(askType) // Calls `postStateToWebview`.
+			const shouldUseQueuedMessageOnResume = this.deferQueuedMessageDrainUntilResume
+			this.deferQueuedMessageDrainUntilResume = false
 
-			let responseText: string | undefined
-			let responseImages: string[] | undefined
+			let responseText: string | undefined =
+				response === "messageResponse" || response === "yesButtonClicked" ? text : undefined
+			let responseImages: string[] | undefined =
+				response === "messageResponse" || response === "yesButtonClicked" ? images : undefined
 
-			if (response === "messageResponse") {
-				await this.say("user_feedback", text, images)
-				responseText = text
-				responseImages = images
+			if (
+				shouldUseQueuedMessageOnResume &&
+				response === "yesButtonClicked" &&
+				!responseText &&
+				(responseImages?.length ?? 0) === 0
+			) {
+				const queuedMessage = this.dequeueNextDeferredMessageForHandoff()
+				if (queuedMessage) {
+					responseText = queuedMessage.text || undefined
+					responseImages = queuedMessage.images
+				}
+			}
+
+			if (
+				(response === "messageResponse" || response === "yesButtonClicked") &&
+				(responseText || responseImages?.length)
+			) {
+				await this.say("user_feedback", responseText, responseImages)
 			}
 
 			// Make sure that the api conversation history can be resumed by the API,
@@ -2810,6 +2964,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				this.userMessageContent = []
 				this.userMessageContentReady = false
 				this.didRejectTool = false
+				this.didSteerCurrentTurn = false
+				this.interruptedAssistantText = undefined
 				this.didAlreadyUseTool = false
 				this.assistantMessageSavedToHistory = false
 				// Reset tool failure flag for each new assistant turn - this ensures that tool failures
@@ -3104,6 +3260,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 							// present iterator to finish and set
 							// userMessageContentReady when its ready.
 							// this.userMessageContentReady = true
+							break
+						}
+						if (this.didSteerCurrentTurn) {
 							break
 						}
 
@@ -3488,8 +3647,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				// the assistant message is already in history. Otherwise, tool_result blocks would appear
 				// BEFORE their corresponding tool_use blocks, causing API errors.
 
+				const assistantTextForHistory = this.interruptedAssistantText ?? assistantMessage
+
 				// Check if we have any content to process (text or tool uses)
-				const hasTextContent = assistantMessage.length > 0
+				const hasTextContent = assistantTextForHistory.length > 0
 
 				const hasToolUses = this.assistantMessageContent.some(
 					(block) => block.type === "tool_use" || block.type === "mcp_tool_use",
@@ -3512,10 +3673,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					const assistantContent: Array<Anthropic.TextBlockParam | Anthropic.ToolUseBlockParam> = []
 
 					// Add text content if present
-					if (assistantMessage) {
+					if (assistantTextForHistory) {
 						assistantContent.push({
 							type: "text" as const,
-							text: assistantMessage,
+							text: assistantTextForHistory,
 						})
 					}
 
@@ -3691,6 +3852,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 						// Reset counter when tools are used successfully
 						this.consecutiveNoToolUseCount = 0
 					}
+
+					await this.consumePendingSteerAtApiBoundary()
 
 					// Push to stack if there's content OR if we're paused waiting for a subtask.
 					// When paused, we push an empty item so the loop continues to the pause check.
@@ -4416,12 +4579,15 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 				return
 			} else {
-				const { response } = await this.ask(
+				const { response, text, images } = await this.ask(
 					"api_req_failed",
 					error.message ?? JSON.stringify(serializeError(error), null, 2),
 				)
 
-				if (response !== "yesButtonClicked") {
+				if (response === "messageResponse") {
+					await this.say("user_feedback", text ?? "", images)
+					await this.appendUserFeedbackToLatestUserMessage(text, images)
+				} else if (response !== "yesButtonClicked") {
 					// This will never happen since if noButtonClicked, we will
 					// clear current task, aborting this instance.
 					throw new Error("API request failed")
@@ -4776,26 +4942,11 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	/**
-	 * Process any queued messages by dequeuing and submitting them.
-	 * This ensures that queued user messages are sent when appropriate,
-	 * preventing them from getting stuck in the queue.
-	 *
-	 * @param context - Context string for logging (e.g., the calling tool name)
+	 * Legacy no-op kept for compatibility with older call sites and tests.
+	 * Deferred messages are now dispatched only through explicit queue/steer
+	 * handoff and safe-boundary helpers.
 	 */
 	public processQueuedMessages(): void {
-		try {
-			if (!this.messageQueueService.isEmpty()) {
-				const queued = this.messageQueueService.dequeueMessage()
-				if (queued) {
-					setTimeout(() => {
-						this.submitUserMessage(queued.text, queued.images).catch((err) =>
-							console.error(`[Task] Failed to submit queued message:`, err),
-						)
-					}, 0)
-				}
-			}
-		} catch (e) {
-			console.error(`[Task] Queue processing error:`, e)
-		}
+		return
 	}
 }

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -29,6 +29,7 @@ import {
 	type ClineMessage,
 	type ClineSay,
 	type ClineAsk,
+	type ExtensionMessage,
 	type ToolProgressStatus,
 	type HistoryItem,
 	type CreateTaskOptions,
@@ -523,7 +524,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		this.messageQueueStateChangedHandler = () => {
 			this.emit(RooCodeEventName.TaskUserMessage, this.taskId)
 			this.emit(RooCodeEventName.QueuedMessagesUpdated, this.taskId, this.messageQueueService.messages)
-			this.providerRef.deref()?.postStateToWebviewWithoutTaskHistory()
+			this.postTaskStateToWebview().catch(() => undefined)
 		}
 
 		this.messageQueueService.on("stateChanged", this.messageQueueStateChangedHandler)
@@ -666,9 +667,13 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		this.providerProfileChangeListener = async () => {
 			try {
+				if (!provider.isTaskVisible(this.taskId)) {
+					return
+				}
 				const newState = await provider.getState()
 				if (newState?.apiConfiguration) {
 					this.updateApiConfiguration(newState.apiConfiguration)
+					this.setTaskApiConfigName(newState.currentApiConfigName)
 				}
 			} catch (error) {
 				console.error(
@@ -679,6 +684,50 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		}
 
 		provider.on(RooCodeEventName.ProviderProfileChanged, this.providerProfileChangeListener)
+	}
+
+	private async getTaskScopedState(): Promise<Awaited<ReturnType<ClineProvider["getState"]>> | undefined> {
+		const provider = this.providerRef.deref()
+		if (!provider) {
+			return undefined
+		}
+
+		const state = await provider.getState()
+
+		return {
+			...state,
+			mode: await this.getTaskMode().catch(() => state.mode ?? defaultModeSlug),
+			apiConfiguration: this.apiConfiguration,
+			currentApiConfigName: await this.getTaskApiConfigName().catch(() => state.currentApiConfigName),
+		}
+	}
+
+	private async postTaskStateToWebview(): Promise<void> {
+		const provider = this.providerRef.deref()
+		if (!provider) {
+			return
+		}
+
+		if (typeof provider.postTaskStateToWebview === "function") {
+			await provider.postTaskStateToWebview(this.taskId)
+			return
+		}
+
+		await provider.postStateToWebviewWithoutTaskHistory?.()
+	}
+
+	private async postTaskMessageToWebview(message: ExtensionMessage): Promise<void> {
+		const provider = this.providerRef.deref()
+		if (!provider) {
+			return
+		}
+
+		if (typeof provider.postTaskMessageToWebview === "function") {
+			await provider.postTaskMessageToWebview(this.taskId, message)
+			return
+		}
+
+		await provider.postMessageToWebview?.(message)
 	}
 
 	/**
@@ -1155,10 +1204,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 	private async addToClineMessages(message: ClineMessage) {
 		this.clineMessages.push(message)
-		const provider = this.providerRef.deref()
 		// Avoid resending large, mostly-static fields (notably taskHistory) on every chat message update.
 		// taskHistory is maintained in-memory in the webview and updated via taskHistoryItemUpdated.
-		await provider?.postStateToWebviewWithoutTaskHistory()
+		await this.postTaskStateToWebview()
 		this.emit(RooCodeEventName.Message, { action: "created", message })
 		await this.saveClineMessages()
 
@@ -1190,8 +1238,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async updateClineMessage(message: ClineMessage) {
-		const provider = this.providerRef.deref()
-		await provider?.postMessageToWebview({ type: "messageUpdated", clineMessage: message })
+		await this.postTaskMessageToWebview({ type: "messageUpdated", clineMessage: message })
 		this.emit(RooCodeEventName.Message, { action: "updated", message })
 
 		// Check if we should sync to cloud and haven't already synced this message
@@ -1362,7 +1409,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		// Automatically approve if the ask according to the user's settings.
 		const provider = this.providerRef.deref()
-		const state = provider ? await provider.getState() : undefined
+		const state = await this.getTaskScopedState()
 		const approval = await checkAutoApproval({ state, ask: type, text, isProtected })
 
 		if (approval.decision === "approve") {
@@ -1399,7 +1446,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 						if (message) {
 							this.interactiveAsk = message
 							this.emit(RooCodeEventName.TaskInteractive, this.taskId)
-							provider?.postMessageToWebview({ type: "interactionRequired" })
+							this.postTaskMessageToWebview({ type: "interactionRequired" }).catch(() => undefined)
 						}
 					}, statusMutationTimeout),
 				)
@@ -1608,7 +1655,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 					// Update this task's API configuration to match the new profile
 					// This ensures the parser state is synchronized with the selected model
-					const newState = await provider.getState()
+					const newState = await this.getTaskScopedState()
 					if (newState?.apiConfiguration) {
 						this.updateApiConfiguration(newState.apiConfiguration)
 					}
@@ -1653,7 +1700,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		const systemPrompt = await this.getSystemPrompt()
 
 		// Get condensing configuration
-		const state = await this.providerRef.deref()?.getState()
+		const state = await this.getTaskScopedState()
 		const customCondensingPrompt = state?.customSupportPrompts?.CONDENSE
 		const { mode, apiConfiguration } = state ?? {}
 
@@ -1892,7 +1939,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				return { enabledToolCount: 0, enabledServerCount: 0 }
 			}
 
-			const { mcpEnabled } = (await provider.getState()) ?? {}
+			const { mcpEnabled } = (await this.getTaskScopedState()) ?? {}
 			if (!(mcpEnabled ?? true)) {
 				return { enabledToolCount: 0, enabledServerCount: 0 }
 			}
@@ -1948,7 +1995,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			// The todo list is already set in the constructor if initialTodos were provided
 			// No need to add any messages - the todoList property is already set
 
-			await this.providerRef.deref()?.postStateToWebviewWithoutTaskHistory()
+			await this.postTaskStateToWebview()
 
 			await this.say("text", task, images)
 
@@ -2593,7 +2640,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			)
 
 			const provider = this.providerRef.deref()
-			const state = provider ? await provider.getState() : undefined
+			const state = await this.getTaskScopedState()
 
 			const showRooIgnoredFiles = state?.showRooIgnoredFiles ?? false
 			const includeDiagnosticMessages = state?.includeDiagnosticMessages ?? true
@@ -2616,7 +2663,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			if (slashCommandMode) {
 				const provider = this.providerRef.deref()
 				if (provider) {
-					const state = await provider.getState()
+					const state = await this.getTaskScopedState()
 					const targetMode = getModeBySlug(slashCommandMode, state?.customModes)
 					if (targetMode) {
 						await provider.handleModeSwitch(slashCommandMode)
@@ -2671,7 +2718,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			} satisfies ClineApiReqInfo)
 
 			await this.saveClineMessages()
-			await this.providerRef.deref()?.postStateToWebviewWithoutTaskHistory()
+			await this.postTaskStateToWebview()
 
 			try {
 				let cacheWriteTokens = 0
@@ -3300,7 +3347,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 							)
 
 							// Apply exponential backoff similar to first-chunk errors when auto-resubmit is enabled
-							const stateForBackoff = await this.providerRef.deref()?.getState()
+							const stateForBackoff = await this.getTaskScopedState()
 							if (stateForBackoff?.autoApprovalEnabled) {
 								await this.backoffAndAnnounce(currentItem.retryAttempt ?? 0, error)
 
@@ -3432,7 +3479,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				}
 
 				await this.saveClineMessages()
-				await this.providerRef.deref()?.postStateToWebviewWithoutTaskHistory()
+				await this.postTaskStateToWebview()
 
 				// No legacy text-stream tool parser state to reset.
 
@@ -3676,7 +3723,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					// apiConversationHistory at line 1876. Since the assistant failed to respond,
 					// we need to remove that message before retrying to avoid having two consecutive
 					// user messages (which would cause tool_result validation errors).
-					let state = await this.providerRef.deref()?.getState()
+					let state = await this.getTaskScopedState()
 					if (this.apiConversationHistory.length > 0) {
 						const lastMessage = this.apiConversationHistory[this.apiConversationHistory.length - 1]
 						if (lastMessage.role === "user") {
@@ -3773,7 +3820,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async getSystemPrompt(): Promise<string> {
-		const { mcpEnabled } = (await this.providerRef.deref()?.getState()) ?? {}
+		const state = await this.getTaskScopedState()
+		const { mcpEnabled } = state ?? {}
 		let mcpHub: McpHub | undefined
 		if (mcpEnabled ?? true) {
 			const provider = this.providerRef.deref()
@@ -3796,8 +3844,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		}
 
 		const rooIgnoreInstructions = this.rooIgnoreController?.getInstructions()
-
-		const state = await this.providerRef.deref()?.getState()
 
 		const {
 			mode,
@@ -3857,7 +3903,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	private async handleContextWindowExceededError(): Promise<void> {
-		const state = await this.providerRef.deref()?.getState()
+		const state = await this.getTaskScopedState()
 		const { profileThresholds = {}, mode, apiConfiguration } = state ?? {}
 
 		const { contextTokens } = this.getTokenUsage()
@@ -3881,7 +3927,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				`Forcing truncation to ${FORCED_CONTEXT_REDUCTION_PERCENT}% of current context.`,
 		)
 		// Send condenseTaskContextStarted to show in-progress indicator
-		await this.providerRef.deref()?.postMessageToWebview({ type: "condenseTaskContextStarted", text: this.taskId })
+		await this.postTaskMessageToWebview({ type: "condenseTaskContextStarted", text: this.taskId })
 
 		// Build tools for condensing metadata (same tools used for normal API calls)
 		const provider = this.providerRef.deref()
@@ -3975,9 +4021,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		} finally {
 			// Notify webview that context management is complete (removes in-progress spinner)
 			// IMPORTANT: Must always be sent to dismiss the spinner, even on error
-			await this.providerRef
-				.deref()
-				?.postMessageToWebview({ type: "condenseTaskContextResponse", text: this.taskId })
+			await this.postTaskMessageToWebview({ type: "condenseTaskContextResponse", text: this.taskId })
 		}
 	}
 
@@ -3988,7 +4032,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	 * the `api_req_rate_limit_wait` say type (not an error).
 	 */
 	private async maybeWaitForProviderRateLimit(retryAttempt: number): Promise<void> {
-		const state = await this.providerRef.deref()?.getState()
+		const state = await this.getTaskScopedState()
 		const rateLimitSeconds =
 			state?.apiConfiguration?.rateLimitSeconds ?? this.apiConfiguration?.rateLimitSeconds ?? 0
 
@@ -4019,7 +4063,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		retryAttempt: number = 0,
 		options: { skipProviderRateLimit?: boolean } = {},
 	): ApiStream {
-		const state = await this.providerRef.deref()?.getState()
+		const state = await this.getTaskScopedState()
 
 		const {
 			apiConfiguration,
@@ -4090,9 +4134,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			// This notification must be sent here (not earlier) because the early check uses stale token count
 			// (before user message is added to history), which could incorrectly skip showing the indicator
 			if (contextManagementWillRun && autoCondenseContext) {
-				await this.providerRef
-					.deref()
-					?.postMessageToWebview({ type: "condenseTaskContextStarted", text: this.taskId })
+				await this.postTaskMessageToWebview({ type: "condenseTaskContextStarted", text: this.taskId })
 			}
 
 			// Build tools for condensing metadata (same tools used for normal API calls)
@@ -4212,9 +4254,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				// This removes the in-progress spinner and allows the completed result to show
 				// IMPORTANT: Must always be sent to dismiss the spinner, even on error
 				if (contextManagementWillRun && autoCondenseContext) {
-					await this.providerRef
-						.deref()
-						?.postMessageToWebview({ type: "condenseTaskContextResponse", text: this.taskId })
+					await this.postTaskMessageToWebview({ type: "condenseTaskContextResponse", text: this.taskId })
 				}
 			}
 		}
@@ -4409,7 +4449,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	// Shared exponential backoff for retries (first-chunk and mid-stream)
 	private async backoffAndAnnounce(retryAttempt: number, error: any): Promise<void> {
 		try {
-			const state = await this.providerRef.deref()?.getState()
+			const state = await this.getTaskScopedState()
 			const baseDelay = state?.requestDelaySeconds || 5
 
 			let exponentialDelay = Math.min(

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -1755,7 +1755,7 @@ describe("Cline", () => {
 	})
 })
 
-describe("Queued message processing after condense", () => {
+describe("Deferred message dispatch boundaries", () => {
 	function createProvider(): any {
 		const storageUri = { fsPath: path.join(os.tmpdir(), "test-storage") }
 		const ctx = {
@@ -1802,7 +1802,30 @@ describe("Queued message processing after condense", () => {
 		apiKey: "test-api-key",
 	} as any
 
-	it("processes queued message after condense completes", async () => {
+	it("keeps queued messages pending when processQueuedMessages is called", async () => {
+		const provider = createProvider()
+		const task = new Task({
+			provider,
+			apiConfiguration: apiConfig,
+			task: "initial task",
+			startTask: false,
+		})
+		const submitSpy = vi.spyOn(task, "submitUserMessage").mockResolvedValue(undefined)
+		task.messageQueueService.addMessage("queued text", ["img1.png"], "queue")
+
+		task.processQueuedMessages()
+
+		expect(submitSpy).not.toHaveBeenCalled()
+		expect(task.messageQueueService.getMessagesByMode("queue")).toEqual([
+			expect.objectContaining({
+				text: "queued text",
+				images: ["img1.png"],
+				deliveryMode: "queue",
+			}),
+		])
+	})
+
+	it("consumes only steer messages at API boundaries and preserves queued follow-ups", async () => {
 		const provider = createProvider()
 		const task = new Task({
 			provider,
@@ -1811,69 +1834,80 @@ describe("Queued message processing after condense", () => {
 			startTask: false,
 		})
 
-		// Make condense fast + deterministic
-		vi.spyOn(task as any, "getSystemPrompt").mockResolvedValue("system")
-		const submitSpy = vi.spyOn(task, "submitUserMessage").mockResolvedValue(undefined)
+		const saySpy = vi.spyOn(task, "say").mockResolvedValue(undefined as any)
 
-		// Queue a message during condensing
-		task.messageQueueService.addMessage("queued text", ["img1.png"])
+		task.messageQueueService.addMessage("queued text", undefined, "queue")
+		task.messageQueueService.addMessage("steer text", undefined, "steer")
 
-		// Use fake timers to capture setTimeout(0) in processQueuedMessages
-		vi.useFakeTimers()
-		await task.condenseContext()
+		const consumed = await task.consumePendingSteerAtApiBoundary()
 
-		// Flush the microtask that submits the queued message
-		vi.runAllTimers()
-		vi.useRealTimers()
-
-		expect(submitSpy).toHaveBeenCalledWith("queued text", ["img1.png"])
-		expect(task.messageQueueService.isEmpty()).toBe(true)
+		expect(consumed).toBe(true)
+		expect(saySpy).toHaveBeenCalledWith("user_feedback", "steer text", undefined)
+		expect(task.messageQueueService.getMessagesByMode("steer")).toEqual([])
+		expect(task.messageQueueService.getMessagesByMode("queue")).toEqual([
+			expect.objectContaining({
+				text: "queued text",
+				deliveryMode: "queue",
+			}),
+		])
+		expect((task as any).userMessageContent).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "text",
+					text: "<user_message>\nsteer text\n</user_message>",
+				}),
+			]),
+		)
 	})
 
-	it("does not cross-drain queues between separate tasks", async () => {
-		const providerA = createProvider()
-		const providerB = createProvider()
-
-		const taskA = new Task({
-			provider: providerA,
+	it("interrupts after a tool boundary for steer messages and injects synthetic tool results for skipped tools", async () => {
+		const provider = createProvider()
+		const task = new Task({
+			provider,
 			apiConfiguration: apiConfig,
-			task: "task A",
-			startTask: false,
-		})
-		const taskB = new Task({
-			provider: providerB,
-			apiConfiguration: apiConfig,
-			task: "task B",
+			task: "initial task",
 			startTask: false,
 		})
 
-		vi.spyOn(taskA as any, "getSystemPrompt").mockResolvedValue("system")
-		vi.spyOn(taskB as any, "getSystemPrompt").mockResolvedValue("system")
+		const saySpy = vi.spyOn(task, "say").mockResolvedValue(undefined as any)
 
-		const spyA = vi.spyOn(taskA, "submitUserMessage").mockResolvedValue(undefined)
-		const spyB = vi.spyOn(taskB, "submitUserMessage").mockResolvedValue(undefined)
+		;(task as any).assistantMessageContent = [
+			{ type: "text", content: "first plan" },
+			{ type: "tool_use", id: "tool-1", partial: false, name: "read_file" },
+			{ type: "tool_use", id: "tool-2", partial: false, name: "edit_file" },
+		]
 
-		taskA.messageQueueService.addMessage("A message")
-		taskB.messageQueueService.addMessage("B message")
+		task.messageQueueService.addMessage("queued follow-up", undefined, "queue")
+		task.messageQueueService.addMessage("steer follow-up", undefined, "steer")
 
-		// Condense in task A should only drain A's queue
-		vi.useFakeTimers()
-		await taskA.condenseContext()
-		vi.runAllTimers()
-		vi.useRealTimers()
+		const interrupted = await task.maybeInterruptForPendingSteerAtToolBoundary(1)
 
-		expect(spyA).toHaveBeenCalledWith("A message", undefined)
-		expect(spyB).not.toHaveBeenCalled()
-		expect(taskB.messageQueueService.isEmpty()).toBe(false)
-
-		// Now condense in task B should drain B's queue
-		vi.useFakeTimers()
-		await taskB.condenseContext()
-		vi.runAllTimers()
-		vi.useRealTimers()
-
-		expect(spyB).toHaveBeenCalledWith("B message", undefined)
-		expect(taskB.messageQueueService.isEmpty()).toBe(true)
+		expect(interrupted).toBe(true)
+		expect(saySpy).toHaveBeenCalledWith("user_feedback", "steer follow-up", undefined)
+		expect((task as any).interruptedAssistantText).toBe("first plan")
+		expect((task as any).currentStreamingContentIndex).toBe((task as any).assistantMessageContent.length)
+		expect((task as any).userMessageContentReady).toBe(true)
+		expect((task as any).didSteerCurrentTurn).toBe(true)
+		expect((task as any).userMessageContent).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "tool_result",
+					tool_use_id: "tool-2",
+					content: "Task was interrupted before this tool call could be completed.",
+				}),
+				expect.objectContaining({
+					type: "text",
+					text: "<user_message>\nsteer follow-up\n</user_message>",
+				}),
+			]),
+		)
+		expect(task.messageQueueService.getMessagesByMode("steer")).toEqual([])
+		expect(task.messageQueueService.getMessagesByMode("queue")).toEqual([
+			expect.objectContaining({
+				text: "queued follow-up",
+				deliveryMode: "queue",
+			}),
+		])
 	})
 })
 

--- a/src/core/task/__tests__/ask-queued-message-drain.spec.ts
+++ b/src/core/task/__tests__/ask-queued-message-drain.spec.ts
@@ -69,4 +69,40 @@ describe("Task.ask queued message drain", () => {
 		expect((task as any).messageQueueService.isEmpty()).toBe(false)
 		expect((task as any).messageQueueService.messages[0]?.text).toBe("1+1=?")
 	})
+
+	it("does not consume queued messages for resumable asks when draining is deferred", async () => {
+		const task = Object.create(Task.prototype) as Task
+		;(task as any).abort = false
+		;(task as any).clineMessages = []
+		;(task as any).askResponse = undefined
+		;(task as any).askResponseText = undefined
+		;(task as any).askResponseImages = undefined
+		;(task as any).lastMessageTs = undefined
+
+		const { MessageQueueService } = await import("../../message-queue/MessageQueueService")
+		;(task as any).messageQueueService = new MessageQueueService()
+		;(task as any).addToClineMessages = vi.fn(async () => {})
+		;(task as any).saveClineMessages = vi.fn(async () => {})
+		;(task as any).updateClineMessage = vi.fn(async () => {})
+		;(task as any).cancelAutoApprovalTimeout = vi.fn(() => {})
+		;(task as any).checkpointSave = vi.fn(async () => {})
+		;(task as any).emit = vi.fn()
+		;(task as any).providerRef = { deref: () => undefined }
+
+		task.setDeferQueuedMessageDrainUntilResume(true)
+
+		const askPromise = task.ask("resume_task", "resume?", false)
+		;(task as any).messageQueueService.addMessage("follow up after cancel")
+
+		setTimeout(() => {
+			task.approveAsk()
+		}, 0)
+
+		const result = await askPromise
+
+		expect(result.response).toBe("yesButtonClicked")
+		expect(result.text).toBeUndefined()
+		expect((task as any).messageQueueService.isEmpty()).toBe(false)
+		expect((task as any).messageQueueService.messages[0]?.text).toBe("follow up after cancel")
+	})
 })

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1270,12 +1270,16 @@ export class ClineProvider
 			const wasVisible = this.visibleTaskId === oldTask?.taskId
 
 			// Abort the old task to stop running processes and mark as abandoned
-			try {
-				await oldTask.abortTask(true)
-			} catch (e) {
-				this.log(
-					`[createTaskWithHistoryItem] abortTask() failed for old task ${oldTask.taskId}.${oldTask.instanceId}: ${e.message}`,
-				)
+			if (oldTask && !oldTask.abandoned) {
+				try {
+					await oldTask.abortTask(true)
+				} catch (error) {
+					this.log(
+						`[createTaskWithHistoryItem] abortTask() failed for old task ${oldTask.taskId}.${oldTask.instanceId}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					)
+				}
 			}
 
 			// Remove event listeners from the old task
@@ -3188,6 +3192,10 @@ export class ClineProvider
 
 		console.log(`[cancelTask] cancelling task ${task.taskId}.${task.instanceId}`)
 		const wasVisible = this.isTaskVisible(task.taskId)
+		const preservedQueuedMessages = task.messageQueueService.messages.map((message) => ({
+			...message,
+			images: message.images ? [...message.images] : undefined,
+		}))
 
 		let historyItem: HistoryItem | undefined
 		try {
@@ -3265,10 +3273,15 @@ export class ClineProvider
 		}
 
 		// Clears task again, so we need to abortTask manually above.
-		await this.createTaskWithHistoryItem(
+		const replacementTask = await this.createTaskWithHistoryItem(
 			{ ...historyItem, rootTask, parentTask },
 			{ replaceExistingTask: true, focus: wasVisible },
 		)
+
+		if (replacementTask && preservedQueuedMessages.length > 0) {
+			replacementTask.messageQueueService.restoreMessages(preservedQueuedMessages)
+			replacementTask.setDeferQueuedMessageDrainUntilResume(true)
+		}
 	}
 
 	// Clear the current task without treating it as a subtask.

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -36,6 +36,7 @@ import {
 	type ToolUsage,
 	type ExtensionMessage,
 	type ExtensionState,
+	type ActiveConversationSummary,
 	type MarketplaceInstalledMetadata,
 	RooCodeEventName,
 	requestyDefaultModelId,
@@ -137,6 +138,8 @@ export class ClineProvider
 	private webviewDisposables: vscode.Disposable[] = []
 	private view?: vscode.WebviewView | vscode.WebviewPanel
 	private clineStack: Task[] = []
+	private visibleTaskId?: string
+	private hasExplicitTaskSelectionClear = false
 	private codeIndexStatusSubscription?: vscode.Disposable
 	private codeIndexManager?: CodeIndexManager
 	private _workspaceTracker?: WorkspaceTracker // workSpaceTracker read-only for access outside this class
@@ -156,6 +159,8 @@ export class ClineProvider
 	private static readonly GLOBAL_STATE_WRITE_THROUGH_DEBOUNCE_MS = 5000 // 5 seconds
 	private pendingOperations: Map<string, PendingEditOperation> = new Map()
 	private static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
+	private activeConversationsUpdateTimer: ReturnType<typeof setTimeout> | null = null
+	private static readonly ACTIVE_CONVERSATIONS_UPDATE_DEBOUNCE_MS = 250
 
 	private cloudOrganizationsCache: CloudOrganizationMembership[] | null = null
 	private cloudOrganizationsCacheTimestamp: number | null = null
@@ -237,24 +242,40 @@ export class ClineProvider
 		// We do something fairly similar for the IPC-based API.
 		this.taskCreationCallback = (instance: Task) => {
 			this.emit(RooCodeEventName.TaskCreated, instance)
+			const broadcastTaskState = () => {
+				this.postTaskStateToWebview(instance.taskId).catch((error) => {
+					this.log(
+						`[taskCreationCallback] Failed to broadcast task state for ${instance.taskId}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					)
+				})
+			}
 
 			// Create named listener functions so we can remove them later.
-			const onTaskStarted = () => this.emit(RooCodeEventName.TaskStarted, instance.taskId)
+			const onTaskStarted = () => {
+				this.emit(RooCodeEventName.TaskStarted, instance.taskId)
+				broadcastTaskState()
+			}
 			const onTaskCompleted = (taskId: string, tokenUsage: TokenUsage, toolUsage: ToolUsage) => {
 				this.emit(RooCodeEventName.TaskCompleted, taskId, tokenUsage, toolUsage)
+				broadcastTaskState()
 			}
 			const onTaskAborted = async () => {
 				this.emit(RooCodeEventName.TaskAborted, instance.taskId)
+				broadcastTaskState()
 
 				try {
 					// Only rehydrate on genuine streaming failures.
 					// User-initiated cancels are handled by cancelTask().
 					if (instance.abortReason === "streaming_failed") {
-						// Defensive safeguard: if another path already replaced this instance, skip
-						const current = this.getCurrentTask()
-						if (current && current.instanceId !== instance.instanceId) {
+						// Defensive safeguard: if another path already replaced or removed this instance, skip
+						const current = this.getTaskById(instance.taskId)
+						if (!current || current.instanceId !== instance.instanceId) {
 							this.log(
-								`[onTaskAborted] Skipping rehydrate: current instance ${current.instanceId} != aborted ${instance.instanceId}`,
+								`[onTaskAborted] Skipping rehydrate for ${instance.taskId}: active instance ${
+									current?.instanceId ?? "none"
+								} != aborted ${instance.instanceId}`,
 							)
 							return
 						}
@@ -262,7 +283,10 @@ export class ClineProvider
 						const { historyItem } = await this.getTaskWithId(instance.taskId)
 						const rootTask = instance.rootTask
 						const parentTask = instance.parentTask
-						await this.createTaskWithHistoryItem({ ...historyItem, rootTask, parentTask })
+						await this.createTaskWithHistoryItem(
+							{ ...historyItem, rootTask, parentTask },
+							{ replaceExistingTask: true, focus: this.isTaskVisible(instance.taskId) },
+						)
 					}
 				} catch (error) {
 					this.log(
@@ -274,12 +298,30 @@ export class ClineProvider
 			}
 			const onTaskFocused = () => this.emit(RooCodeEventName.TaskFocused, instance.taskId)
 			const onTaskUnfocused = () => this.emit(RooCodeEventName.TaskUnfocused, instance.taskId)
-			const onTaskActive = (taskId: string) => this.emit(RooCodeEventName.TaskActive, taskId)
-			const onTaskInteractive = (taskId: string) => this.emit(RooCodeEventName.TaskInteractive, taskId)
-			const onTaskResumable = (taskId: string) => this.emit(RooCodeEventName.TaskResumable, taskId)
-			const onTaskIdle = (taskId: string) => this.emit(RooCodeEventName.TaskIdle, taskId)
-			const onTaskPaused = (taskId: string) => this.emit(RooCodeEventName.TaskPaused, taskId)
-			const onTaskUnpaused = (taskId: string) => this.emit(RooCodeEventName.TaskUnpaused, taskId)
+			const onTaskActive = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskActive, taskId)
+				broadcastTaskState()
+			}
+			const onTaskInteractive = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskInteractive, taskId)
+				broadcastTaskState()
+			}
+			const onTaskResumable = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskResumable, taskId)
+				broadcastTaskState()
+			}
+			const onTaskIdle = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskIdle, taskId)
+				broadcastTaskState()
+			}
+			const onTaskPaused = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskPaused, taskId)
+				broadcastTaskState()
+			}
+			const onTaskUnpaused = (taskId: string) => {
+				this.emit(RooCodeEventName.TaskUnpaused, taskId)
+				broadcastTaskState()
+			}
 			const onTaskSpawned = (taskId: string) => this.emit(RooCodeEventName.TaskSpawned, taskId)
 			const onTaskUserMessage = (taskId: string) => this.emit(RooCodeEventName.TaskUserMessage, taskId)
 			const onTaskTokenUsageUpdated = (taskId: string, tokenUsage: TokenUsage, toolUsage: ToolUsage) =>
@@ -319,6 +361,195 @@ export class ClineProvider
 				() => instance.off(RooCodeEventName.TaskTokenUsageUpdated, onTaskTokenUsageUpdated),
 			])
 		}
+	}
+
+	private getTaskById(taskId?: string): Task | undefined {
+		if (!taskId) {
+			return undefined
+		}
+
+		return this.clineStack.find((task) => task.taskId === taskId)
+	}
+
+	private getRootTaskId(task: Pick<Task, "taskId" | "rootTaskId">): string {
+		return task.rootTaskId ?? task.taskId
+	}
+
+	private getTaskActivityTs(task: Task): number {
+		return (
+			this.taskHistoryStore.get(task.taskId)?.ts ??
+			this.taskHistoryStore.get(this.getRootTaskId(task))?.ts ??
+			task.clineMessages.at(-1)?.ts ??
+			0
+		)
+	}
+
+	public isTaskVisible(taskId: string): boolean {
+		return this.visibleTaskId === taskId
+	}
+
+	private async syncVisibleTaskContext(task: Task): Promise<void> {
+		const [mode, currentApiConfigName] = await Promise.all([
+			typeof task.getTaskMode === "function"
+				? task.getTaskMode().catch(() => defaultModeSlug)
+				: Promise.resolve(task.taskMode ?? defaultModeSlug),
+			typeof task.getTaskApiConfigName === "function"
+				? task.getTaskApiConfigName().catch(() => undefined)
+				: Promise.resolve(task.taskApiConfigName),
+		])
+
+		await this.contextProxy.setValue("mode", mode)
+		if (task.apiConfiguration) {
+			await this.contextProxy.setProviderSettings(task.apiConfiguration)
+		}
+
+		if (currentApiConfigName !== undefined) {
+			await this.contextProxy.setValue("currentApiConfigName", currentApiConfigName)
+		}
+
+		this.emit(RooCodeEventName.ModeChanged, mode)
+
+		if (task.apiConfiguration?.apiProvider) {
+			this.emit(RooCodeEventName.ProviderProfileChanged, {
+				name: currentApiConfigName ?? "default",
+				provider: task.apiConfiguration.apiProvider,
+			})
+		}
+	}
+
+	private getActiveConversationSummaries(): ActiveConversationSummary[] {
+		const taskByRoot = new Map<string, Task>()
+
+		for (const task of this.clineStack) {
+			const rootTaskId = this.getRootTaskId(task)
+			const existing = taskByRoot.get(rootTaskId)
+
+			if (!existing || this.getTaskActivityTs(task) >= this.getTaskActivityTs(existing)) {
+				taskByRoot.set(rootTaskId, task)
+			}
+		}
+
+		return Array.from(taskByRoot.values())
+			.map((task) => {
+				const rootTaskId = this.getRootTaskId(task)
+				const rootTaskItem = this.taskHistoryStore.get(rootTaskId)
+				const activeTaskItem = this.taskHistoryStore.get(task.taskId)
+				const taskMetadata = task.metadata
+				const queuedMessages = task.queuedMessages ?? []
+				const steerMessageCount = queuedMessages.filter(
+					(message) => (message as { deliveryMode?: string }).deliveryMode === "steer",
+				).length
+
+				return {
+					rootTaskId,
+					activeTaskId: task.taskId,
+					rootTask: rootTaskItem?.task ?? activeTaskItem?.task ?? taskMetadata?.task ?? rootTaskId,
+					activeTask: activeTaskItem?.task ?? taskMetadata?.task ?? rootTaskItem?.task ?? task.taskId,
+					ts: this.getTaskActivityTs(task),
+					status: task.taskStatus ?? "running",
+					parentTaskId: task.parentTaskId,
+					queuedMessageCount: queuedMessages.length,
+					steerMessageCount,
+				} satisfies ActiveConversationSummary
+			})
+			.sort((a, b) => {
+				if (a.activeTaskId === this.visibleTaskId) {
+					return -1
+				}
+				if (b.activeTaskId === this.visibleTaskId) {
+					return 1
+				}
+				return b.ts - a.ts
+			})
+	}
+
+	private postActiveConversationsStateToWebview(): void {
+		const taskStateSeq = ++this.clineMessagesSeq
+		this.postMessageToWebview({
+			type: "state",
+			state: {
+				clineMessagesSeq: taskStateSeq,
+				activeConversations: this.getActiveConversationSummaries(),
+			},
+		})
+	}
+
+	private scheduleActiveConversationsStateToWebview(options: { immediate?: boolean } = {}): void {
+		if (this._disposed) {
+			return
+		}
+
+		const flush = () => {
+			this.activeConversationsUpdateTimer = null
+			if (!this._disposed) {
+				this.postActiveConversationsStateToWebview()
+			}
+		}
+
+		if (options.immediate) {
+			if (this.activeConversationsUpdateTimer) {
+				clearTimeout(this.activeConversationsUpdateTimer)
+				this.activeConversationsUpdateTimer = null
+			}
+			flush()
+			return
+		}
+
+		if (!this.activeConversationsUpdateTimer) {
+			this.activeConversationsUpdateTimer = setTimeout(
+				flush,
+				ClineProvider.ACTIVE_CONVERSATIONS_UPDATE_DEBOUNCE_MS,
+			)
+		}
+	}
+
+	public async selectTask(taskId?: string, options?: { broadcast?: boolean }): Promise<void> {
+		const { broadcast = true } = options ?? {}
+		const previousTask = this.getTaskById(this.visibleTaskId)
+		const nextTask = this.getTaskById(taskId)
+		const nextSelectionCleared = taskId === undefined && nextTask === undefined
+
+		if (previousTask?.taskId === nextTask?.taskId && this.hasExplicitTaskSelectionClear === nextSelectionCleared) {
+			if (broadcast) {
+				if (nextTask) {
+					await this.syncVisibleTaskContext(nextTask)
+				}
+				await this.postStateToWebviewWithoutTaskHistory()
+			}
+			return
+		}
+
+		if (previousTask) {
+			previousTask.emit(RooCodeEventName.TaskUnfocused)
+		}
+
+		this.visibleTaskId = nextTask?.taskId
+		this.hasExplicitTaskSelectionClear = nextSelectionCleared
+
+		if (nextTask) {
+			await this.syncVisibleTaskContext(nextTask)
+			nextTask.emit(RooCodeEventName.TaskFocused)
+		}
+
+		if (broadcast) {
+			await this.postStateToWebviewWithoutTaskHistory()
+		}
+	}
+
+	public async postTaskStateToWebview(taskId: string): Promise<void> {
+		if (this.isTaskVisible(taskId)) {
+			await this.postStateToWebviewWithoutTaskHistory()
+			return
+		}
+		this.scheduleActiveConversationsStateToWebview({ immediate: true })
+	}
+
+	public async postTaskMessageToWebview(taskId: string, message: ExtensionMessage): Promise<void> {
+		if (this.isTaskVisible(taskId)) {
+			await this.postMessageToWebview(message)
+			return
+		}
+		this.scheduleActiveConversationsStateToWebview()
 	}
 
 	/**
@@ -403,11 +634,11 @@ export class ClineProvider
 	// The instance is pushed to the top of the stack (LIFO order).
 	// When the task is completed, the top instance is removed, reactivating the
 	// previous task.
-	async addClineToStack(task: Task) {
+	async addClineToStack(task: Task, options?: { focus?: boolean }) {
+		const { focus = true } = options ?? {}
 		// Add this cline instance into the stack that represents the order of
 		// all the called tasks.
 		this.clineStack.push(task)
-		task.emit(RooCodeEventName.TaskFocused)
 
 		// Perform special setup provider specific tasks.
 		await this.performPreparationTasks(task)
@@ -417,6 +648,12 @@ export class ClineProvider
 
 		if (!state || typeof state.mode !== "string") {
 			throw new Error(t("common:errors.retrieve_current_mode"))
+		}
+
+		if (focus) {
+			await this.selectTask(task.taskId, { broadcast: false })
+		} else if (this.isViewLaunched) {
+			await this.postStateToWebviewWithoutClineMessages()
 		}
 	}
 
@@ -438,23 +675,34 @@ export class ClineProvider
 		}
 	}
 
-	// Removes and destroys the top Cline instance (the current finished task),
-	// activating the previous one (resuming the parent task).
-	async removeClineFromStack(options?: { skipDelegationRepair?: boolean }) {
+	// Removes and destroys an active Task instance.
+	async removeClineFromStack(options?: { skipDelegationRepair?: boolean; taskId?: string; broadcast?: boolean }) {
 		if (this.clineStack.length === 0) {
 			return
 		}
 
-		// Pop the top Cline instance from the stack.
-		let task = this.clineStack.pop()
+		const { broadcast = true } = options ?? {}
+		const taskIdToRemove =
+			options?.taskId ?? this.visibleTaskId ?? this.clineStack[this.clineStack.length - 1]?.taskId
+		const taskIndex = this.clineStack.findIndex((task) => task.taskId === taskIdToRemove)
+
+		if (taskIndex === -1) {
+			return
+		}
+
+		let task: Task | undefined = this.clineStack.splice(taskIndex, 1)[0]
 
 		if (task) {
 			// Capture delegation metadata before abort/dispose, since abortTask(true)
 			// is async and the task reference is cleared afterwards.
 			const childTaskId = task.taskId
 			const parentTaskId = task.parentTaskId
+			const wasVisible = this.visibleTaskId === childTaskId
 
-			task.emit(RooCodeEventName.TaskUnfocused)
+			if (wasVisible) {
+				this.visibleTaskId = undefined
+				task.emit(RooCodeEventName.TaskUnfocused)
+			}
 
 			try {
 				// Abort the running task and set isAbandoned to true so
@@ -479,7 +727,7 @@ export class ClineProvider
 			task = undefined
 
 			// Delegation-aware parent metadata repair:
-			// If the popped task was a delegated child, repair the parent's metadata
+			// If the removed task was a delegated child, repair the parent's metadata
 			// so it transitions from "delegated" back to "active" and becomes resumable
 			// from the task history list.
 			// Skip when called from delegateParentAndOpenChild() during nested delegation
@@ -500,12 +748,21 @@ export class ClineProvider
 						)
 					}
 				} catch (err) {
-					// Non-fatal: log but do not block the pop operation.
+					// Non-fatal: log but do not block the removal operation.
 					this.log(
 						`[ClineProvider#removeClineFromStack] Failed to repair parent metadata for ${parentTaskId} (non-fatal): ${
 							err instanceof Error ? err.message : String(err)
 						}`,
 					)
+				}
+			}
+
+			if (broadcast) {
+				if (wasVisible) {
+					const fallbackTaskId = this.clineStack[this.clineStack.length - 1]?.taskId
+					await this.selectTask(fallbackTaskId)
+				} else {
+					await this.postStateToWebviewWithoutClineMessages()
 				}
 			}
 		}
@@ -896,126 +1153,92 @@ export class ClineProvider
 
 	public async createTaskWithHistoryItem(
 		historyItem: HistoryItem & { rootTask?: Task; parentTask?: Task },
-		options?: { startTask?: boolean },
+		options?: { startTask?: boolean; replaceExistingTask?: boolean; focus?: boolean },
 	) {
 		const isCliRuntime = process.env.ROO_CLI_RUNTIME === "1"
 		// CLI injects runtime provider settings from command flags/env at startup.
 		// Restoring provider profiles from task history can overwrite those
 		// runtime settings with stale/incomplete persisted profiles.
 		const skipProfileRestoreFromHistory = isCliRuntime
+		const { startTask = true, replaceExistingTask = false, focus = true } = options ?? {}
+		const existingTask = this.getTaskById(historyItem.id)
 
-		// Check if we're rehydrating the current task to avoid flicker
-		const currentTask = this.getCurrentTask()
-		const isRehydratingCurrentTask = currentTask && currentTask.taskId === historyItem.id
-
-		if (!isRehydratingCurrentTask) {
-			await this.removeClineFromStack()
+		if (existingTask && !replaceExistingTask) {
+			if (focus) {
+				await this.selectTask(existingTask.taskId)
+			}
+			return existingTask
 		}
 
-		// If the history item has a saved mode, restore it and its associated API configuration.
 		if (historyItem.mode) {
-			// Validate that the mode still exists
 			const customModes = await this.customModesManager.getCustomModes()
 			const modeExists = getModeBySlug(historyItem.mode, customModes) !== undefined
 
 			if (!modeExists) {
-				// Mode no longer exists, fall back to default mode.
 				this.log(
 					`Mode '${historyItem.mode}' from history no longer exists. Falling back to default mode '${defaultModeSlug}'.`,
 				)
 				historyItem.mode = defaultModeSlug
 			}
-
-			await this.updateGlobalState("mode", historyItem.mode)
-
-			// Load the saved API config for the restored mode if it exists.
-			// Skip mode-based profile activation if historyItem.apiConfigName exists,
-			// since the task's specific provider profile will override it anyway.
-			const lockApiConfigAcrossModes = this.context.workspaceState.get("lockApiConfigAcrossModes", false)
-
-			if (!historyItem.apiConfigName && !lockApiConfigAcrossModes && !skipProfileRestoreFromHistory) {
-				const savedConfigId = await this.providerSettingsManager.getModeConfigId(historyItem.mode)
-				const listApiConfig = await this.providerSettingsManager.listConfig()
-
-				// Update listApiConfigMeta first to ensure UI has latest data.
-				await this.updateGlobalState("listApiConfigMeta", listApiConfig)
-
-				// If this mode has a saved config, use it.
-				if (savedConfigId) {
-					const profile = listApiConfig.find(({ id }) => id === savedConfigId)
-
-					if (profile?.name) {
-						try {
-							// Check if the profile has actual API configuration (not just an id).
-							// In CLI mode, the ProviderSettingsManager may return empty default profiles
-							// that only contain 'id' and 'name' fields. Activating such a profile would
-							// overwrite the CLI's working API configuration with empty settings.
-							const fullProfile = await this.providerSettingsManager.getProfile({ name: profile.name })
-							const hasActualSettings = !!fullProfile.apiProvider
-
-							if (hasActualSettings) {
-								await this.activateProviderProfile({ name: profile.name })
-							} else {
-								// The task will continue with the current/default configuration.
-							}
-						} catch (error) {
-							// Log the error but continue with task restoration.
-							this.log(
-								`Failed to restore API configuration for mode '${historyItem.mode}': ${
-									error instanceof Error ? error.message : String(error)
-								}. Continuing with default configuration.`,
-							)
-							// The task will continue with the current/default configuration.
-						}
-					}
-				}
-			}
 		}
 
-		// If the history item has a saved API config name (provider profile), restore it.
-		// This overrides any mode-based config restoration above, because the task's
-		// specific provider profile takes precedence over mode defaults.
-		if (historyItem.apiConfigName && !skipProfileRestoreFromHistory) {
-			const listApiConfig = await this.providerSettingsManager.listConfig()
-			// Keep global state/UI in sync with latest profiles for parity with mode restoration above.
-			await this.updateGlobalState("listApiConfigMeta", listApiConfig)
-			const profile = listApiConfig.find(({ name }) => name === historyItem.apiConfigName)
-
-			if (profile?.name) {
-				try {
-					await this.activateProviderProfile(
-						{ name: profile.name },
-						{ persistModeConfig: false, persistTaskHistory: false },
-					)
-				} catch (error) {
-					// Log the error but continue with task restoration.
-					this.log(
-						`Failed to restore API configuration '${historyItem.apiConfigName}' for task: ${
-							error instanceof Error ? error.message : String(error)
-						}. Continuing with current configuration.`,
-					)
-				}
-			} else {
-				// Profile no longer exists, log warning but continue
-				this.log(
-					`Provider profile '${historyItem.apiConfigName}' from history no longer exists. Using current configuration.`,
-				)
-			}
-		} else if (historyItem.apiConfigName && skipProfileRestoreFromHistory) {
+		if (historyItem.apiConfigName && skipProfileRestoreFromHistory) {
 			this.log(
 				`Skipping restore of provider profile '${historyItem.apiConfigName}' for task ${historyItem.id} in CLI runtime.`,
 			)
 		}
 
-		const { apiConfiguration, enableCheckpoints, checkpointTimeout, experiments, cloudUserInfo, taskSyncEnabled } =
-			await this.getState()
+		const { apiConfiguration, enableCheckpoints, checkpointTimeout, experiments } = await this.getState()
+		const listApiConfig = await this.providerSettingsManager.listConfig()
+		const lockApiConfigAcrossModes = this.context.workspaceState.get("lockApiConfigAcrossModes", false)
+		await this.updateGlobalState("listApiConfigMeta", listApiConfig)
+
+		let restoredApiConfiguration = apiConfiguration
+		let restoredApiConfigName = historyItem.apiConfigName
+
+		if (!skipProfileRestoreFromHistory) {
+			let profileNameToRestore = historyItem.apiConfigName
+
+			if (!profileNameToRestore && historyItem.mode && !lockApiConfigAcrossModes) {
+				const savedConfigId = await this.providerSettingsManager.getModeConfigId(historyItem.mode)
+				profileNameToRestore = listApiConfig.find(({ id }) => id === savedConfigId)?.name
+			}
+
+			if (profileNameToRestore) {
+				const profile = listApiConfig.find(({ name }) => name === profileNameToRestore)
+
+				if (profile?.name) {
+					try {
+						const {
+							id: _profileId,
+							name: _profileName,
+							...providerSettings
+						} = await this.providerSettingsManager.getProfile({ name: profile.name })
+						if (providerSettings.apiProvider) {
+							restoredApiConfiguration = providerSettings
+							restoredApiConfigName = profile.name
+						}
+					} catch (error) {
+						this.log(
+							`Failed to restore API configuration '${profile.name}' for task ${historyItem.id}: ${
+								error instanceof Error ? error.message : String(error)
+							}. Continuing with current configuration.`,
+						)
+					}
+				} else if (historyItem.apiConfigName) {
+					this.log(
+						`Provider profile '${historyItem.apiConfigName}' from history no longer exists. Using current configuration.`,
+					)
+				}
+			}
+		}
 
 		const task = new Task({
 			provider: this,
-			apiConfiguration,
+			apiConfiguration: restoredApiConfiguration,
 			enableCheckpoints,
 			checkpointTimeout,
-			consecutiveMistakeLimit: apiConfiguration.consecutiveMistakeLimit,
+			consecutiveMistakeLimit: restoredApiConfiguration.consecutiveMistakeLimit,
 			historyItem,
 			experiments,
 			rootTask: historyItem.rootTask,
@@ -1023,17 +1246,28 @@ export class ClineProvider
 			taskNumber: historyItem.number,
 			workspacePath: historyItem.workspace,
 			onCreated: this.taskCreationCallback,
-			startTask: options?.startTask ?? true,
+			startTask,
 			// Preserve the status from the history item to avoid overwriting it when the task saves messages
 			initialStatus: historyItem.status,
 		})
+		if (typeof task.setTaskApiConfigName === "function") {
+			task.setTaskApiConfigName(restoredApiConfigName)
+		} else {
+			;(task as any)._taskApiConfigName = restoredApiConfigName
+			;(task as any).taskApiConfigName = restoredApiConfigName
+		}
+		if (typeof task.getTaskMode !== "function") {
+			;(task as any)._taskMode = historyItem.mode ?? defaultModeSlug
+			;(task as any).taskMode = historyItem.mode ?? defaultModeSlug
+		}
 
-		if (isRehydratingCurrentTask) {
+		if (existingTask && replaceExistingTask) {
 			// Replace the current task in-place to avoid UI flicker
-			const stackIndex = this.clineStack.length - 1
+			const stackIndex = this.clineStack.findIndex((candidate) => candidate.taskId === existingTask.taskId)
 
 			// Properly dispose of the old task to ensure garbage collection
 			const oldTask = this.clineStack[stackIndex]
+			const wasVisible = this.visibleTaskId === oldTask?.taskId
 
 			// Abort the old task to stop running processes and mark as abandoned
 			try {
@@ -1053,16 +1287,21 @@ export class ClineProvider
 
 			// Replace the task in the stack
 			this.clineStack[stackIndex] = task
-			task.emit(RooCodeEventName.TaskFocused)
 
 			// Perform preparation tasks and set up event listeners
 			await this.performPreparationTasks(task)
+
+			if (focus || wasVisible) {
+				await this.selectTask(task.taskId, { broadcast: false })
+			} else if (this.isViewLaunched) {
+				await this.postStateToWebviewWithoutClineMessages()
+			}
 
 			this.log(
 				`[createTaskWithHistoryItem] rehydrated task ${task.taskId}.${task.instanceId} in-place (flicker-free)`,
 			)
 		} else {
-			await this.addClineToStack(task)
+			await this.addClineToStack(task, { focus })
 
 			this.log(
 				`[createTaskWithHistoryItem] ${task.parentTask ? "child" : "parent"} task ${task.taskId}.${task.instanceId} instantiated`,
@@ -1778,10 +2017,12 @@ export class ClineProvider
 	}
 
 	async showTaskWithId(id: string) {
-		if (id !== this.getCurrentTask()?.taskId) {
-			// Non-current task.
+		const activeTask = this.getTaskById(id)
+		if (activeTask) {
+			await this.selectTask(activeTask.taskId)
+		} else if (id !== this.getCurrentTask()?.taskId) {
 			const { historyItem } = await this.getTaskWithId(id)
-			await this.createTaskWithHistoryItem(historyItem) // Clears existing task.
+			await this.createTaskWithHistoryItem(historyItem)
 		}
 
 		await this.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
@@ -1811,10 +2052,14 @@ export class ClineProvider
 			}
 		}
 		if (!task) {
+			await this.postMessageToWebview({ type: "condenseTaskContextResponse", text: taskId })
 			throw new Error(`Task with id ${taskId} not found in stack`)
 		}
-		await task.condenseContext()
-		await this.postMessageToWebview({ type: "condenseTaskContextResponse", text: taskId })
+		try {
+			await task.condenseContext()
+		} finally {
+			await this.postMessageToWebview({ type: "condenseTaskContextResponse", text: taskId })
+		}
 	}
 
 	// this function deletes a task from task history, and deletes its checkpoints and delete the task folder
@@ -1847,13 +2092,19 @@ export class ClineProvider
 				await collectChildIds(id)
 			}
 
-			// Remove from stack if any of the tasks to delete are in the current task stack
-			for (const taskId of allIdsToDelete) {
-				if (taskId === this.getCurrentTask()?.taskId) {
-					// Close the current task instance; delegation flows will be handled via metadata if applicable.
-					await this.removeClineFromStack()
-					break
-				}
+			// Remove any live instances for tasks being deleted, not just the currently visible one.
+			const liveTaskIdsToDelete = this.clineStack
+				.filter((task) => allIdsToDelete.includes(task.taskId))
+				.map((task) => task.taskId)
+			const removedVisibleTask =
+				this.visibleTaskId !== undefined && liveTaskIdsToDelete.includes(this.visibleTaskId)
+
+			for (const taskId of liveTaskIdsToDelete) {
+				await this.removeClineFromStack({ taskId, broadcast: false })
+			}
+
+			if (removedVisibleTask) {
+				await this.selectTask(this.clineStack[this.clineStack.length - 1]?.taskId, { broadcast: false })
 			}
 
 			// Delete all tasks from state in one batch
@@ -2219,6 +2470,7 @@ export class ClineProvider
 			uriScheme: vscode.env.uriScheme,
 			currentTaskId: currentTask?.taskId,
 			currentTaskItem: currentTask?.taskId ? this.taskHistoryStore.get(currentTask.taskId) : undefined,
+			activeConversations: this.getActiveConversationSummaries(),
 			clineMessages: currentTask?.clineMessages || [],
 			currentTaskTodos: currentTask?.todoList || [],
 			messageQueue: currentTask?.messageQueueService?.messages,
@@ -2765,11 +3017,28 @@ export class ClineProvider
 	 */
 
 	public getCurrentTask(): Task | undefined {
+		const visibleTask = this.getTaskById(this.visibleTaskId)
+		if (visibleTask) {
+			return visibleTask
+		}
+
+		if (this.hasExplicitTaskSelectionClear) {
+			return undefined
+		}
+
 		if (this.clineStack.length === 0) {
 			return undefined
 		}
 
 		return this.clineStack[this.clineStack.length - 1]
+	}
+
+	public resolveMessageTask(taskId?: string): Task | undefined {
+		if (taskId !== undefined && taskId !== "") {
+			return this.getTaskById(taskId)
+		}
+
+		return this.getCurrentTask()
 	}
 
 	public getRecentTasks(): string[] {
@@ -2873,18 +3142,12 @@ export class ClineProvider
 		const { apiConfiguration, organizationAllowList, enableCheckpoints, checkpointTimeout, experiments } =
 			await this.getState()
 
-		// Single-open-task invariant: always enforce for user-initiated top-level tasks
-		if (!parentTask) {
-			try {
-				await this.removeClineFromStack()
-			} catch {
-				// Non-fatal
-			}
-		}
-
 		if (!ProfileValidator.isProfileAllowed(apiConfiguration, organizationAllowList)) {
 			throw new OrganizationAllowListViolationError(t("common:errors.violated_organization_allowlist"))
 		}
+
+		const resolvedParentTask = parentTask as Task | undefined
+		const rootTask = resolvedParentTask ? (resolvedParentTask.rootTask ?? resolvedParentTask) : undefined
 
 		const task = new Task({
 			provider: this,
@@ -2895,9 +3158,9 @@ export class ClineProvider
 			task: text,
 			images,
 			experiments,
-			rootTask: this.clineStack.length > 0 ? this.clineStack[0] : undefined,
-			parentTask,
-			taskNumber: this.clineStack.length + 1,
+			rootTask,
+			parentTask: resolvedParentTask,
+			taskNumber: this.taskHistoryStore.getAll().length + 1,
 			onCreated: this.taskCreationCallback,
 			initialTodos: options.initialTodos,
 			// Ensure this task is present in clineStack before startTask() emits
@@ -2906,7 +3169,7 @@ export class ClineProvider
 			...options,
 		})
 
-		await this.addClineToStack(task)
+		await this.addClineToStack(task, { focus: options.focus ?? true })
 		task.start()
 
 		this.log(
@@ -2916,14 +3179,15 @@ export class ClineProvider
 		return task
 	}
 
-	public async cancelTask(): Promise<void> {
-		const task = this.getCurrentTask()
+	public async cancelTask(taskId?: string): Promise<void> {
+		const task = this.resolveMessageTask(taskId)
 
 		if (!task) {
 			return
 		}
 
 		console.log(`[cancelTask] cancelling task ${task.taskId}.${task.instanceId}`)
+		const wasVisible = this.isTaskVisible(task.taskId)
 
 		let historyItem: HistoryItem | undefined
 		try {
@@ -2962,13 +3226,13 @@ export class ClineProvider
 
 		await pWaitFor(
 			() =>
-				this.getCurrentTask()! === undefined ||
-				this.getCurrentTask()!.isStreaming === false ||
-				this.getCurrentTask()!.didFinishAbortingStream ||
+				this.getTaskById(task.taskId) === undefined ||
+				task.isStreaming === false ||
+				task.didFinishAbortingStream ||
 				// If only the first chunk is processed, then there's no
 				// need to wait for graceful abort (closes edits, browser,
 				// etc).
-				this.getCurrentTask()!.isWaitingForFirstChunk,
+				task.isWaitingForFirstChunk,
 			{
 				timeout: 3_000,
 			},
@@ -2977,7 +3241,7 @@ export class ClineProvider
 		})
 
 		// Defensive safeguard: if current instance already changed, skip rehydrate
-		const current = this.getCurrentTask()
+		const current = this.getTaskById(task.taskId)
 		if (current && current.instanceId !== originalInstanceId) {
 			this.log(
 				`[cancelTask] Skipping rehydrate: current instance ${current.instanceId} != original ${originalInstanceId}`,
@@ -2987,7 +3251,7 @@ export class ClineProvider
 
 		// Final race check before rehydrate to avoid duplicate rehydration
 		{
-			const currentAfterCheck = this.getCurrentTask()
+			const currentAfterCheck = this.getTaskById(task.taskId)
 			if (currentAfterCheck && currentAfterCheck.instanceId !== originalInstanceId) {
 				this.log(
 					`[cancelTask] Skipping rehydrate after final check: current instance ${currentAfterCheck.instanceId} != original ${originalInstanceId}`,
@@ -3001,16 +3265,19 @@ export class ClineProvider
 		}
 
 		// Clears task again, so we need to abortTask manually above.
-		await this.createTaskWithHistoryItem({ ...historyItem, rootTask, parentTask })
+		await this.createTaskWithHistoryItem(
+			{ ...historyItem, rootTask, parentTask },
+			{ replaceExistingTask: true, focus: wasVisible },
+		)
 	}
 
 	// Clear the current task without treating it as a subtask.
 	// This is used when the user cancels a task that is not a subtask.
 	public async clearTask(): Promise<void> {
-		if (this.clineStack.length > 0) {
-			const task = this.clineStack[this.clineStack.length - 1]
+		const task = this.getCurrentTask()
+		if (task) {
 			console.log(`[clearTask] clearing task ${task.taskId}.${task.instanceId}`)
-			await this.removeClineFromStack()
+			await this.selectTask(undefined)
 		}
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.flicker-free-cancel.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.flicker-free-cancel.spec.ts
@@ -173,7 +173,15 @@ describe("ClineProvider flicker-free cancel", () => {
 			instanceId: "instance-1",
 			emit: vi.fn(),
 			abortTask: vi.fn().mockResolvedValue(undefined),
+			cancelCurrentRequest: vi.fn(),
+			cancelAutoApprovalTimeout: vi.fn(),
+			supersedePendingAsk: vi.fn(),
+			messageQueueService: { messages: [] },
+			terminalProcess: { abort: vi.fn() },
+			rootTask: undefined,
+			parentTask: undefined,
 			abandoned: false,
+			abort: false,
 			dispose: vi.fn(),
 			on: vi.fn(),
 			off: vi.fn(),
@@ -188,10 +196,12 @@ describe("ClineProvider flicker-free cancel", () => {
 		}
 
 		// Mock Task constructor
-		vi.mocked(Task).mockImplementation(() => mockTask2 as any)
+		vi.mocked(Task).mockImplementation(function () {
+			return mockTask2 as any
+		})
 	})
 
-	it("should not remove current task from stack when rehydrating same taskId", async () => {
+	it("should reuse the current task instance when reopening the same taskId without replacement", async () => {
 		// Setup: Add a task to the stack first
 		;(provider as any).clineStack = [mockTask1]
 
@@ -215,30 +225,33 @@ describe("ClineProvider flicker-free cancel", () => {
 			workspace: "/test/workspace",
 		}
 
-		// Act: Create task with history item (should rehydrate in-place)
-		await provider.createTaskWithHistoryItem(historyItem)
+		// Act: Reopen the same task ID without forcing replacement
+		const task = await provider.createTaskWithHistoryItem(historyItem)
 
 		// Assert: removeClineFromStack should NOT be called
 		expect(removeClineFromStackSpy).not.toHaveBeenCalled()
 
-		// Verify the task was replaced in-place
+		// Verify the existing task instance was reused
+		expect(task).toBe(mockTask1)
 		expect((provider as any).clineStack).toHaveLength(1)
-		expect((provider as any).clineStack[0]).toBe(mockTask2)
+		expect((provider as any).clineStack[0]).toBe(mockTask1)
 
-		// Verify old event listeners were cleaned up
-		expect(mockCleanupFunctions[0]).toHaveBeenCalled()
-		expect(mockCleanupFunctions[1]).toHaveBeenCalled()
+		// No replacement means no cleanup or fresh Task construction
+		expect(mockCleanupFunctions[0]).not.toHaveBeenCalled()
+		expect(mockCleanupFunctions[1]).not.toHaveBeenCalled()
+		expect(Task).not.toHaveBeenCalled()
 
-		// Verify new task received focus event
-		expect(mockTask2.emit).toHaveBeenCalledWith("taskFocused")
+		// Verify the existing task received focus
+		expect(mockTask1.emit).toHaveBeenCalledWith("taskFocused")
 	})
 
-	it("should remove task from stack when creating different task", async () => {
+	it("should append a different task without removing the existing stack", async () => {
 		// Setup: Add a task to the stack first
 		;(provider as any).clineStack = [mockTask1]
 
-		// Spy on removeClineFromStack to verify it IS called
+		// Spy on removeClineFromStack to verify it is NOT called
 		const removeClineFromStackSpy = vi.spyOn(provider, "removeClineFromStack").mockResolvedValue(undefined)
+		mockTask2.taskId = "task-2"
 
 		// Create history item with different taskId
 		const historyItem: HistoryItem = {
@@ -253,13 +266,17 @@ describe("ClineProvider flicker-free cancel", () => {
 		}
 
 		// Act: Create task with different history item
-		await provider.createTaskWithHistoryItem(historyItem)
+		const task = await provider.createTaskWithHistoryItem(historyItem)
 
-		// Assert: removeClineFromStack should be called
-		expect(removeClineFromStackSpy).toHaveBeenCalled()
+		// Assert: multi-conversation restore keeps both tasks alive
+		expect(removeClineFromStackSpy).not.toHaveBeenCalled()
+		expect(task).toBe(mockTask2)
+		expect((provider as any).clineStack).toHaveLength(2)
+		expect((provider as any).clineStack[0]).toBe(mockTask1)
+		expect((provider as any).clineStack[1]).toBe(mockTask2)
 	})
 
-	it("should handle empty stack gracefully during rehydration attempt", async () => {
+	it("should handle empty stack gracefully during task creation", async () => {
 		// Setup: Empty stack
 		;(provider as any).clineStack = []
 
@@ -278,14 +295,17 @@ describe("ClineProvider flicker-free cancel", () => {
 			workspace: "/test/workspace",
 		}
 
-		// Act: Should not error and should call removeClineFromStack
-		await provider.createTaskWithHistoryItem(historyItem)
+		// Act: Should create a fresh task without trying to remove anything
+		const task = await provider.createTaskWithHistoryItem(historyItem)
 
-		// Assert: removeClineFromStack should be called (no current task to rehydrate)
-		expect(removeClineFromStackSpy).toHaveBeenCalled()
+		// Assert: removeClineFromStack should not be called
+		expect(removeClineFromStackSpy).not.toHaveBeenCalled()
+		expect(task).toBe(mockTask2)
+		expect((provider as any).clineStack).toHaveLength(1)
+		expect((provider as any).clineStack[0]).toBe(mockTask2)
 	})
 
-	it("should maintain task stack integrity during flicker-free replacement", async () => {
+	it("should replace the matching task in-place when replacement is explicitly requested", async () => {
 		// Setup: Stack with multiple tasks
 		const mockParentTask = {
 			taskId: "parent-task",
@@ -295,9 +315,10 @@ describe("ClineProvider flicker-free cancel", () => {
 
 		;(provider as any).clineStack = [mockParentTask, mockTask1]
 		;(provider as any).taskEventListeners = new WeakMap()
-		;(provider as any).taskEventListeners.set(mockTask1, [vi.fn()])
+		const cleanup = vi.fn()
+		;(provider as any).taskEventListeners.set(mockTask1, [cleanup])
 
-		// Act: Rehydrate the current (top) task
+		// Act: Rehydrate the current (top) task with explicit replacement
 		const historyItem: HistoryItem = {
 			id: "task-1",
 			number: 1,
@@ -309,11 +330,15 @@ describe("ClineProvider flicker-free cancel", () => {
 			workspace: "/test/workspace",
 		}
 
-		await provider.createTaskWithHistoryItem(historyItem)
+		const removeClineFromStackSpy = vi.spyOn(provider, "removeClineFromStack").mockResolvedValue(undefined)
+		await provider.createTaskWithHistoryItem(historyItem, { replaceExistingTask: true })
 
 		// Assert: Stack should maintain parent task and replace current task
+		expect(removeClineFromStackSpy).not.toHaveBeenCalled()
 		expect((provider as any).clineStack).toHaveLength(2)
 		expect((provider as any).clineStack[0]).toBe(mockParentTask)
 		expect((provider as any).clineStack[1]).toBe(mockTask2)
+		expect(mockTask1.abortTask).toHaveBeenCalledWith(true)
+		expect(cleanup).toHaveBeenCalled()
 	})
 })

--- a/src/core/webview/__tests__/ClineProvider.flicker-free-cancel.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.flicker-free-cancel.spec.ts
@@ -193,6 +193,8 @@ describe("ClineProvider flicker-free cancel", () => {
 			emit: vi.fn(),
 			on: vi.fn(),
 			off: vi.fn(),
+			messageQueueService: { restoreMessages: vi.fn() },
+			setDeferQueuedMessageDrainUntilResume: vi.fn(),
 		}
 
 		// Mock Task constructor
@@ -340,5 +342,25 @@ describe("ClineProvider flicker-free cancel", () => {
 		expect((provider as any).clineStack[1]).toBe(mockTask2)
 		expect(mockTask1.abortTask).toHaveBeenCalledWith(true)
 		expect(cleanup).toHaveBeenCalled()
+	})
+
+	it("restores queued messages on the replacement task after cancel", async () => {
+		const queuedMessage = {
+			id: "queued-1",
+			text: "follow-up while streaming",
+			images: ["image-1.png"],
+			timestamp: 123,
+			createdAt: 123,
+			updatedAt: 123,
+			deliveryMode: "steer" as const,
+		}
+
+		mockTask1.messageQueueService = { messages: [queuedMessage] }
+		;(provider as any).clineStack = [mockTask1]
+
+		await provider.cancelTask("task-1")
+
+		expect(mockTask2.messageQueueService.restoreMessages).toHaveBeenCalledWith([queuedMessage])
+		expect(mockTask2.setDeferQueuedMessageDrainUntilResume).toHaveBeenCalledWith(true)
 	})
 })

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -1743,6 +1743,7 @@ describe("ClineProvider", () => {
 				getModeConfigId: vi.fn().mockResolvedValue(undefined),
 				listConfig: vi.fn().mockResolvedValue([]),
 			}
+			const logSpy = vi.spyOn(provider, "log")
 
 			// Create history item without mode
 			const historyItem = {
@@ -1756,11 +1757,12 @@ describe("ClineProvider", () => {
 				totalCost: 0,
 			}
 
-			// Initialize with history item
-			await provider.createTaskWithHistoryItem(historyItem)
+			// Initialize with history item without forcing a visible-task sync.
+			await provider.createTaskWithHistoryItem(historyItem, { focus: false })
 
-			// Verify no mode validation occurred (mode update not called)
-			expect(mockContext.globalState.update).not.toHaveBeenCalledWith("mode", expect.any(String))
+			// Verify no mode validation/fallback occurred.
+			expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("Falling back to default mode"))
+			expect(historyItem).not.toHaveProperty("mode")
 		})
 
 		test("continues with task restoration even if mode config loading fails", async () => {
@@ -1788,7 +1790,7 @@ describe("ClineProvider", () => {
 				listConfig: vi
 					.fn()
 					.mockResolvedValue([{ name: "test-config", id: "config-id", apiProvider: "anthropic" }]),
-				activateProfile: vi.fn().mockRejectedValue(new Error("Failed to load config")),
+				getProfile: vi.fn().mockRejectedValue(new Error("Failed to load config")),
 			}
 
 			// Spy on log method
@@ -1811,7 +1813,7 @@ describe("ClineProvider", () => {
 
 			// Verify error was logged but task restoration continued
 			expect(logSpy).toHaveBeenCalledWith(
-				expect.stringContaining("Failed to restore API configuration for mode 'code'"),
+				expect.stringContaining("Failed to restore API configuration 'test-config' for task test-id"),
 			)
 		})
 	})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -3244,13 +3244,21 @@ export const webviewMessageHandler = async (
 		 */
 
 		case "queueMessage": {
-			const resolved = await resolveIncomingImages({ text: message.text, images: message.images })
 			const targetTask = provider.resolveMessageTask(message.taskId)
 			if (!targetTask) {
+				await restoreDroppedInput(message.text, message.images)
+				break
+			}
+
+			const expectedTaskId = targetTask.taskId
+			const resolved = await resolveIncomingImages({ text: message.text, images: message.images })
+			const stillActive = provider.resolveMessageTask(expectedTaskId)
+			if (!stillActive || stillActive.taskId !== expectedTaskId) {
 				await restoreDroppedInput(resolved.text, resolved.images)
 				break
 			}
-			targetTask.messageQueueService.addMessage(resolved.text, resolved.images)
+
+			stillActive.messageQueueService.addMessage(resolved.text, resolved.images, message.deliveryMode ?? "queue")
 			break
 		}
 		case "removeQueuedMessage": {
@@ -3259,8 +3267,10 @@ export const webviewMessageHandler = async (
 		}
 		case "editQueuedMessage": {
 			if (message.payload) {
-				const { id, text, images } = message.payload as EditQueuedMessagePayload
-				provider.resolveMessageTask(message.taskId)?.messageQueueService.updateMessage(id, text, images)
+				const { id, text, images, deliveryMode } = message.payload as EditQueuedMessagePayload
+				provider
+					.resolveMessageTask(message.taskId)
+					?.messageQueueService.updateMessage(id, text, images, deliveryMode)
 			}
 
 			break

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -196,6 +196,21 @@ export const webviewMessageHandler = async (
 		})
 		return resolved
 	}
+
+	const restoreDroppedInput = async (text?: string, images?: string[]) => {
+		const restoredText = text ?? ""
+		const restoredImages = images ?? []
+		if (!restoredText && restoredImages.length === 0) {
+			return
+		}
+
+		await provider.postMessageToWebview({
+			type: "invoke",
+			invoke: "setChatBoxMessage",
+			text: restoredText,
+			images: restoredImages,
+		})
+	}
 	/**
 	 * Shared utility to find message indices based on timestamp.
 	 * When multiple messages share the same timestamp (e.g., after condense),
@@ -653,10 +668,25 @@ export const webviewMessageHandler = async (
 
 		case "askResponse":
 			{
+				const targetTask = provider.resolveMessageTask(message.taskId)
+				if (!targetTask) {
+					provider.log(
+						`[askResponse] dropped because target task ${message.taskId ?? "(current)"} is not active`,
+					)
+					await restoreDroppedInput(message.text, message.images)
+					break
+				}
+				const expectedTaskId = targetTask.taskId
 				const resolved = await resolveIncomingImages({ text: message.text, images: message.images })
-				provider
-					.getCurrentTask()
-					?.handleWebviewAskResponse(message.askResponse!, resolved.text, resolved.images)
+				const stillActive = provider.resolveMessageTask(expectedTaskId)
+				if (!stillActive || stillActive.taskId !== expectedTaskId) {
+					provider.log(
+						`[askResponse] dropped after image resolution because task ${expectedTaskId} is not active`,
+					)
+					await restoreDroppedInput(resolved.text, resolved.images)
+					break
+				}
+				stillActive.handleWebviewAskResponse(message.askResponse!, resolved.text, resolved.images)
 			}
 			break
 
@@ -760,7 +790,7 @@ export const webviewMessageHandler = async (
 
 		case "terminalOperation":
 			if (message.terminalOperation) {
-				provider.getCurrentTask()?.handleTerminalOperation(message.terminalOperation)
+				provider.resolveMessageTask(message.taskId)?.handleTerminalOperation(message.terminalOperation)
 			}
 			break
 		case "clearTask":
@@ -803,7 +833,13 @@ export const webviewMessageHandler = async (
 			provider.showTaskWithId(message.text!)
 			break
 		case "condenseTaskContextRequest":
-			provider.condenseTaskContext(message.text!)
+			provider.condenseTaskContext(message.text!).catch((error) => {
+				provider.log(
+					`[condenseTaskContextRequest] failed for task ${message.text}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				)
+			})
 			break
 		case "deleteTaskWithId":
 			provider.deleteTaskWithId(message.text!)
@@ -1263,7 +1299,7 @@ export const webviewMessageHandler = async (
 			break
 		}
 		case "cancelTask":
-			await provider.cancelTask()
+			await provider.cancelTask(message.taskId)
 			break
 		case "cancelAutoApproval":
 			// Cancel any pending auto-approval timeout for the current task
@@ -3209,17 +3245,22 @@ export const webviewMessageHandler = async (
 
 		case "queueMessage": {
 			const resolved = await resolveIncomingImages({ text: message.text, images: message.images })
-			provider.getCurrentTask()?.messageQueueService.addMessage(resolved.text, resolved.images)
+			const targetTask = provider.resolveMessageTask(message.taskId)
+			if (!targetTask) {
+				await restoreDroppedInput(resolved.text, resolved.images)
+				break
+			}
+			targetTask.messageQueueService.addMessage(resolved.text, resolved.images)
 			break
 		}
 		case "removeQueuedMessage": {
-			provider.getCurrentTask()?.messageQueueService.removeMessage(message.text ?? "")
+			provider.resolveMessageTask(message.taskId)?.messageQueueService.removeMessage(message.text ?? "")
 			break
 		}
 		case "editQueuedMessage": {
 			if (message.payload) {
 				const { id, text, images } = message.payload as EditQueuedMessagePayload
-				provider.getCurrentTask()?.messageQueueService.updateMessage(id, text, images)
+				provider.resolveMessageTask(message.taskId)?.messageQueueService.updateMessage(id, text, images)
 			}
 
 			break

--- a/webview-ui/src/components/chat/ActiveConversationList.tsx
+++ b/webview-ui/src/components/chat/ActiveConversationList.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState } from "react"
+import type { ActiveConversationSummary } from "@roo-code/types"
+import { Trash2 } from "lucide-react"
+
+import { Button, StandardTooltip } from "@src/components/ui"
+import { cn } from "@src/lib/utils"
+
+export interface ConversationListItem extends ActiveConversationSummary {
+	kind: "task" | "draft"
+}
+
+interface ActiveConversationListProps {
+	conversations: ConversationListItem[]
+	selectedConversationId?: string
+	onCreateConversation: () => void
+	onSelectConversation: (conversation: ConversationListItem) => void
+	onDeleteConversation: (conversation: ConversationListItem) => void
+}
+
+const STATUS_LABELS: Record<ActiveConversationSummary["status"], string> = {
+	running: "Running",
+	interactive: "Waiting",
+	resumable: "Paused",
+	idle: "Idle",
+	none: "Ready",
+}
+
+export default function ActiveConversationList({
+	conversations,
+	selectedConversationId,
+	onCreateConversation,
+	onSelectConversation,
+	onDeleteConversation,
+}: ActiveConversationListProps) {
+	const [contextMenu, setContextMenu] = useState<{
+		conversation: ConversationListItem
+		x: number
+		y: number
+	} | null>(null)
+
+	useEffect(() => {
+		if (!contextMenu) {
+			return
+		}
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				setContextMenu(null)
+			}
+		}
+
+		window.addEventListener("keydown", handleKeyDown)
+		return () => window.removeEventListener("keydown", handleKeyDown)
+	}, [contextMenu])
+
+	const contextMenuPosition = useMemo(() => {
+		if (!contextMenu) {
+			return undefined
+		}
+
+		const width = 176
+		const height = 52
+		const maxLeft = typeof window !== "undefined" ? Math.max(8, window.innerWidth - width - 8) : contextMenu.x
+		const maxTop = typeof window !== "undefined" ? Math.max(8, window.innerHeight - height - 8) : contextMenu.y
+
+		return {
+			left: Math.min(contextMenu.x, maxLeft),
+			top: Math.min(contextMenu.y, maxTop),
+		}
+	}, [contextMenu])
+
+	if (conversations.length === 0) {
+		return null
+	}
+
+	return (
+		<aside className="flex w-[220px] shrink-0 flex-col border-r border-vscode-editorGroup-border bg-vscode-sideBar-background/40">
+			<div className="flex items-center justify-between gap-2 border-b border-vscode-editorGroup-border px-3 py-2">
+				<div className="min-w-0">
+					<div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-vscode-descriptionForeground">
+						Conversations
+					</div>
+					<div className="text-xs text-vscode-descriptionForeground">{conversations.length} open</div>
+				</div>
+				<Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onCreateConversation}>
+					New
+				</Button>
+			</div>
+			<div className="min-h-0 flex-1 overflow-y-auto p-2">
+				<div className="flex flex-col gap-1">
+					{conversations.map((conversation) => {
+						const isActive = conversation.activeTaskId === selectedConversationId
+						const subtitle =
+							conversation.activeTaskId !== conversation.rootTaskId
+								? `${conversation.activeTask} · ${STATUS_LABELS[conversation.status]}`
+								: STATUS_LABELS[conversation.status]
+
+						return (
+							<div
+								key={conversation.activeTaskId}
+								role="button"
+								tabIndex={0}
+								aria-pressed={isActive}
+								onClick={() => {
+									setContextMenu(null)
+									onSelectConversation(conversation)
+								}}
+								onKeyDown={(event) => {
+									if (event.key === "Enter" || event.key === " ") {
+										event.preventDefault()
+										setContextMenu(null)
+										onSelectConversation(conversation)
+									}
+								}}
+								onContextMenu={(event) => {
+									event.preventDefault()
+									event.stopPropagation()
+									setContextMenu({
+										conversation,
+										x: event.clientX,
+										y: event.clientY,
+									})
+								}}
+								className={cn(
+									"group flex w-full cursor-pointer flex-col gap-1 rounded-lg border px-3 py-2 text-left transition-colors",
+									"border-transparent bg-transparent hover:border-vscode-focusBorder/40 hover:bg-vscode-list-hoverBackground focus:outline-none",
+									isActive &&
+										"border-vscode-focusBorder bg-vscode-list-activeSelectionBackground text-vscode-list-activeSelectionForeground",
+								)}>
+								<div className="flex items-start justify-between gap-2">
+									<div className="min-w-0 text-sm font-medium leading-5">
+										<div className="truncate">{conversation.rootTask}</div>
+									</div>
+									<div className="flex shrink-0 items-center gap-1">
+										{conversation.steerMessageCount > 0 && (
+											<span
+												className={cn(
+													"shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold",
+													isActive
+														? "border-vscode-focusBorder/70 bg-vscode-badge-background text-vscode-badge-foreground"
+														: "border-vscode-focusBorder/40 bg-vscode-badge-background/70 text-vscode-badge-foreground",
+												)}>
+												Steer
+											</span>
+										)}
+										{conversation.queuedMessageCount > 0 && (
+											<span
+												className={cn(
+													"shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+													isActive
+														? "bg-vscode-badge-background text-vscode-badge-foreground"
+														: "bg-vscode-badge-background/80 text-vscode-badge-foreground",
+												)}>
+												{conversation.queuedMessageCount}
+											</span>
+										)}
+									</div>
+								</div>
+								<div className="flex items-center justify-between gap-2">
+									<div
+										className={cn(
+											"min-w-0 text-xs leading-4",
+											isActive ? "opacity-80" : "text-vscode-descriptionForeground",
+										)}>
+										<div className="truncate">{subtitle}</div>
+									</div>
+									<StandardTooltip content="Delete">
+										<Button
+											variant="ghost"
+											size="icon"
+											aria-label="Delete conversation"
+											className={cn(
+												"h-6 w-6 shrink-0 rounded-md opacity-0 transition-opacity group-hover:opacity-100",
+												isActive && "opacity-70 group-hover:opacity-100",
+											)}
+											onClick={(event) => {
+												event.stopPropagation()
+												setContextMenu(null)
+												onDeleteConversation(conversation)
+											}}>
+											<Trash2 className="size-3.5" />
+										</Button>
+									</StandardTooltip>
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			</div>
+			{contextMenu && contextMenuPosition && (
+				<div
+					className="fixed inset-0 z-50"
+					onMouseDown={() => setContextMenu(null)}
+					onContextMenu={(event) => event.preventDefault()}>
+					<div
+						data-conversation-context-menu
+						className="absolute min-w-44 overflow-hidden rounded-md border border-vscode-focusBorder bg-vscode-dropdown-background p-1 text-vscode-dropdown-foreground shadow-lg"
+						style={contextMenuPosition}
+						onMouseDown={(event) => event.stopPropagation()}
+						onClick={(event) => event.stopPropagation()}>
+						<button
+							type="button"
+							className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-vscode-list-activeSelectionBackground hover:text-vscode-list-activeSelectionForeground"
+							onClick={() => {
+								onDeleteConversation(contextMenu.conversation)
+								setContextMenu(null)
+							}}>
+							<Trash2 className="size-4" />
+							Delete
+						</button>
+					</div>
+				</div>
+			)}
+		</aside>
+	)
+}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -703,7 +703,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				) {
 					try {
 						console.log("queueMessage", text, images)
-						vscode.postMessage({ type: "queueMessage", taskId: currentTaskId, text, images })
+						vscode.postMessage({
+							type: "queueMessage",
+							taskId: currentTaskId,
+							text,
+							images,
+							deliveryMode: "queue",
+						})
 						setInputValue("")
 						setSelectedImages([])
 					} catch (error) {
@@ -843,6 +849,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				taskId: currentTaskId,
 				text,
 				images: selectedImages,
+				deliveryMode: "queue",
 			})
 			setInputValue("")
 			setSelectedImages([])
@@ -1704,6 +1711,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					taskId: currentTaskId,
 					text: inputValue.trim(),
 					images: selectedImages,
+					deliveryMode: "queue",
 				})
 				setInputValue("")
 				setSelectedImages([])
@@ -1943,27 +1951,24 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 					<QueuedMessages
 						queue={visibleMessageQueue}
-						onRemove={(index) => {
-							if (visibleMessageQueue[index]) {
-								vscode.postMessage({
-									type: "removeQueuedMessage",
-									text: visibleMessageQueue[index].id,
-									taskId: currentTaskId,
-								})
-							}
+						onRemove={(messageId) => {
+							vscode.postMessage({
+								type: "removeQueuedMessage",
+								text: messageId,
+								taskId: currentTaskId,
+							})
 						}}
-						onUpdate={(index, newText) => {
-							if (visibleMessageQueue[index]) {
-								vscode.postMessage({
-									type: "editQueuedMessage",
-									taskId: currentTaskId,
-									payload: {
-										id: visibleMessageQueue[index].id,
-										text: newText,
-										images: visibleMessageQueue[index].images,
-									},
-								})
-							}
+						onUpdate={(message, updates) => {
+							vscode.postMessage({
+								type: "editQueuedMessage",
+								taskId: currentTaskId,
+								payload: {
+									id: message.id,
+									text: updates.text ?? message.text,
+									images: message.images,
+									deliveryMode: updates.deliveryMode ?? message.deliveryMode,
+								},
+							})
 						}}
 					/>
 					{showRetiredProviderWarning && (

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -10,7 +10,15 @@ import { appendImages } from "@src/utils/imageUtils"
 import { getCostBreakdownIfNeeded } from "@src/utils/costFormatting"
 import { batchConsecutive } from "@src/utils/batchConsecutive"
 
-import type { ClineAsk, ClineSayTool, ClineMessage, ExtensionMessage, AudioType } from "@roo-code/types"
+import type {
+	ClineAsk,
+	ClineSayTool,
+	ClineMessage,
+	ExtensionMessage,
+	AudioType,
+	TodoItem,
+	QueuedMessage,
+} from "@roo-code/types"
 import { isRetiredProvider } from "@roo-code/types"
 
 import { findLast } from "@roo/array"
@@ -34,6 +42,7 @@ import TelemetryBanner from "../common/TelemetryBanner"
 import VersionIndicator from "../common/VersionIndicator"
 import HistoryPreview from "../history/HistoryPreview"
 import Announcement from "./Announcement"
+import ActiveConversationList, { type ConversationListItem } from "./ActiveConversationList"
 import ChatRow from "./ChatRow"
 import WarningRow from "./WarningRow"
 import { ChatTextArea } from "./ChatTextArea"
@@ -59,6 +68,16 @@ export const MAX_IMAGES_PER_MESSAGE = 20 // This is the Anthropic limit.
 
 const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0
 
+interface DraftConversation {
+	id: string
+	ts: number
+	title: string
+}
+
+const EMPTY_MESSAGES: ClineMessage[] = []
+const EMPTY_TODOS: TodoItem[] = []
+const EMPTY_MESSAGE_QUEUE: QueuedMessage[] = []
+
 const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewProps> = (
 	{ isHidden, showAnnouncement, hideAnnouncement },
 	ref,
@@ -71,9 +90,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const modeShortcutText = `${isMac ? "⌘" : "Ctrl"} + . ${t("chat:forNextMode")}, ${isMac ? "⌘" : "Ctrl"} + Shift + . ${t("chat:forPreviousMode")}`
 
 	const {
-		clineMessages: messages,
-		currentTaskItem,
-		currentTaskTodos,
+		clineMessages: contextMessages,
+		currentTaskId: contextCurrentTaskId,
+		currentTaskItem: contextCurrentTaskItem,
+		currentTaskTodos: contextCurrentTaskTodos,
+		activeConversations = [],
 		taskHistory,
 		apiConfiguration,
 		organizationAllowList,
@@ -87,6 +108,83 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		messageQueue = [],
 		showWorktreesInHomeScreen,
 	} = useExtensionState()
+	const [draftConversations, setDraftConversations] = useState<DraftConversation[]>([])
+	const [selectedDraftId, setSelectedDraftId] = useState<string | undefined>(undefined)
+	const isDraftSelected = selectedDraftId !== undefined
+	const messages = useMemo(
+		() => (isDraftSelected ? EMPTY_MESSAGES : contextMessages),
+		[contextMessages, isDraftSelected],
+	)
+	const currentTaskId = isDraftSelected ? undefined : contextCurrentTaskId
+	const currentTaskItem = isDraftSelected ? undefined : contextCurrentTaskItem
+	const currentTaskTodos = useMemo(
+		() => (isDraftSelected ? EMPTY_TODOS : contextCurrentTaskTodos),
+		[contextCurrentTaskTodos, isDraftSelected],
+	)
+	const visibleMessageQueue = useMemo(
+		() => (isDraftSelected ? EMPTY_MESSAGE_QUEUE : messageQueue),
+		[messageQueue, isDraftSelected],
+	)
+
+	const visibleConversationIds = useMemo(
+		() =>
+			new Set(
+				activeConversations.flatMap((conversation) => [conversation.rootTaskId, conversation.activeTaskId]),
+			),
+		[activeConversations],
+	)
+
+	useEffect(() => {
+		setDraftConversations((prev) => {
+			const next = prev.filter((draft) => !visibleConversationIds.has(draft.id))
+			return next.length === prev.length ? prev : next
+		})
+
+		if (selectedDraftId && visibleConversationIds.has(selectedDraftId)) {
+			setSelectedDraftId(undefined)
+		}
+	}, [selectedDraftId, visibleConversationIds])
+
+	const selectedConversationId = selectedDraftId ?? currentTaskId
+
+	const conversations = useMemo<ConversationListItem[]>(() => {
+		const draftItems = draftConversations
+			.filter((draft) => !visibleConversationIds.has(draft.id))
+			.map(
+				(draft) =>
+					({
+						kind: "draft",
+						rootTaskId: draft.id,
+						activeTaskId: draft.id,
+						rootTask: draft.title,
+						activeTask: draft.title,
+						ts: draft.ts,
+						status: "none",
+						queuedMessageCount: 0,
+						steerMessageCount: 0,
+					}) satisfies ConversationListItem,
+			)
+
+		const taskItems = activeConversations.map(
+			(conversation) =>
+				({
+					...conversation,
+					kind: "task",
+				}) satisfies ConversationListItem,
+		)
+
+		return [...draftItems, ...taskItems].sort((a, b) => {
+			if (a.activeTaskId === selectedConversationId) {
+				return -1
+			}
+			if (b.activeTaskId === selectedConversationId) {
+				return 1
+			}
+			return b.ts - a.ts
+		})
+	}, [activeConversations, draftConversations, selectedConversationId, visibleConversationIds])
+
+	const hasConversationSidebar = conversations.length > 0
 
 	// Show a WarningRow when the user sends a message with a retired provider.
 	const [showRetiredProviderWarning, setShowRetiredProviderWarning] = useState(false)
@@ -364,7 +462,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						case "completion_result":
 							// Extension waiting for feedback, but we can just present a new task button.
 							// Only play celebration sound if there are no queued messages.
-							if (!isPartial && messageQueue.length === 0) {
+							if (!isPartial && visibleMessageQueue.length === 0) {
 								playSound("celebration")
 							}
 							setSendingDisabled(isPartial)
@@ -600,12 +698,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				if (
 					sendingDisabled ||
 					isStreaming ||
-					messageQueue.length > 0 ||
+					visibleMessageQueue.length > 0 ||
 					clineAskRef.current === "command_output"
 				) {
 					try {
 						console.log("queueMessage", text, images)
-						vscode.postMessage({ type: "queueMessage", text, images })
+						vscode.postMessage({ type: "queueMessage", taskId: currentTaskId, text, images })
 						setInputValue("")
 						setSelectedImages([])
 					} catch (error) {
@@ -621,7 +719,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				userRespondedRef.current = true
 
 				if (messagesRef.current.length === 0) {
-					vscode.postMessage({ type: "newTask", text, images })
+					vscode.postMessage({ type: "newTask", taskId: selectedDraftId, text, images })
 				} else if (clineAskRef.current) {
 					if (clineAskRef.current === "followup") {
 						markFollowUpAsAnswered()
@@ -641,6 +739,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						case "mistake_limit_reached":
 							vscode.postMessage({
 								type: "askResponse",
+								taskId: currentTaskId,
 								askResponse: "messageResponse",
 								text,
 								images,
@@ -650,7 +749,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					}
 				} else {
 					// This is a new message in an ongoing task.
-					vscode.postMessage({ type: "askResponse", askResponse: "messageResponse", text, images })
+					vscode.postMessage({
+						type: "askResponse",
+						taskId: currentTaskId,
+						askResponse: "messageResponse",
+						text,
+						images,
+					})
 				}
 
 				handleChatReset()
@@ -661,8 +766,10 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			markFollowUpAsAnswered,
 			sendingDisabled,
 			isStreaming,
-			messageQueue.length,
+			visibleMessageQueue.length,
 			apiConfiguration?.apiProvider,
+			currentTaskId,
+			selectedDraftId,
 		], // messagesRef and clineAskRef are stable
 	)
 
@@ -682,15 +789,50 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	)
 
 	const startNewTask = useCallback(() => {
+		const draftId = `draft-${
+			typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+				? crypto.randomUUID()
+				: Date.now().toString(36)
+		}`
 		setShowRetiredProviderWarning(false)
+		setInputValue("")
+		setSelectedImages([])
+		setSelectedDraftId(draftId)
+		setDraftConversations((prev) => [{ id: draftId, ts: Date.now(), title: "New conversation" }, ...prev])
 		vscode.postMessage({ type: "clearTask" })
+	}, [])
+
+	const handleSelectConversation = useCallback(
+		(conversation: ConversationListItem) => {
+			if (conversation.kind === "draft") {
+				setSelectedDraftId(conversation.activeTaskId)
+				if (currentTaskId) {
+					vscode.postMessage({ type: "clearTask" })
+				}
+				return
+			}
+
+			setSelectedDraftId(undefined)
+			vscode.postMessage({ type: "showTaskWithId", text: conversation.activeTaskId })
+		},
+		[currentTaskId],
+	)
+
+	const handleDeleteConversation = useCallback((conversation: ConversationListItem) => {
+		if (conversation.kind === "draft") {
+			setDraftConversations((prev) => prev.filter((draft) => draft.id !== conversation.activeTaskId))
+			setSelectedDraftId((prev) => (prev === conversation.activeTaskId ? undefined : prev))
+			return
+		}
+
+		vscode.postMessage({ type: "deleteTaskWithId", text: conversation.rootTaskId })
 	}, [])
 
 	// Handle stop button click from textarea
 	const handleStopTask = useCallback(() => {
-		vscode.postMessage({ type: "cancelTask" })
+		vscode.postMessage({ type: "cancelTask", taskId: currentTaskId })
 		setDidClickCancel(true)
-	}, [setDidClickCancel])
+	}, [currentTaskId, setDidClickCancel])
 
 	// Handle enqueue button click from textarea
 	const handleEnqueueCurrentMessage = useCallback(() => {
@@ -698,13 +840,14 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		if (text || selectedImages.length > 0) {
 			vscode.postMessage({
 				type: "queueMessage",
+				taskId: currentTaskId,
 				text,
 				images: selectedImages,
 			})
 			setInputValue("")
 			setSelectedImages([])
 		}
-	}, [inputValue, selectedImages])
+	}, [currentTaskId, inputValue, selectedImages])
 
 	// This logic depends on the useEffect[messages] above to set clineAsk,
 	// after which buttons are shown and we then send an askResponse to the
@@ -726,6 +869,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					if (trimmedInput || (images && images.length > 0)) {
 						vscode.postMessage({
 							type: "askResponse",
+							taskId: currentTaskId,
 							askResponse: "yesButtonClicked",
 							text: trimmedInput,
 							images: images,
@@ -734,7 +878,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						setInputValue("")
 						setSelectedImages([])
 					} else {
-						vscode.postMessage({ type: "askResponse", askResponse: "yesButtonClicked" })
+						vscode.postMessage({
+							type: "askResponse",
+							taskId: currentTaskId,
+							askResponse: "yesButtonClicked",
+						})
 					}
 					break
 				case "resume_task":
@@ -752,6 +900,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						if (trimmedInput || (images && images.length > 0)) {
 							vscode.postMessage({
 								type: "askResponse",
+								taskId: currentTaskId,
 								askResponse: "yesButtonClicked",
 								text: trimmedInput,
 								images: images,
@@ -760,7 +909,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setInputValue("")
 							setSelectedImages([])
 						} else {
-							vscode.postMessage({ type: "askResponse", askResponse: "yesButtonClicked" })
+							vscode.postMessage({
+								type: "askResponse",
+								taskId: currentTaskId,
+								askResponse: "yesButtonClicked",
+							})
 						}
 					}
 					break
@@ -770,7 +923,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					startNewTask()
 					break
 				case "command_output":
-					vscode.postMessage({ type: "terminalOperation", terminalOperation: "continue" })
+					vscode.postMessage({
+						type: "terminalOperation",
+						taskId: currentTaskId,
+						terminalOperation: "continue",
+					})
 					break
 			}
 
@@ -780,7 +937,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			setPrimaryButtonText(undefined)
 			setSecondaryButtonText(undefined)
 		},
-		[clineAsk, startNewTask, currentTaskItem?.parentTaskId],
+		[clineAsk, currentTaskId, startNewTask, currentTaskItem?.parentTaskId],
 	)
 
 	const handleSecondaryButtonClick = useCallback(
@@ -791,7 +948,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			const trimmedInput = text?.trim()
 
 			if (isStreaming) {
-				vscode.postMessage({ type: "cancelTask" })
+				vscode.postMessage({ type: "cancelTask", taskId: currentTaskId })
 				setDidClickCancel(true)
 				return
 			}
@@ -809,6 +966,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					if (trimmedInput || (images && images.length > 0)) {
 						vscode.postMessage({
 							type: "askResponse",
+							taskId: currentTaskId,
 							askResponse: "noButtonClicked",
 							text: trimmedInput,
 							images: images,
@@ -818,18 +976,26 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						setSelectedImages([])
 					} else {
 						// Responds to the API with a "This operation failed" and lets it try again
-						vscode.postMessage({ type: "askResponse", askResponse: "noButtonClicked" })
+						vscode.postMessage({
+							type: "askResponse",
+							taskId: currentTaskId,
+							askResponse: "noButtonClicked",
+						})
 					}
 					break
 				case "command_output":
-					vscode.postMessage({ type: "terminalOperation", terminalOperation: "abort" })
+					vscode.postMessage({
+						type: "terminalOperation",
+						taskId: currentTaskId,
+						terminalOperation: "abort",
+					})
 					break
 			}
 			setSendingDisabled(true)
 			setClineAsk(undefined)
 			setEnableButtons(false)
 		},
-		[clineAsk, startNewTask, isStreaming, setDidClickCancel],
+		[clineAsk, currentTaskId, startNewTask, isStreaming, setDidClickCancel],
 	)
 
 	const { info: model } = useSelectedModel(apiConfiguration)
@@ -1384,10 +1550,18 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		[handleSendMessage, setInputValue, switchToMode, alwaysAllowModeSwitch, clineAsk, markFollowUpAsAnswered],
 	)
 
-	const handleBatchFileResponse = useCallback((response: { [key: string]: boolean }) => {
-		// Handle batch file response, e.g., for file uploads
-		vscode.postMessage({ type: "askResponse", askResponse: "objectResponse", text: JSON.stringify(response) })
-	}, [])
+	const handleBatchFileResponse = useCallback(
+		(response: { [key: string]: boolean }) => {
+			// Handle batch file response, e.g., for file uploads
+			vscode.postMessage({
+				type: "askResponse",
+				taskId: currentTaskId,
+				askResponse: "objectResponse",
+				text: JSON.stringify(response),
+			})
+		},
+		[currentTaskId],
+	)
 
 	// Cancel backend auto-approval timeout when FollowUpSuggest's countdown effect cleans up.
 	// This is called when auto-approve is toggled off, a suggestion is clicked, or the component unmounts.
@@ -1525,7 +1699,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			// Special case: during command_output, queue the message instead of
 			// triggering the primary button action (which would lose the message)
 			if (clineAskRef.current === "command_output" && hasInput) {
-				vscode.postMessage({ type: "queueMessage", text: inputValue.trim(), images: selectedImages })
+				vscode.postMessage({
+					type: "queueMessage",
+					taskId: currentTaskId,
+					text: inputValue.trim(),
+					images: selectedImages,
+				})
 				setInputValue("")
 				setSelectedImages([])
 				return
@@ -1567,231 +1746,270 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					}}
 				/>
 			)}
-			{task ? (
-				<>
-					<TaskHeader
-						task={task}
-						tokensIn={apiMetrics.totalTokensIn}
-						tokensOut={apiMetrics.totalTokensOut}
-						cacheWrites={apiMetrics.totalCacheWrites}
-						cacheReads={apiMetrics.totalCacheReads}
-						totalCost={apiMetrics.totalCost}
-						aggregatedCost={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? aggregatedCostsMap.get(currentTaskItem.id)!.totalCost
-								: undefined
-						}
-						hasSubtasks={
-							!!(
-								currentTaskItem?.id &&
-								aggregatedCostsMap.has(currentTaskItem.id) &&
-								aggregatedCostsMap.get(currentTaskItem.id)!.childrenCost > 0
-							)
-						}
-						parentTaskId={currentTaskItem?.parentTaskId}
-						costBreakdown={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? getCostBreakdownIfNeeded(aggregatedCostsMap.get(currentTaskItem.id)!, {
-										own: t("common:costs.own"),
-										subtasks: t("common:costs.subtasks"),
-									})
-								: undefined
-						}
-						contextTokens={apiMetrics.contextTokens}
-						buttonsDisabled={sendingDisabled}
-						handleCondenseContext={handleCondenseContext}
-						todos={latestTodos}
+			<div className="flex min-h-0 flex-1 overflow-hidden">
+				{hasConversationSidebar && (
+					<ActiveConversationList
+						conversations={conversations}
+						selectedConversationId={selectedConversationId}
+						onCreateConversation={startNewTask}
+						onSelectConversation={handleSelectConversation}
+						onDeleteConversation={handleDeleteConversation}
 					/>
+				)}
+				<div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+					{task ? (
+						<>
+							<TaskHeader
+								task={task}
+								tokensIn={apiMetrics.totalTokensIn}
+								tokensOut={apiMetrics.totalTokensOut}
+								cacheWrites={apiMetrics.totalCacheWrites}
+								cacheReads={apiMetrics.totalCacheReads}
+								totalCost={apiMetrics.totalCost}
+								aggregatedCost={
+									currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
+										? aggregatedCostsMap.get(currentTaskItem.id)!.totalCost
+										: undefined
+								}
+								hasSubtasks={
+									!!(
+										currentTaskItem?.id &&
+										aggregatedCostsMap.has(currentTaskItem.id) &&
+										aggregatedCostsMap.get(currentTaskItem.id)!.childrenCost > 0
+									)
+								}
+								parentTaskId={currentTaskItem?.parentTaskId}
+								costBreakdown={
+									currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
+										? getCostBreakdownIfNeeded(aggregatedCostsMap.get(currentTaskItem.id)!, {
+												own: t("common:costs.own"),
+												subtasks: t("common:costs.subtasks"),
+											})
+										: undefined
+								}
+								contextTokens={apiMetrics.contextTokens}
+								buttonsDisabled={sendingDisabled}
+								handleCondenseContext={handleCondenseContext}
+								todos={latestTodos}
+							/>
 
-					{checkpointWarning && (
-						<div className="px-3">
-							<CheckpointWarning warning={checkpointWarning} />
-						</div>
-					)}
-				</>
-			) : (
-				<div className="flex flex-col h-full justify-center p-6 min-h-0 overflow-y-auto gap-4 relative">
-					<div className="flex flex-col items-start gap-2 justify-center h-full min-[400px]:px-6">
-						<VersionIndicator
-							onClick={() => setShowAnnouncementModal(true)}
-							className="absolute top-2 right-3 z-10"
-						/>
-						<div className="flex flex-col gap-4 w-full">
-							<RooHero />
-							<RooTips />
-							{/* Everyone should see their task history if any */}
-							{taskHistory.length > 0 && <HistoryPreview />}
-						</div>
-					</div>
-				</div>
-			)}
-
-			{!task && showWorktreesInHomeScreen && <WorktreeSelector />}
-
-			{task && (
-				<>
-					<div className="grow flex" ref={scrollContainerRef}>
-						<Virtuoso
-							ref={virtuosoRef}
-							key={task.ts}
-							className="scrollable grow overflow-y-scroll mb-1"
-							increaseViewportBy={{ top: 3_000, bottom: 1000 }}
-							data={groupedMessages}
-							itemContent={itemContent}
-							followOutput={followOutputCallback}
-							atBottomStateChange={atBottomStateChangeCallback}
-							atBottomThreshold={10}
-						/>
-					</div>
-					<FileChangesPanel clineMessages={messages} />
-					{areButtonsVisible && (
-						<div
-							className={`flex h-9 items-center mb-1 px-[15px] ${
-								showScrollToBottom ? "opacity-100" : enableButtons ? "opacity-100" : "opacity-50"
-							}`}>
-							{showScrollToBottom ? (
-								<>
-									<StandardTooltip content={t("chat:scrollToBottom")}>
-										<Button
-											variant="secondary"
-											className={hasLatestCheckpoint ? "flex-1 mr-[6px]" : "flex-[2]"}
-											onClick={handleScrollToBottomAndResetCheckpointCursor}>
-											<span className="codicon codicon-chevron-down"></span>
-										</Button>
-									</StandardTooltip>
-									{hasLatestCheckpoint && (
-										<StandardTooltip content={t("chat:scrollToLatestCheckpoint")}>
-											<Button
-												variant="secondary"
-												className="flex-1 ml-[6px]"
-												onClick={handleScrollToLatestCheckpoint}
-												aria-label={t("chat:scrollToLatestCheckpoint")}>
-												<span className="codicon codicon-history"></span>
-											</Button>
-										</StandardTooltip>
-									)}
-								</>
-							) : (
-								<>
-									{primaryButtonText && (
-										<StandardTooltip
-											content={
-												primaryButtonText === t("chat:retry.title")
-													? t("chat:retry.tooltip")
-													: primaryButtonText === t("chat:save.title")
-														? t("chat:save.tooltip")
-														: primaryButtonText === t("chat:approve.title")
-															? t("chat:approve.tooltip")
-															: primaryButtonText === t("chat:runCommand.title")
-																? t("chat:runCommand.tooltip")
-																: primaryButtonText === t("chat:startNewTask.title")
-																	? t("chat:startNewTask.tooltip")
-																	: primaryButtonText === t("chat:resumeTask.title")
-																		? t("chat:resumeTask.tooltip")
-																		: primaryButtonText ===
-																			  t("chat:proceedAnyways.title")
-																			? t("chat:proceedAnyways.tooltip")
-																			: primaryButtonText ===
-																				  t("chat:proceedWhileRunning.title")
-																				? t("chat:proceedWhileRunning.tooltip")
-																				: undefined
-											}>
-											<Button
-												variant="primary"
-												disabled={!enableButtons}
-												className={secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"}
-												onClick={() => handlePrimaryButtonClick(inputValue, selectedImages)}>
-												{primaryButtonText}
-											</Button>
-										</StandardTooltip>
-									)}
-									{secondaryButtonText && (
-										<StandardTooltip
-											content={
-												secondaryButtonText === t("chat:startNewTask.title")
-													? t("chat:startNewTask.tooltip")
-													: secondaryButtonText === t("chat:reject.title")
-														? t("chat:reject.tooltip")
-														: secondaryButtonText === t("chat:terminate.title")
-															? t("chat:terminate.tooltip")
-															: secondaryButtonText === t("chat:killCommand.title")
-																? t("chat:killCommand.tooltip")
-																: undefined
-											}>
-											<Button
-												variant="secondary"
-												disabled={!enableButtons}
-												className="flex-1 ml-[6px]"
-												onClick={() => handleSecondaryButtonClick(inputValue, selectedImages)}>
-												{secondaryButtonText}
-											</Button>
-										</StandardTooltip>
-									)}
-								</>
+							{checkpointWarning && (
+								<div className="px-3">
+									<CheckpointWarning warning={checkpointWarning} />
+								</div>
 							)}
+						</>
+					) : (
+						<div className="flex flex-col h-full justify-center p-6 min-h-0 overflow-y-auto gap-4 relative">
+							<div className="flex flex-col items-start gap-2 justify-center h-full min-[400px]:px-6">
+								<VersionIndicator
+									onClick={() => setShowAnnouncementModal(true)}
+									className="absolute top-2 right-3 z-10"
+								/>
+								<div className="flex flex-col gap-4 w-full">
+									<RooHero />
+									<RooTips />
+									{/* Everyone should see their task history if any */}
+									{taskHistory.length > 0 && <HistoryPreview />}
+								</div>
+							</div>
 						</div>
 					)}
-				</>
-			)}
 
-			<QueuedMessages
-				queue={messageQueue}
-				onRemove={(index) => {
-					if (messageQueue[index]) {
-						vscode.postMessage({ type: "removeQueuedMessage", text: messageQueue[index].id })
-					}
-				}}
-				onUpdate={(index, newText) => {
-					if (messageQueue[index]) {
-						vscode.postMessage({
-							type: "editQueuedMessage",
-							payload: { id: messageQueue[index].id, text: newText, images: messageQueue[index].images },
-						})
-					}
-				}}
-			/>
-			{showRetiredProviderWarning && (
-				<div className="px-[15px] py-1">
-					<WarningRow
-						title={t("chat:retiredProvider.title")}
-						message={t("chat:retiredProvider.message")}
-						actionText={t("chat:retiredProvider.openSettings")}
-						onAction={() => vscode.postMessage({ type: "switchTab", tab: "settings" })}
+					{!task && showWorktreesInHomeScreen && <WorktreeSelector />}
+
+					{task && (
+						<>
+							<div className="grow flex" ref={scrollContainerRef}>
+								<Virtuoso
+									ref={virtuosoRef}
+									key={task.ts}
+									className="scrollable grow overflow-y-scroll mb-1"
+									increaseViewportBy={{ top: 3_000, bottom: 1000 }}
+									data={groupedMessages}
+									itemContent={itemContent}
+									followOutput={followOutputCallback}
+									atBottomStateChange={atBottomStateChangeCallback}
+									atBottomThreshold={10}
+								/>
+							</div>
+							<FileChangesPanel clineMessages={messages} />
+							{areButtonsVisible && (
+								<div
+									className={`flex h-9 items-center mb-1 px-[15px] ${
+										showScrollToBottom
+											? "opacity-100"
+											: enableButtons
+												? "opacity-100"
+												: "opacity-50"
+									}`}>
+									{showScrollToBottom ? (
+										<>
+											<StandardTooltip content={t("chat:scrollToBottom")}>
+												<Button
+													variant="secondary"
+													className={hasLatestCheckpoint ? "flex-1 mr-[6px]" : "flex-[2]"}
+													onClick={handleScrollToBottomAndResetCheckpointCursor}>
+													<span className="codicon codicon-chevron-down"></span>
+												</Button>
+											</StandardTooltip>
+											{hasLatestCheckpoint && (
+												<StandardTooltip content={t("chat:scrollToLatestCheckpoint")}>
+													<Button
+														variant="secondary"
+														className="flex-1 ml-[6px]"
+														onClick={handleScrollToLatestCheckpoint}
+														aria-label={t("chat:scrollToLatestCheckpoint")}>
+														<span className="codicon codicon-history"></span>
+													</Button>
+												</StandardTooltip>
+											)}
+										</>
+									) : (
+										<>
+											{primaryButtonText && (
+												<StandardTooltip
+													content={
+														primaryButtonText === t("chat:retry.title")
+															? t("chat:retry.tooltip")
+															: primaryButtonText === t("chat:save.title")
+																? t("chat:save.tooltip")
+																: primaryButtonText === t("chat:approve.title")
+																	? t("chat:approve.tooltip")
+																	: primaryButtonText === t("chat:runCommand.title")
+																		? t("chat:runCommand.tooltip")
+																		: primaryButtonText ===
+																			  t("chat:startNewTask.title")
+																			? t("chat:startNewTask.tooltip")
+																			: primaryButtonText ===
+																				  t("chat:resumeTask.title")
+																				? t("chat:resumeTask.tooltip")
+																				: primaryButtonText ===
+																					  t("chat:proceedAnyways.title")
+																					? t("chat:proceedAnyways.tooltip")
+																					: primaryButtonText ===
+																						  t(
+																								"chat:proceedWhileRunning.title",
+																						  )
+																						? t(
+																								"chat:proceedWhileRunning.tooltip",
+																							)
+																						: undefined
+													}>
+													<Button
+														variant="primary"
+														disabled={!enableButtons}
+														className={
+															secondaryButtonText ? "flex-1 mr-[6px]" : "flex-[2] mr-0"
+														}
+														onClick={() =>
+															handlePrimaryButtonClick(inputValue, selectedImages)
+														}>
+														{primaryButtonText}
+													</Button>
+												</StandardTooltip>
+											)}
+											{secondaryButtonText && (
+												<StandardTooltip
+													content={
+														secondaryButtonText === t("chat:startNewTask.title")
+															? t("chat:startNewTask.tooltip")
+															: secondaryButtonText === t("chat:reject.title")
+																? t("chat:reject.tooltip")
+																: secondaryButtonText === t("chat:terminate.title")
+																	? t("chat:terminate.tooltip")
+																	: secondaryButtonText ===
+																		  t("chat:killCommand.title")
+																		? t("chat:killCommand.tooltip")
+																		: undefined
+													}>
+													<Button
+														variant="secondary"
+														disabled={!enableButtons}
+														className="flex-1 ml-[6px]"
+														onClick={() =>
+															handleSecondaryButtonClick(inputValue, selectedImages)
+														}>
+														{secondaryButtonText}
+													</Button>
+												</StandardTooltip>
+											)}
+										</>
+									)}
+								</div>
+							)}
+						</>
+					)}
+
+					<QueuedMessages
+						queue={visibleMessageQueue}
+						onRemove={(index) => {
+							if (visibleMessageQueue[index]) {
+								vscode.postMessage({
+									type: "removeQueuedMessage",
+									text: visibleMessageQueue[index].id,
+									taskId: currentTaskId,
+								})
+							}
+						}}
+						onUpdate={(index, newText) => {
+							if (visibleMessageQueue[index]) {
+								vscode.postMessage({
+									type: "editQueuedMessage",
+									taskId: currentTaskId,
+									payload: {
+										id: visibleMessageQueue[index].id,
+										text: newText,
+										images: visibleMessageQueue[index].images,
+									},
+								})
+							}
+						}}
 					/>
-				</div>
-			)}
-			<ChatTextArea
-				ref={textAreaRef}
-				inputValue={inputValue}
-				setInputValue={setInputValue}
-				sendingDisabled={sendingDisabled || isProfileDisabled}
-				selectApiConfigDisabled={sendingDisabled && clineAsk !== "api_req_failed"}
-				placeholderText={placeholderText}
-				selectedImages={selectedImages}
-				setSelectedImages={setSelectedImages}
-				onSend={() => handleSendMessage(inputValue, selectedImages)}
-				onSelectImages={selectImages}
-				shouldDisableImages={shouldDisableImages}
-				onHeightChange={() => {
-					if (isAtBottomRef.current && scrollPhaseRef.current !== "USER_BROWSING_HISTORY") {
-						scrollToBottomAuto()
-					}
-				}}
-				mode={mode}
-				setMode={setMode}
-				modeShortcutText={modeShortcutText}
-				isStreaming={isStreaming}
-				onStop={handleStopTask}
-				onEnqueueMessage={handleEnqueueCurrentMessage}
-			/>
+					{showRetiredProviderWarning && (
+						<div className="px-[15px] py-1">
+							<WarningRow
+								title={t("chat:retiredProvider.title")}
+								message={t("chat:retiredProvider.message")}
+								actionText={t("chat:retiredProvider.openSettings")}
+								onAction={() => vscode.postMessage({ type: "switchTab", tab: "settings" })}
+							/>
+						</div>
+					)}
+					<ChatTextArea
+						ref={textAreaRef}
+						inputValue={inputValue}
+						setInputValue={setInputValue}
+						sendingDisabled={sendingDisabled || isProfileDisabled}
+						selectApiConfigDisabled={sendingDisabled && clineAsk !== "api_req_failed"}
+						placeholderText={placeholderText}
+						selectedImages={selectedImages}
+						setSelectedImages={setSelectedImages}
+						onSend={() => handleSendMessage(inputValue, selectedImages)}
+						onSelectImages={selectImages}
+						shouldDisableImages={shouldDisableImages}
+						onHeightChange={() => {
+							if (isAtBottomRef.current && scrollPhaseRef.current !== "USER_BROWSING_HISTORY") {
+								scrollToBottomAuto()
+							}
+						}}
+						mode={mode}
+						setMode={setMode}
+						modeShortcutText={modeShortcutText}
+						isStreaming={isStreaming}
+						onStop={handleStopTask}
+						onEnqueueMessage={handleEnqueueCurrentMessage}
+					/>
 
-			{isProfileDisabled && (
-				<div className="px-3">
-					<ProfileViolationWarning />
-				</div>
-			)}
+					{isProfileDisabled && (
+						<div className="px-3">
+							<ProfileViolationWarning />
+						</div>
+					)}
 
-			<div id="roo-portal" />
+					<div id="roo-portal" />
+				</div>
+			</div>
 		</div>
 	)
 }

--- a/webview-ui/src/components/chat/QueuedMessages.tsx
+++ b/webview-ui/src/components/chat/QueuedMessages.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useLayoutEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { QueuedMessage } from "@roo-code/types"
@@ -11,8 +11,54 @@ import { Mention } from "./Mention"
 
 interface QueuedMessagesProps {
 	queue: QueuedMessage[]
-	onRemove: (index: number) => void
-	onUpdate: (index: number, newText: string) => void
+	onRemove: (messageId: string) => void
+	onUpdate: (message: QueuedMessage, updates: { text?: string; deliveryMode?: QueuedMessage["deliveryMode"] }) => void
+}
+
+interface QueuedMessageEditorProps {
+	value: string
+	onChange: (value: string) => void
+	onSave: () => void
+	onCancel: () => void
+	placeholder: string
+	rows: number
+}
+
+const QueuedMessageEditor = ({ value, onChange, onSave, onCancel, placeholder, rows }: QueuedMessageEditorProps) => {
+	const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+	const didPlaceInitialCaretRef = useRef(false)
+
+	useLayoutEffect(() => {
+		if (didPlaceInitialCaretRef.current || !textareaRef.current) {
+			return
+		}
+
+		didPlaceInitialCaretRef.current = true
+		const textarea = textareaRef.current
+		textarea.focus()
+		textarea.setSelectionRange(textarea.value.length, textarea.value.length)
+	}, [])
+
+	return (
+		<textarea
+			ref={textareaRef}
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			onBlur={onSave}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" && !e.shiftKey) {
+					e.preventDefault()
+					onSave()
+				}
+				if (e.key === "Escape") {
+					onCancel()
+				}
+			}}
+			className="w-full bg-vscode-input-background text-vscode-input-foreground border border-vscode-input-border rounded px-2 py-1 resize-none focus:outline-0 focus:ring-1 focus:ring-vscode-focusBorder"
+			placeholder={placeholder}
+			rows={rows}
+		/>
+	)
 }
 
 export const QueuedMessages = ({ queue, onRemove, onUpdate }: QueuedMessagesProps) => {
@@ -34,79 +80,120 @@ export const QueuedMessages = ({ queue, onRemove, onUpdate }: QueuedMessagesProp
 		}))
 	}
 
-	const handleSaveEdit = (index: number, messageId: string, newValue: string) => {
-		onUpdate(index, newValue)
-		setEditState(messageId, false)
+	const handleSaveEdit = (message: QueuedMessage, newValue: string) => {
+		onUpdate(message, { text: newValue })
+		setEditState(message.id, false)
 	}
+
+	const handleCancelEdit = (message: QueuedMessage) => {
+		setEditState(message.id, false, message.text)
+	}
+
+	const renderLane = (
+		title: string,
+		messages: QueuedMessage[],
+		options?: { emptyLabel?: string; alternateActionLabel?: string; alternateMode?: QueuedMessage["deliveryMode"] },
+	) => {
+		if (messages.length === 0 && !options?.emptyLabel) {
+			return null
+		}
+
+		return (
+			<div className="flex flex-col gap-2">
+				<div className="flex items-center justify-between gap-2 px-1">
+					<div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-vscode-descriptionForeground">
+						{title}
+					</div>
+					<div className="text-[11px] text-vscode-descriptionForeground">{messages.length}</div>
+				</div>
+				{messages.length === 0 ? (
+					<div className="rounded-xs border border-dashed border-vscode-editorGroup-border px-3 py-2 text-xs text-vscode-descriptionForeground">
+						{options?.emptyLabel}
+					</div>
+				) : (
+					messages.map((message) => {
+						const editState = getEditState(message.id, message.text)
+
+						return (
+							<div
+								key={message.id}
+								className="bg-vscode-editor-background border rounded-xs p-1 overflow-hidden whitespace-pre-wrap flex-shrink-0">
+								<div className="flex justify-between gap-2">
+									<div className="flex-grow px-2 py-1 wrap-anywhere">
+										<div className="mb-1 flex items-center gap-2">
+											<span className="rounded-full bg-vscode-badge-background/80 px-1.5 py-0.5 text-[10px] font-semibold text-vscode-badge-foreground">
+												{message.deliveryMode === "steer" ? "Steer next" : "Queued"}
+											</span>
+										</div>
+										{editState.isEditing ? (
+											<QueuedMessageEditor
+												value={editState.value}
+												onChange={(value) => setEditState(message.id, true, value)}
+												onSave={() => handleSaveEdit(message, editState.value)}
+												onCancel={() => handleCancelEdit(message)}
+												placeholder={t("chat:editMessage.placeholder")}
+												rows={Math.min(editState.value.split("\n").length, 10)}
+											/>
+										) : (
+											<div
+												onClick={() => setEditState(message.id, true, message.text)}
+												className="cursor-pointer hover:bg-vscode-list-hoverBackground px-1 py-0.5 -mx-1 -my-0.5 rounded transition-colors"
+												title={t("chat:queuedMessages.clickToEdit")}>
+												<Mention text={message.text} withShadow />
+											</div>
+										)}
+									</div>
+									<div className="flex shrink-0 flex-col items-end gap-1 py-1 pr-1">
+										{options?.alternateMode && options.alternateActionLabel && (
+											<Button
+												variant="ghost"
+												size="sm"
+												className="h-6 rounded-md px-2 text-xs"
+												onClick={(e) => {
+													e.stopPropagation()
+													onUpdate(message, { deliveryMode: options.alternateMode })
+												}}>
+												{options.alternateActionLabel}
+											</Button>
+										)}
+										<Button
+											variant="ghost"
+											size="icon"
+											className="shrink-0"
+											onClick={(e) => {
+												e.stopPropagation()
+												onRemove(message.id)
+											}}>
+											<span className="codicon codicon-trash" />
+										</Button>
+									</div>
+								</div>
+								{message.images && message.images.length > 0 && (
+									<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
+								)}
+							</div>
+						)
+					})
+				)}
+			</div>
+		)
+	}
+
+	const steerMessages = queue.filter((message) => message.deliveryMode === "steer")
+	const queuedMessages = queue.filter((message) => message.deliveryMode !== "steer")
 
 	return (
 		<div className="px-[15px] py-[10px] pr-[6px]" data-testid="queued-messages">
 			<div className="text-vscode-descriptionForeground text-md mb-2">{t("queuedMessages.title")}</div>
-			<div className="flex flex-col gap-2 max-h-[300px] overflow-y-auto pr-2">
-				{queue.map((message, index) => {
-					const editState = getEditState(message.id, message.text)
-
-					return (
-						<div
-							key={message.id}
-							className="bg-vscode-editor-background border rounded-xs p-1 overflow-hidden whitespace-pre-wrap flex-shrink-0">
-							<div className="flex justify-between">
-								<div className="flex-grow px-2 py-1 wrap-anywhere">
-									{editState.isEditing ? (
-										<textarea
-											ref={(textarea) => {
-												if (textarea) {
-													// Set cursor at the end
-													textarea.setSelectionRange(
-														textarea.value.length,
-														textarea.value.length,
-													)
-												}
-											}}
-											value={editState.value}
-											onChange={(e) => setEditState(message.id, true, e.target.value)}
-											onBlur={() => handleSaveEdit(index, message.id, editState.value)}
-											onKeyDown={(e) => {
-												if (e.key === "Enter" && !e.shiftKey) {
-													e.preventDefault()
-													handleSaveEdit(index, message.id, editState.value)
-												}
-												if (e.key === "Escape") {
-													setEditState(message.id, false, message.text)
-												}
-											}}
-											className="w-full bg-vscode-input-background text-vscode-input-foreground border border-vscode-input-border rounded px-2 py-1 resize-none focus:outline-0 focus:ring-1 focus:ring-vscode-focusBorder"
-											placeholder={t("chat:editMessage.placeholder")}
-											autoFocus
-											rows={Math.min(editState.value.split("\n").length, 10)}
-										/>
-									) : (
-										<div
-											onClick={() => setEditState(message.id, true, message.text)}
-											className="cursor-pointer hover:bg-vscode-list-hoverBackground px-1 py-0.5 -mx-1 -my-0.5 rounded transition-colors"
-											title={t("chat:queuedMessages.clickToEdit")}>
-											<Mention text={message.text} withShadow />
-										</div>
-									)}
-								</div>
-								<div className="flex">
-									<Button
-										variant="ghost"
-										size="icon"
-										className="shrink-0"
-										onClick={(e) => {
-											e.stopPropagation()
-											onRemove(index)
-										}}>
-										<span className="codicon codicon-trash" />
-									</Button>
-								</div>
-							</div>
-							{message.images && message.images.length > 0 && (
-								<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
-							)}
-						</div>
-					)
+			<div className="flex flex-col gap-3 max-h-[320px] overflow-y-auto pr-2">
+				{renderLane("Steer next", steerMessages, {
+					emptyLabel: "No steer messages pending.",
+					alternateActionLabel: "Queue",
+					alternateMode: "queue",
+				})}
+				{renderLane("Queued", queuedMessages, {
+					alternateActionLabel: "Steer",
+					alternateMode: "steer",
 				})}
 			</div>
 		</div>

--- a/webview-ui/src/components/chat/__tests__/ChatView.notification-sound.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.notification-sound.spec.tsx
@@ -83,19 +83,22 @@ vi.mock("../QueuedMessages", () => ({
 		queue = [],
 		onRemove,
 	}: {
-		queue?: Array<{ id: string; text: string; images?: string[] }>
-		onRemove?: (index: number) => void
-		onUpdate?: (index: number, newText: string) => void
+		queue?: Array<{ id: string; text: string; images?: string[]; deliveryMode?: "queue" | "steer" }>
+		onRemove?: (messageId: string) => void
+		onUpdate?: (
+			message: { id: string; text: string; images?: string[] },
+			updates: { text?: string; deliveryMode?: "queue" | "steer" },
+		) => void
 	}) {
 		if (!queue || queue.length === 0) {
 			return null
 		}
 		return (
 			<div data-testid="queued-messages">
-				{queue.map((msg, index) => (
+				{queue.map((msg) => (
 					<div key={msg.id}>
 						<span>{msg.text}</span>
-						<button aria-label="Remove message" onClick={() => onRemove?.(index)}>
+						<button aria-label="Remove message" onClick={() => onRemove?.(msg.id)}>
 							Remove
 						</button>
 					</div>

--- a/webview-ui/src/components/chat/__tests__/ChatView.preserve-images.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.preserve-images.spec.tsx
@@ -78,19 +78,22 @@ vi.mock("../QueuedMessages", () => ({
 		queue = [],
 		onRemove,
 	}: {
-		queue?: Array<{ id: string; text: string; images?: string[] }>
-		onRemove?: (index: number) => void
-		onUpdate?: (index: number, newText: string) => void
+		queue?: Array<{ id: string; text: string; images?: string[]; deliveryMode?: "queue" | "steer" }>
+		onRemove?: (messageId: string) => void
+		onUpdate?: (
+			message: { id: string; text: string; images?: string[] },
+			updates: { text?: string; deliveryMode?: "queue" | "steer" },
+		) => void
 	}) {
 		if (!queue || queue.length === 0) {
 			return null
 		}
 		return (
 			<div data-testid="queued-messages">
-				{queue.map((msg, index) => (
+				{queue.map((msg) => (
 					<div key={msg.id}>
 						<span>{msg.text}</span>
-						<button aria-label="Remove message" onClick={() => onRemove?.(index)}>
+						<button aria-label="Remove message" onClick={() => onRemove?.(msg.id)}>
 							Remove
 						</button>
 					</div>

--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -104,19 +104,30 @@ vi.mock("../QueuedMessages", () => ({
 		queue = [],
 		onRemove,
 	}: {
-		queue?: Array<{ id: string; text: string; images?: string[] }>
-		onRemove?: (index: number) => void
-		onUpdate?: (index: number, newText: string) => void
+		queue?: Array<{
+			id: string
+			text: string
+			images?: string[]
+			timestamp?: number
+			createdAt?: number
+			updatedAt?: number
+			deliveryMode?: "queue" | "steer"
+		}>
+		onRemove?: (messageId: string) => void
+		onUpdate?: (
+			message: { id: string; text: string; images?: string[] },
+			updates: { text?: string; deliveryMode?: "queue" | "steer" },
+		) => void
 	}) {
 		if (!queue || queue.length === 0) {
 			return null
 		}
 		return (
 			<div data-testid="queued-messages">
-				{queue.map((msg, index) => (
+				{queue.map((msg) => (
 					<div key={msg.id}>
 						<span>{msg.text}</span>
-						<button aria-label="Remove message" onClick={() => onRemove?.(index)}>
+						<button aria-label="Remove message" onClick={() => onRemove?.(msg.id)}>
 							Remove
 						</button>
 					</div>
@@ -841,11 +852,14 @@ describe("ChatView - Message Queueing Tests", () => {
 
 		// Verify that the message was queued, not sent as askResponse
 		await waitFor(() => {
-			expect(vscode.postMessage).toHaveBeenCalledWith({
-				type: "queueMessage",
-				text: "follow-up question during spinner",
-				images: [],
-			})
+			expect(vscode.postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "queueMessage",
+					text: "follow-up question during spinner",
+					images: [],
+					deliveryMode: "queue",
+				}),
+			)
 		})
 
 		// Verify it was NOT sent as a direct askResponse (which would get lost)
@@ -971,11 +985,14 @@ describe("ChatView - Message Queueing Tests", () => {
 
 		// Verify that the new message was queued (not sent directly) to preserve order
 		await waitFor(() => {
-			expect(vscode.postMessage).toHaveBeenCalledWith({
-				type: "queueMessage",
-				text: "message during queue drain",
-				images: [],
-			})
+			expect(vscode.postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "queueMessage",
+					text: "message during queue drain",
+					images: [],
+					deliveryMode: "queue",
+				}),
+			)
 		})
 
 		// Verify it was NOT sent as askResponse (which would break ordering)
@@ -1034,11 +1051,14 @@ describe("ChatView - Message Queueing Tests", () => {
 
 		// Verify that the message was queued (not lost via terminalOperation)
 		await waitFor(() => {
-			expect(vscode.postMessage).toHaveBeenCalledWith({
-				type: "queueMessage",
-				text: "message during command execution",
-				images: [],
-			})
+			expect(vscode.postMessage).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: "queueMessage",
+					text: "message during command execution",
+					images: [],
+					deliveryMode: "queue",
+				}),
+			)
 		})
 
 		// Verify it was NOT sent as terminalOperation (which would lose the message)

--- a/webview-ui/src/components/chat/__tests__/QueuedMessages.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/QueuedMessages.spec.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@src/utils/test-utils"
+
+import { QueuedMessages } from "../QueuedMessages"
+
+describe("QueuedMessages", () => {
+	const queue = [
+		{
+			id: "queue-1",
+			text: "queued follow-up",
+			images: [],
+			timestamp: 1,
+			createdAt: 1,
+			updatedAt: 1,
+			deliveryMode: "queue" as const,
+		},
+		{
+			id: "steer-1",
+			text: "steer next",
+			images: [],
+			timestamp: 2,
+			createdAt: 2,
+			updatedAt: 2,
+			deliveryMode: "steer" as const,
+		},
+	]
+
+	it("separates queue and steer lanes and can move messages between them", () => {
+		const onUpdate = vi.fn()
+
+		render(<QueuedMessages queue={queue} onRemove={vi.fn()} onUpdate={onUpdate} />)
+
+		expect(screen.getByText("queued follow-up")).toBeInTheDocument()
+		expect(screen.getByText("steer next")).toBeInTheDocument()
+
+		fireEvent.click(screen.getByRole("button", { name: "Steer" }))
+		expect(onUpdate).toHaveBeenCalledWith(queue[0], { deliveryMode: "steer" })
+
+		fireEvent.click(screen.getByRole("button", { name: "Queue" }))
+		expect(onUpdate).toHaveBeenCalledWith(queue[1], { deliveryMode: "queue" })
+	})
+
+	it("saves edited queued message text", () => {
+		const onUpdate = vi.fn()
+
+		render(<QueuedMessages queue={[queue[0]]} onRemove={vi.fn()} onUpdate={onUpdate} />)
+
+		fireEvent.click(screen.getByText("queued follow-up"))
+
+		const editor = screen.getByRole("textbox")
+		fireEvent.change(editor, { target: { value: "updated follow-up" } })
+		fireEvent.keyDown(editor, { key: "Enter", code: "Enter" })
+
+		expect(onUpdate).toHaveBeenCalledWith(queue[0], { text: "updated follow-up" })
+	})
+})


### PR DESCRIPTION
### Related GitHub Issue

Closes: #133

### Description

This PR adds explicit queue and steer delivery modes for messages sent while a conversation is running. It is stacked on the concurrent-conversations work from PR #128.

Dependency PR: #128. Please review/merge #128 first; until then this PR is intentionally opened as a stacked draft and its GitHub diff against `main` may include the concurrent-conversations prerequisite.

Key changes:

- Adds `QueuedMessageDeliveryMode` and extends queued-message payloads with `createdAt`, `updatedAt`, and `deliveryMode`.
- Reworks `MessageQueueService` into separate `queue` and `steer` lanes with steer-first combined ordering, lane-specific dequeue, delivery-mode switching, restore support, and tests.
- Updates webview message handling to resolve the target task before and after image resolution, preserve dropped input, and pass delivery mode through queue/edit actions.
- Updates `QueuedMessages` UI to show separate "Steer next" and "Queued" lanes with edit, remove, and Queue/Steer toggle actions.
- Updates Task handoff behavior so ordinary queued messages drain only at appropriate follow-up/idle handoffs, while steer messages can be consumed at API boundaries or after completed tool boundaries.
- Adds synthetic tool results for skipped tool calls when steer input interrupts after a tool boundary.
- Preserves queued/steer messages across cancel/replacement and defers draining until resume.
- Keeps the legacy `processQueuedMessages()` method as a no-op compatibility shim so queued messages are not drained from unsafe call sites.
- Adds focused tests for queue service lanes, queued-message UI, ask drain behavior, task steer boundaries, and cancel restoration.

Reviewer focus:

- Boundary safety for steer delivery and provider API history validity.
- Whether the UI language clearly distinguishes ordinary queued input from steer input.
- Whether cancel/resume restoration preserves user intent without prematurely delivering queued messages.
- Interaction with concurrent conversation switching from PR #128.

### Test Procedure

From the Zoo Code worktree after the concurrent-conversations branch is present:

```bash
pnpm lint
pnpm check-types
pnpm --filter zoo-code test -- core/message-queue/__tests__/MessageQueueService.spec.ts core/task/__tests__/Task.spec.ts core/task/__tests__/ask-queued-message-drain.spec.ts core/webview/__tests__/ClineProvider.flicker-free-cancel.spec.ts
pnpm --filter @roo-code/vscode-webview test -- src/components/chat/__tests__/QueuedMessages.spec.tsx src/components/chat/__tests__/ChatView.spec.tsx
```

Manual verification recommended:

- Start a long-running conversation.
- Send one message as queued input and one as steer input.
- Confirm the queued-message list shows both messages and their delivery modes.
- Edit a queued message before it is delivered.
- Confirm steer input is delivered at a safe boundary and ordinary queued input is drained in order.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [ ] **Scope**: My changes are focused on the linked issue.
- [ ] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates.
- [ ] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshots / Videos

TODO: Attach a short video showing messages being queued, edited, switched between delivery modes, and delivered during a running conversation.

### Documentation Updates

Yes. User-facing docs should explain the difference between queued input and steer input.

### Additional Notes

This should be reviewed after or on top of PR #128. If opened before #128 merges, the GitHub diff against Zoo `main` will include prerequisite concurrent-conversation changes.

### Get in Touch

Discord: `coorbin`
