### PR TITLE
fix(webview): use zoo-diagnostics- prefix for diagnostics temp file (#193)

### DIFF
--- a/src/core/webview/__tests__/diagnosticsHandler.spec.ts
+++ b/src/core/webview/__tests__/diagnosticsHandler.spec.ts
@@ -74,7 +74,7 @@ describe("generateErrorDiagnostics", () => {
 		})
 
 		expect(result.success).toBe(true)
-		expect(result.filePath).toContain("roo-diagnostics-")
+		expect(result.filePath).toContain("zoo-diagnostics-")
 
 		// Verify we attempted to read API history
 		expect(fs.readFile).toHaveBeenCalledWith(path.join("/mock/task-dir", "api_conversation_history.json"), "utf8")
@@ -83,7 +83,7 @@ describe("generateErrorDiagnostics", () => {
 		expect(fs.writeFile).toHaveBeenCalledTimes(1)
 		const [writtenPath, writtenContent] = vi.mocked(fs.writeFile).mock.calls[0]
 		// taskId.slice(0, 8) = "test-tas" from "test-task-id"
-		expect(String(writtenPath)).toContain("roo-diagnostics-test-tas")
+		expect(String(writtenPath)).toContain("zoo-diagnostics-test-tas")
 		expect(String(writtenContent)).toContain(
 			"// Please share this file with Zoo Code Support (support@zoocode.dev) to diagnose the issue faster",
 		)

--- a/src/core/webview/diagnosticsHandler.ts
+++ b/src/core/webview/diagnosticsHandler.ts
@@ -73,7 +73,7 @@ export async function generateErrorDiagnostics(params: GenerateDiagnosticsParams
 		// Create a temporary diagnostics file
 		const tmpDir = os.tmpdir()
 		const timestamp = Date.now()
-		const tempFileName = `roo-diagnostics-${taskId.slice(0, 8)}-${timestamp}.json`
+		const tempFileName = `zoo-diagnostics-${taskId.slice(0, 8)}-${timestamp}.json`
 		const tempFilePath = path.join(tmpDir, tempFileName)
 
 		await fs.writeFile(tempFilePath, fullContent, "utf8")


### PR DESCRIPTION
## Summary

Fixes #193. The diagnostics temp file is still created with the legacy `roo-diagnostics-` prefix; this renames it to `zoo-diagnostics-` to match the Roo → Zoo rebrand.

## Note on history (re-opening earlier work)

This re-does the fix from #194, which I closed myself by mistake. That night I had two Shift+Enter PRs in play — my #202 was correctly superseded by #199 — and a few hours later I mistakenly closed #194 (diagnostics) citing "#199" too. #194 is unrelated to #199 (different feature, no shared files), so the diagnostics bug was never actually fixed. Reopening cleanly here with proof.

## Proof the bug is still live on `main`

`src/core/webview/diagnosticsHandler.ts:76`
```ts
const tempFileName = `roo-diagnostics-${taskId.slice(0, 8)}-${timestamp}.json`
```
#199 (merged 2026-05-19) only touched `webview-ui/.../ChatTextArea.tsx`, so it could not have changed this line.

## Change

- `src/core/webview/diagnosticsHandler.ts`: `roo-diagnostics-` → `zoo-diagnostics-`
- Updated test expectations in `diagnosticsHandler.spec.ts`

## Testing

```
vitest run core/webview/__tests__/diagnosticsHandler.spec.ts
# Test Files 1 passed (1) · Tests 5 passed (5)
```

Thanks for the earlier reviews on #194 (@navedmerchant, @edelauna) — reusing that work here. Sorry for the churn!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the naming convention for generated diagnostic files to improve consistency and identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->