### PR TITLE
Welcome screen fix

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1610,8 +1610,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					)}
 				</>
 			) : (
-				<div className="flex flex-col h-full justify-center p-6 min-h-0 overflow-y-auto gap-4 relative">
-					<div className="flex flex-col items-start gap-2 justify-center h-full min-[400px]:px-6">
+				<div className="flex flex-col h-full p-6 min-h-0 overflow-y-auto gap-4 relative">
+					<div className="flex flex-col items-start gap-2 my-auto min-[400px]:px-6">
 						<VersionIndicator
 							onClick={() => setShowAnnouncementModal(true)}
 							className="absolute top-2 right-3 z-10"


### PR DESCRIPTION
### Related GitHub Issue

Closes: #162

### Description

The welcome screen (displayed when no task is active) used `justify-center` on both the outer scroll container and inner content wrapper. This is a well-known CSS flexbox pitfall: when content overflows the container, `justify-center` positions the content at the geometric center of the flex container, pushing the top portion above the scroll boundary. Since browsers cannot scroll to negative offsets, the top content (RooHero, RooTips) becomes permanently unreachable.

This manifests when `HistoryPreview` shows 4 task groups (the max it displays via `groups.slice(0, 4)`), which combined with RooHero and RooTips exceeds the sidebar viewport height.

**Fix:** Replace `justify-center` with the `my-auto` pattern on the inner content wrapper in [`ChatView.tsx`](webview-ui/src/components/chat/ChatView.tsx:1613-1614):

- Outer container: Removed `justify-center` (keeps `overflow-y-auto` and `min-h-0` for scrolling)
- Inner div: Replaced `justify-center h-full` with `my-auto`

The `my-auto` pattern (`margin-top: auto; margin-bottom: auto`) centers content when it fits within the viewport (auto margins split free space equally), but gracefully falls back to top-alignment when content overflows (auto margins collapse to 0), allowing `overflow-y-auto` to scroll to all content.

**Roadmap alignment:** Enhanced User Experience — fixes a friction point where users with task history cannot access the welcome screen hero/tips content.

### Test Procedure

1. **Unit tests:** All 339 chat tests and 11 welcome tests pass
2. **Type check:** `webview-ui` passes `pnpm run check-types` cleanly
3. **Manual testing:**
   - Open Zoo Code with no active task and 4+ items in task history
   - Verify RooHero and RooTips are visible at the top of the welcome screen
   - Scroll down to verify HistoryPreview items are accessible
   - Verify that with 0-1 history items, the welcome content is still vertically centered

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (#162)
- [x] **Scope**: My changes are focused on the linked issue (one fix per PR)
- [x] **Self-Review**: I have performed a thorough self-review of my code
- [x] **Testing**: Existing tests cover this change; no new tests needed as this is a CSS-only fix with no behavioral logic change
- [x] **Documentation Impact**: No documentation updates required
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines

### Screenshots / Videos

<!-- Before: with 4+ history items, RooHero and RooTips are pushed above the scroll boundary and unreachable -->
<img width="495" height="708" alt="Screenshot 2026-05-17 at 11 08 45 PM" src="https://github.com/user-attachments/assets/aa6bfe20-de1d-41d3-938a-bd69dbf3dc41" />
<!-- After: all content starts from the top and is scrollable; when content fits, it remains centered -->
<img width="511" height="732" alt="Screenshot 2026-05-17 at 11 26 45 PM" src="https://github.com/user-attachments/assets/6a3149b9-2fd8-4d27-b42d-a9685f09855e" />

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This is a minimal, surgical CSS fix — two class name changes, no logic or component structure modifications. The `my-auto` pattern is the standard solution for the "flexbox centering overflow" problem (see [CSS-Tricks: Flexbox Truncation](https://css-tricks.com/flexbox-truncation-text/)).

### Get in Touch

navedmerchant

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the 'no active task' UI layout container for improved scrollability and element spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->