### PR TITLE
fix(openai): omit temperature for models that don't support it (#215)

### DIFF
--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -4,7 +4,7 @@ import { OpenAiHandler, getOpenAiModels } from "../openai"
 import { ApiHandlerOptions } from "../../../shared/api"
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
-import { openAiModelInfoSaneDefaults } from "@roo-code/types"
+import { openAiModelInfoSaneDefaults, DEEP_SEEK_DEFAULT_TEMPERATURE } from "@roo-code/types"
 import { Package } from "../../../shared/package"
 import axios from "axios"
 
@@ -416,6 +416,26 @@ describe("OpenAiHandler", () => {
 			expect(mockCreate).toHaveBeenCalled()
 			const callArgs = mockCreate.mock.calls[0][0]
 			expect(callArgs).toHaveProperty("temperature")
+		})
+
+		it("should use the configured modelTemperature when supportsTemperature is not false", async () => {
+			const customTempHandler = new OpenAiHandler({ ...mockOptions, modelTemperature: 0.5 })
+			const stream = customTempHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.temperature).toBe(0.5)
+		})
+
+		it("should default to DEEP_SEEK_DEFAULT_TEMPERATURE for deepseek-reasoner models", async () => {
+			const deepseekHandler = new OpenAiHandler({ ...mockOptions, openAiModelId: "deepseek-reasoner" })
+			const stream = deepseekHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.temperature).toBe(DEEP_SEEK_DEFAULT_TEMPERATURE)
 		})
 
 		it("should include max_tokens when includeMaxTokens is true", async () => {

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -391,6 +391,33 @@ describe("OpenAiHandler", () => {
 			expect(callArgs.reasoning_effort).toBeUndefined()
 		})
 
+		it("should omit temperature when the model sets supportsTemperature to false", async () => {
+			const noTempOptions: ApiHandlerOptions = {
+				...mockOptions,
+				openAiCustomModelInfo: {
+					contextWindow: 128_000,
+					supportsPromptCache: false,
+					supportsTemperature: false,
+				},
+			}
+			const noTempHandler = new OpenAiHandler(noTempOptions)
+			const stream = noTempHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs).not.toHaveProperty("temperature")
+		})
+
+		it("should include temperature by default when supportsTemperature is not set", async () => {
+			const stream = handler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs).toHaveProperty("temperature")
+		})
+
 		it("should include max_tokens when includeMaxTokens is true", async () => {
 			const optionsWithMaxTokens: ApiHandlerOptions = {
 				...mockOptions,

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -154,7 +154,13 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 				model: modelId,
-				temperature: this.options.modelTemperature ?? (deepseekReasoner ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0),
+				// Some OpenAI-Compatible models (e.g. claude-opus-4-7) reject `temperature` as
+				// deprecated/unsupported. Honor the model's `supportsTemperature` flag and omit it
+				// when explicitly set to false (undefined still sends temperature, preserving behavior).
+				...(modelInfo.supportsTemperature !== false && {
+					temperature:
+						this.options.modelTemperature ?? (deepseekReasoner ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0),
+				}),
 				messages: convertedMessages,
 				stream: true as const,
 				...(isGrokXAI ? {} : { stream_options: { include_usage: true } }),


### PR DESCRIPTION
## Summary

Fixes #215. Using `claude-opus-4-7` through the **OpenAI-Compatible** provider fails with a `400` error because the upstream API (e.g. via LiteLLM/Bedrock) rejects `temperature` as deprecated/unsupported for that model.

`OpenAiHandler.createMessage()` always included `temperature` in the streaming request. This honors the model's existing `supportsTemperature` flag — already respected by `openai-native`, `gemini`, `lite-llm` and `vercel-ai-gateway` — and omits `temperature` when it is explicitly set to `false`.

## Behavior

- `supportsTemperature: false` → `temperature` is omitted from the request.
- `undefined` / `true` → `temperature` is sent exactly as before (no behavior change for existing models).

Users hitting this can set **Supports temperature → off** on the OpenAI-Compatible model (the flag already exists in `ModelInfo` and the settings UI).

## Testing

```
vitest run api/providers/__tests__/openai.spec.ts
# Test Files 1 passed (1) · Tests 50 passed (50)
```
Added tests asserting `temperature` is omitted when `supportsTemperature: false` and included by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Omit temperature for models that don't support temperature while preserving prior behavior for others; ensure DeepSeek reasoner models use the correct default temperature.
* **Tests**
  * Added tests covering temperature behavior: omitted when unsupported, included by default, honored when explicitly set, and defaulted for DeepSeek models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->