### PR TITLE
fix(diff): repair truncated Grok diffs with missing markers (#186)

### DIFF
--- a/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
@@ -1286,6 +1286,44 @@ function sum(a, b) {
 			const result = strategy["repairTruncatedDiff"](diff)
 			expect(result).toBe("<<<<<<< SEARCH\n" + "original\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE")
 		})
+
+		it("inserts ======= before an existing closer instead of synthesizing a second one", () => {
+			// Has >>>>>>> REPLACE but no ======= separator.
+			const diff = "<<<<<<< SEARCH\n" + "old line\n" + ">>>>>>> REPLACE"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe("<<<<<<< SEARCH\n" + "old line\n" + "=======\n" + ">>>>>>> REPLACE")
+			// Exactly one closer, exactly one separator.
+			expect(result.match(/>>>>>>> REPLACE/g)).toHaveLength(1)
+			expect(result.match(/^=======$/gm)).toHaveLength(1)
+		})
+
+		it("preserves :start_line: / ------- directives instead of treating them as SEARCH content", () => {
+			const diff = "<<<<<<< SEARCH\n" + ":start_line:5\n" + "-------\n" + "old line\n" + "new line"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(
+				"<<<<<<< SEARCH\n" +
+					":start_line:5\n" +
+					"-------\n" +
+					"old line\n" +
+					"=======\n" +
+					"new line\n" +
+					">>>>>>> REPLACE",
+			)
+		})
+
+		it("treats a single content line after a directive header as the SEARCH target", () => {
+			const diff = "<<<<<<< SEARCH\n" + ":start_line:5\n" + "-------\n" + "old line"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(
+				"<<<<<<< SEARCH\n" +
+					":start_line:5\n" +
+					"-------\n" +
+					"old line\n" +
+					"=======\n" +
+					"\n" +
+					">>>>>>> REPLACE",
+			)
+		})
 	})
 
 	// Regression guards for #186: Grok sometimes truncates the streamed diff and drops

--- a/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
@@ -1287,4 +1287,53 @@ function sum(a, b) {
 			expect(result).toBe("<<<<<<< SEARCH\n" + "original\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE")
 		})
 	})
+
+	// Regression guards for #186: Grok sometimes truncates the streamed diff and drops
+	// the closing markers, which previously surfaced as "Unable to apply diff - Expected
+	// '=======' was not found". These fixtures exercise the full applyDiff() path end-to-end.
+	describe("truncated Grok diff regression (#186)", () => {
+		const grokStrategy = new MultiSearchReplaceDiffStrategy(1.0, 5)
+		const originalContent = 'function greet() {\n\treturn "hello"\n}\n'
+		const expectedContent = 'function greet() {\n\treturn "hi there"\n}\n'
+
+		it("applies a diff whose closing >>>>>>> REPLACE marker was truncated", async () => {
+			const diff =
+				"src/greet.ts\n" + "<<<<<<< SEARCH\n" + '\treturn "hello"\n' + "=======\n" + '\treturn "hi there"'
+			const result = await grokStrategy.applyDiff(originalContent, diff)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe(expectedContent)
+			}
+		})
+
+		it("applies a diff truncated before the ======= separator", async () => {
+			const diff = "src/greet.ts\n" + "<<<<<<< SEARCH\n" + '\treturn "hello"\n' + '\treturn "hi there"'
+			const result = await grokStrategy.applyDiff(originalContent, diff)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe(expectedContent)
+			}
+		})
+
+		it("leaves a well-formed multi-block diff unchanged", async () => {
+			const multiBlock = "export const a = 1\nexport const b = 2\n"
+			const diff =
+				"src/consts.ts\n" +
+				"<<<<<<< SEARCH\n" +
+				"export const a = 1\n" +
+				"=======\n" +
+				"export const a = 10\n" +
+				">>>>>>> REPLACE\n" +
+				"<<<<<<< SEARCH\n" +
+				"export const b = 2\n" +
+				"=======\n" +
+				"export const b = 20\n" +
+				">>>>>>> REPLACE"
+			const result = await grokStrategy.applyDiff(multiBlock, diff)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe("export const a = 10\nexport const b = 20\n")
+			}
+		})
+	})
 })

--- a/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
@@ -1204,4 +1204,87 @@ function sum(a, b) {
 			expect(result.error).toContain(":start_line:5    <-- Invalid location")
 		})
 	})
+
+	describe("repairTruncatedDiff", () => {
+		let strategy: MultiSearchReplaceDiffStrategy
+
+		beforeEach(() => {
+			strategy = new MultiSearchReplaceDiffStrategy()
+		})
+
+		it("should not modify a complete diff", () => {
+			const diff = "<<<<<<< SEARCH\n" + "original content\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(diff)
+		})
+
+		it("should not modify a diff with multiple complete blocks", () => {
+			const diff =
+				"<<<<<<< SEARCH\n" +
+				"content1\n" +
+				"=======\n" +
+				"new1\n" +
+				">>>>>>> REPLACE\n\n" +
+				"<<<<<<< SEARCH\n" +
+				"content2\n" +
+				"=======\n" +
+				"new2\n" +
+				">>>>>>> REPLACE"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(diff)
+		})
+
+		it("should repair diff missing ======= and >>>>>>> REPLACE", () => {
+			const diff = "<<<<<<< SEARCH\n" + "original content\n" + "new content"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(
+				"<<<<<<< SEARCH\n" + "original content\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE",
+			)
+		})
+
+		it("should repair diff missing only >>>>>>> REPLACE", () => {
+			const diff = "<<<<<<< SEARCH\n" + "original content\n" + "=======\n" + "new content"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(
+				"<<<<<<< SEARCH\n" + "original content\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE",
+			)
+		})
+
+		it("should repair first truncated block while preserving subsequent complete blocks", () => {
+			const diff =
+				"<<<<<<< SEARCH\n" +
+				"content1\n" +
+				"new1\n\n" +
+				"<<<<<<< SEARCH\n" +
+				"content2\n" +
+				"=======\n" +
+				"new2\n" +
+				">>>>>>> REPLACE"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe(
+				"<<<<<<< SEARCH\n" +
+					"content1\n" +
+					"=======\n" +
+					"new1\n" +
+					">>>>>>> REPLACE\n\n" +
+					"<<<<<<< SEARCH\n" +
+					"content2\n" +
+					"=======\n" +
+					"new2\n" +
+					">>>>>>> REPLACE",
+			)
+		})
+
+		it("should handle empty search content with missing replace marker", () => {
+			const diff = "<<<<<<< SEARCH\n" + "replacement text"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe("<<<<<<< SEARCH\n" + "=======\n" + "replacement text\n" + ">>>>>>> REPLACE")
+		})
+
+		it("should not add trailing newline if content already ends with one", () => {
+			const diff = "<<<<<<< SEARCH\n" + "original\n" + "=======\n" + "new content\n"
+			const result = strategy["repairTruncatedDiff"](diff)
+			expect(result).toBe("<<<<<<< SEARCH\n" + "original\n" + "=======\n" + "new content\n" + ">>>>>>> REPLACE")
+		})
+	})
 })

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -295,10 +295,28 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 				// Has ======= but missing >>>>>>> REPLACE — append closing marker
 				const body = block.replace(/\s+$/, "")
 				repaired += body + "\n>>>>>>> REPLACE" + separator
+			} else if (hasCloser && !hasSeparator) {
+				// Has >>>>>>> REPLACE but missing the ======= separator. Don't synthesize a
+				// second closer; splice the separator in right before the existing closer so
+				// everything above it becomes the SEARCH section.
+				const body = block.replace(/\s+$/, "")
+				repaired += body.replace(/(\n)(>>>>>>> REPLACE)(?=\n|$)/, "$1=======\n$2") + separator
 			} else {
-				// Missing both ======= and >>>>>>> REPLACE
+				// Missing both ======= and >>>>>>> REPLACE.
 				const searchMatch = block.match(/^<<<<<<< SEARCH\n?([\s\S]*)$/)
-				const content = (searchMatch?.[1] ?? "").replace(/\s+$/, "")
+				let content = (searchMatch?.[1] ?? "").replace(/\s+$/, "")
+
+				// Peel off any leading Grok header directives (:start_line:, :end_line:, -------)
+				// so the "first line is SEARCH" heuristic sees real content, not metadata. The
+				// directives are preserved as a header on the SEARCH section.
+				let header = ""
+				const directiveLine = /^(?::start_line:\s*\d+|:end_line:\s*\d+|-------)\s*$/
+				let nlIdx: number
+				while ((nlIdx = content.indexOf("\n")) !== -1 && directiveLine.test(content.slice(0, nlIdx))) {
+					header += content.slice(0, nlIdx + 1)
+					content = content.slice(nlIdx + 1)
+				}
+
 				const firstNewlineIdx = content.indexOf("\n")
 				if (firstNewlineIdx !== -1) {
 					// First line is SEARCH content, rest is REPLACE content
@@ -306,11 +324,16 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 					const replaceContent = content.substring(firstNewlineIdx + 1)
 					repaired +=
 						"<<<<<<< SEARCH\n" +
+						header +
 						searchContent +
 						"\n=======\n" +
 						replaceContent +
 						"\n>>>>>>> REPLACE" +
 						separator
+				} else if (header) {
+					// Only a directive header plus a single content line: that line is the SEARCH
+					// target (the user pinned it with start_line); the REPLACE section is empty.
+					repaired += "<<<<<<< SEARCH\n" + header + content + "\n=======\n\n>>>>>>> REPLACE" + separator
 				} else {
 					// Single line — treat as empty SEARCH with content as REPLACE
 					repaired += "<<<<<<< SEARCH\n=======\n" + content + "\n>>>>>>> REPLACE" + separator
@@ -329,9 +352,9 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 	): Promise<DiffResult> {
 		// Repair truncated diffs before validation (common with Grok and other models
 		// whose output gets cut off mid-stream, leaving missing ======= and >>>>>>> REPLACE markers)
-		diffContent = this.repairTruncatedDiff(diffContent)
+		const repairedDiff = this.repairTruncatedDiff(diffContent)
 
-		const validseq = this.validateMarkerSequencing(diffContent)
+		const validseq = this.validateMarkerSequencing(repairedDiff)
 		if (!validseq.success) {
 			return {
 				success: false,
@@ -371,7 +394,7 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 		*/
 
 		let matches = [
-			...diffContent.matchAll(
+			...repairedDiff.matchAll(
 				/(?:^|\n)(?<!\\)<<<<<<< SEARCH>?\s*\n((?:\:start_line:\s*(\d+)\s*\n))?((?:\:end_line:\s*(\d+)\s*\n))?((?<!\\)-------\s*\n)?([\s\S]*?)(?:\n)?(?:(?<=\n)(?<!\\)=======\s*\n)([\s\S]*?)(?:\n)?(?:(?<=\n)(?<!\\)>>>>>>> REPLACE)(?=\n|$)/g,
 			),
 		]

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -242,12 +242,95 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 				}
 	}
 
+	/**
+	 * Repairs truncated diffs (common with Grok) by adding missing ======= and >>>>>>> REPLACE markers.
+	 * When the model's output gets cut off mid-stream, the diff may end after SEARCH content
+	 * without the separator or closing marker. This method detects that pattern and appends
+	 * the missing markers so the diff can still be parsed and applied.
+	 */
+	private repairTruncatedDiff(diffContent: string): string {
+		// Only repair if the diff has at least one SEARCH marker
+		if (!/(?<!\\)<<<<<<< SEARCH/.test(diffContent)) {
+			return diffContent
+		}
+
+		// Split into blocks based on SEARCH markers
+		const blocks = diffContent.split(/(?=(?<!\\)<<<<<<< SEARCH)/)
+
+		let repaired = ""
+		let needsRepair = false
+
+		for (let i = 0; i < blocks.length; i++) {
+			const block = blocks[i]
+
+			if (block.trim() === "") {
+				continue
+			}
+
+			// Skip prefix blocks that don't contain a SEARCH marker
+			// (e.g., the filename line before the first <<<<<<< SEARCH)
+			if (!/(?<!\\)<<<<<<< SEARCH/.test(block)) {
+				repaired += block
+				continue
+			}
+
+			// Check if this block is complete (has both ======= and >>>>>>> REPLACE)
+			const hasSeparator = /(?<=\n)(?<!\\)=======\s*\n/.test(block)
+			const hasCloser = /(?<=\n)(?<!\\)>>>>>>> REPLACE(?=\n|$)/.test(block)
+
+			if (hasSeparator && hasCloser) {
+				// Block is complete — emit verbatim (keeps its own trailing separator)
+				repaired += block
+				continue
+			}
+
+			// Block needs repair. Build a clean block ending at >>>>>>> REPLACE, then
+			// re-add an inter-block separator if more (non-empty) blocks follow, so the
+			// appended closer never gets glued to the next "<<<<<<< SEARCH".
+			needsRepair = true
+			const isLast = blocks.slice(i + 1).every((b) => b.trim() === "")
+			const separator = isLast ? "" : "\n\n"
+
+			if (hasSeparator && !hasCloser) {
+				// Has ======= but missing >>>>>>> REPLACE — append closing marker
+				const body = block.replace(/\s+$/, "")
+				repaired += body + "\n>>>>>>> REPLACE" + separator
+			} else {
+				// Missing both ======= and >>>>>>> REPLACE
+				const searchMatch = block.match(/^<<<<<<< SEARCH\n?([\s\S]*)$/)
+				const content = (searchMatch?.[1] ?? "").replace(/\s+$/, "")
+				const firstNewlineIdx = content.indexOf("\n")
+				if (firstNewlineIdx !== -1) {
+					// First line is SEARCH content, rest is REPLACE content
+					const searchContent = content.substring(0, firstNewlineIdx)
+					const replaceContent = content.substring(firstNewlineIdx + 1)
+					repaired +=
+						"<<<<<<< SEARCH\n" +
+						searchContent +
+						"\n=======\n" +
+						replaceContent +
+						"\n>>>>>>> REPLACE" +
+						separator
+				} else {
+					// Single line — treat as empty SEARCH with content as REPLACE
+					repaired += "<<<<<<< SEARCH\n=======\n" + content + "\n>>>>>>> REPLACE" + separator
+				}
+			}
+		}
+
+		return repaired || diffContent
+	}
+
 	async applyDiff(
 		originalContent: string,
 		diffContent: string,
 		_paramStartLine?: number,
 		_paramEndLine?: number,
 	): Promise<DiffResult> {
+		// Repair truncated diffs before validation (common with Grok and other models
+		// whose output gets cut off mid-stream, leaving missing ======= and >>>>>>> REPLACE markers)
+		diffContent = this.repairTruncatedDiff(diffContent)
+
 		const validseq = this.validateMarkerSequencing(diffContent)
 		if (!validseq.success) {
 			return {

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -258,7 +258,6 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 		const blocks = diffContent.split(/(?=(?<!\\)<<<<<<< SEARCH)/)
 
 		let repaired = ""
-		let needsRepair = false
 
 		for (let i = 0; i < blocks.length; i++) {
 			const block = blocks[i]
@@ -287,7 +286,6 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 			// Block needs repair. Build a clean block ending at >>>>>>> REPLACE, then
 			// re-add an inter-block separator if more (non-empty) blocks follow, so the
 			// appended closer never gets glued to the next "<<<<<<< SEARCH".
-			needsRepair = true
 			const isLast = blocks.slice(i + 1).every((b) => b.trim() === "")
 			const separator = isLast ? "" : "\n\n"
 


### PR DESCRIPTION
## Summary

Fixes #186. Grok (4.3) frequently truncates streamed diffs mid-output, so a `<<<<<<< SEARCH` block can arrive without its `=======` separator and/or `>>>>>>> REPLACE` closer. The parser then rejects the whole edit with *"Expected '=======' was not found"* and the user sees **"Unable to apply diff"**.

This adds a small recovery layer, `repairTruncatedDiff()`, called at the start of `applyDiff()` that reconstructs the missing markers so a salvageable diff can still be applied.

## How it works

For each `<<<<<<< SEARCH` block the repair step:
- leaves **complete** blocks (both `=======` and `>>>>>>> REPLACE`) untouched, verbatim;
- if only `>>>>>>> REPLACE` is missing, appends it;
- if both markers are missing, treats the first line after `SEARCH` as the search content and the rest as the replacement, then inserts `=======` and `>>>>>>> REPLACE`;
- preserves escaped markers via `(?<!\\)` look-behinds (won't touch `\<<<<<<<` content);
- when a repaired block is followed by more blocks, re-adds an inter-block separator so the appended `>>>>>>> REPLACE` never gets glued to the next `<<<<<<< SEARCH`.

Complete, valid diffs pass through unchanged, so behavior for well-formed input is identical.

## Testing

Added coverage in `multi-search-replace.spec.ts` (complete-diff passthrough, missing closer, missing both markers, empty-search edge case, multi-block truncation, no spurious trailing newline).

```
vitest run core/diff/strategies/__tests__/multi-search-replace.spec.ts
# Test Files 1 passed (1) · Tests 65 passed (65)
```

## Files
- `src/core/diff/strategies/multi-search-replace.ts` — `repairTruncatedDiff()` + call in `applyDiff()`
- `src/core/diff/strategies/__tests__/multi-search-replace.spec.ts` — tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of truncated merge-style diffs: missing separators and end markers are detected and synthesized so truncated outputs are repaired without changing well-formed diffs. Preserves directive/header lines, handles empty search blocks, maintains trailing-newline behavior, and limits repair to the first truncated block when later blocks are complete.

* **Tests**
  * Added targeted and regression tests covering multiple truncation scenarios and edge cases to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->