### PR TITLE
fix(shell): report PowerShell on Windows when no profile is configured (#82)

### DIFF
--- a/src/utils/__tests__/shell.spec.ts
+++ b/src/utils/__tests__/shell.spec.ts
@@ -173,23 +173,27 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
-		it("respects userInfo() if no VS Code config is available and shell is allowed", () => {
+		it("defaults to Windows PowerShell when VS Code has no configured profile", () => {
+			// Modern VS Code launches PowerShell by default on Windows (issue #82), so
+			// getShell() should report PowerShell rather than falling through to cmd.exe.
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			vi.mocked(userInfo).mockReturnValue({ shell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" } as any)
 
-			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
-		it("falls back to safe shell when userInfo() returns non-allowlisted shell", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
-			vi.mocked(userInfo).mockReturnValue({ shell: "C:\\Custom\\PowerShell.exe" } as any)
+		it("falls back to safe shell when the configured profile path is non-allowlisted", () => {
+			mockVsCodeConfig("windows", "Custom", {
+				Custom: { path: "C:\\Custom\\evil.exe" },
+			})
 
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
-		it("falls back to safe shell when COMSPEC is non-allowlisted", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
-			process.env.COMSPEC = "D:\\CustomCmd\\cmd.exe"
+		it("uses cmd.exe when a Command Prompt profile is explicitly configured", () => {
+			mockVsCodeConfig("windows", "Command Prompt", {
+				"Command Prompt": { path: "C:\\Windows\\System32\\cmd.exe" },
+			})
 
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})

--- a/src/utils/__tests__/shell.spec.ts
+++ b/src/utils/__tests__/shell.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import * as vscode from "vscode"
+import { existsSync } from "fs"
 import { userInfo } from "os"
 import { getShell } from "../shell"
 
@@ -13,6 +14,11 @@ vi.mock("vscode", () => ({
 // Mock the os module
 vi.mock("os", () => ({
 	userInfo: vi.fn(() => ({ shell: null })),
+}))
+
+// Mock the fs module — getWindowsShellFromVSCode probes for PowerShell 7 (pwsh.exe).
+vi.mock("fs", () => ({
+	existsSync: vi.fn(() => false),
 }))
 
 // Mock path module for testing
@@ -57,6 +63,8 @@ describe("Shell Detection Tests", () => {
 
 		// Reset userInfo mock to default
 		vi.mocked(userInfo).mockReturnValue({ shell: null } as any)
+		// Default: PowerShell 7 is not installed, so the probe falls back to legacy.
+		vi.mocked(existsSync).mockReturnValue(false)
 	})
 
 	afterEach(() => {
@@ -173,11 +181,20 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
-		it("defaults to Windows PowerShell when VS Code has no configured profile", () => {
-			// Modern VS Code launches PowerShell by default on Windows (issue #82), so
-			// getShell() should report PowerShell rather than falling through to cmd.exe.
+		it("defaults to PowerShell 7 when no profile is configured and pwsh.exe is installed", () => {
+			// Modern VS Code launches PowerShell by default on Windows (issue #82) and
+			// prefers PS7 when present, so getShell() should report pwsh.exe.
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
-			vi.mocked(userInfo).mockReturnValue({ shell: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" } as any)
+			vi.mocked(existsSync).mockReturnValue(true)
+
+			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+		})
+
+		it("falls back to Windows PowerShell 5.1 when no profile is configured and PS7 is absent", () => {
+			// Without PS7 installed, the probe falls back to the always-present legacy
+			// PowerShell rather than cmd.exe.
+			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			vi.mocked(existsSync).mockReturnValue(false)
 
 			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { existsSync } from "fs"
 import { userInfo } from "os"
 import * as path from "path"
 
@@ -188,13 +189,12 @@ function normalizeShellPath(path: string | string[] | undefined): string | null 
 function getWindowsShellFromVSCode(): string | null {
 	const { defaultProfileName, profiles } = getWindowsTerminalConfig()
 	if (!defaultProfileName) {
-		// No explicit Windows terminal profile is configured. VS Code's built-in
-		// default on modern Windows is PowerShell (not cmd.exe), and that is the
-		// shell the integrated terminal actually launches. Mirror it here so the
-		// system prompt advertises the real shell instead of falling through to
-		// COMSPEC (cmd.exe). Windows PowerShell is always present, so it is a safe
-		// allowlisted default. See issue #82.
-		return SHELL_PATHS.POWERSHELL_LEGACY
+		// No explicit Windows terminal profile is configured. VS Code auto-detects
+		// the default on modern Windows and prefers PowerShell 7 (pwsh.exe) when it
+		// is installed, otherwise the always-present Windows PowerShell 5.1. Mirror
+		// that here so the system prompt advertises the real shell instead of falling
+		// through to COMSPEC (cmd.exe). See issue #82.
+		return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
 	}
 
 	const profile = profiles[defaultProfileName]

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -188,7 +188,13 @@ function normalizeShellPath(path: string | string[] | undefined): string | null 
 function getWindowsShellFromVSCode(): string | null {
 	const { defaultProfileName, profiles } = getWindowsTerminalConfig()
 	if (!defaultProfileName) {
-		return null
+		// No explicit Windows terminal profile is configured. VS Code's built-in
+		// default on modern Windows is PowerShell (not cmd.exe), and that is the
+		// shell the integrated terminal actually launches. Mirror it here so the
+		// system prompt advertises the real shell instead of falling through to
+		// COMSPEC (cmd.exe). Windows PowerShell is always present, so it is a safe
+		// allowlisted default. See issue #82.
+		return SHELL_PATHS.POWERSHELL_LEGACY
 	}
 
 	const profile = profiles[defaultProfileName]


### PR DESCRIPTION
## Summary

Fixes #82. On Windows the system prompt told the model the shell was **cmd.exe**, but the integrated terminal actually runs **PowerShell** — VS Code's default on modern Windows. The two shell-detection paths disagreed.

`getShell()` (used by the system prompt in `system-info.ts` and shell-specific `rules.ts`) called `getWindowsShellFromVSCode()`, which returned `null` when no explicit `terminal.integrated.defaultProfile.windows` was set. `getShell()` then fell through to `COMSPEC` (cmd.exe), which is **not** what VS Code launches.

## Fix

When no Windows terminal profile is configured, `getWindowsShellFromVSCode()` now returns Windows PowerShell (VS Code's built-in default) instead of `null`. Windows PowerShell is always present and allowlisted, so it's a safe default.

Explicitly configured profiles are unchanged: PowerShell 7 / legacy / WSL / custom paths and an explicit **Command Prompt** profile all still resolve as before.

## Testing

```
vitest run utils/__tests__/shell.spec.ts core/prompts/sections/__tests__/system-info.spec.ts
# Test Files 2 passed (2) · Tests 40 passed (40)
```
Updated the no-profile Windows tests to assert PowerShell, kept allowlist-safety coverage (non-allowlisted profile path → safe fallback), and added a test confirming an explicit Command Prompt profile still yields cmd.exe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows shell detection now prefers PowerShell 7 when present, otherwise falls back to legacy Windows PowerShell; downstream fallbacks are bypassed.
  * Non-allowlisted terminal profile paths now fall back to Command Prompt; explicitly configured Command Prompt is respected.

* **Tests**
  * Updated Windows shell detection tests to reflect the new defaulting and fallback behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->