### PR TITLE
fix: bundle ripgrep and fall back to it when VS Code's copy is not found

### DIFF
--- a/.changeset/bundle-ripgrep-fallback.md
+++ b/.changeset/bundle-ripgrep-fallback.md
@@ -1,0 +1,5 @@
+---
+"zoo-code": patch
+---
+
+Bundle a ripgrep binary with the extension and fall back to it when ripgrep cannot be located in the VS Code installation. Fixes "Could not find ripgrep binary" errors that break search_files / list_files on VS Code Insiders' newer staged-install layout.

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -63,7 +63,7 @@ jobs:
           grep -q "extension/webview-ui/build/assets/index.js" /tmp/zoo-code-vsix-contents.txt
           grep -q "extension/assets/codicons/codicon.ttf" /tmp/zoo-code-vsix-contents.txt
           grep -q "extension/assets/vscode-material-icons/icons/3d.svg" /tmp/zoo-code-vsix-contents.txt
-          grep -q "extension/dist/bin/rg" /tmp/zoo-code-vsix-contents.txt
+          grep -qE "extension/dist/bin/[^/]+/rg" /tmp/zoo-code-vsix-contents.txt
 
       - name: Validate packaged manifest identity
         run: |

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -63,6 +63,7 @@ jobs:
           grep -q "extension/webview-ui/build/assets/index.js" /tmp/zoo-code-vsix-contents.txt
           grep -q "extension/assets/codicons/codicon.ttf" /tmp/zoo-code-vsix-contents.txt
           grep -q "extension/assets/vscode-material-icons/icons/3d.svg" /tmp/zoo-code-vsix-contents.txt
+          grep -q "extension/dist/bin/rg" /tmp/zoo-code-vsix-contents.txt
 
       - name: Validate packaged manifest identity
         run: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,6 +788,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.3
         version: 3.2.4(vitest@3.2.4)
+      '@vscode/ripgrep':
+        specifier: ^1.17.0
+        version: 1.17.0
       '@vscode/test-electron':
         specifier: ^2.5.2
         version: 2.5.2

--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -89,15 +89,19 @@ async function main() {
 			name: "copyRipgrep",
 			setup(build) {
 				build.onEnd(async () => {
-					// Copy the ripgrep binary into dist/bin/ so it ships inside the
-					// VSIX. getBinPath() in src/services/ripgrep/index.ts falls back
-					// to this bundled copy when ripgrep cannot be located in the VS
-					// Code installation (e.g. VS Code Insiders' staged-install layout).
+					// Copy the ripgrep binary into dist/bin/<platform>-<arch>/ so it
+					// ships inside the universal VSIX. getBinPath() in
+					// src/services/ripgrep/index.ts falls back to this bundled copy
+					// when ripgrep cannot be located in the VS Code installation
+					// (e.g. VS Code Insiders' staged-install layout). The
+					// <platform>-<arch> subfolder keeps the runtime fallback from
+					// picking a binary built for a different OS (the name `rg` is
+					// shared by Linux and macOS).
 					const { rgPath } = await import("@vscode/ripgrep")
 					if (!rgPath) {
 						throw new Error("[copyRipgrep] @vscode/ripgrep did not provide rgPath")
 					}
-					const rgDestDir = path.join(distDir, "bin")
+					const rgDestDir = path.join(distDir, "bin", `${process.platform}-${process.arch}`)
 					fs.mkdirSync(rgDestDir, { recursive: true })
 					const rgDest = path.join(rgDestDir, path.basename(rgPath))
 					fs.copyFileSync(rgPath, rgDest)

--- a/src/esbuild.mjs
+++ b/src/esbuild.mjs
@@ -86,6 +86,27 @@ async function main() {
 			},
 		},
 		{
+			name: "copyRipgrep",
+			setup(build) {
+				build.onEnd(async () => {
+					// Copy the ripgrep binary into dist/bin/ so it ships inside the
+					// VSIX. getBinPath() in src/services/ripgrep/index.ts falls back
+					// to this bundled copy when ripgrep cannot be located in the VS
+					// Code installation (e.g. VS Code Insiders' staged-install layout).
+					const { rgPath } = await import("@vscode/ripgrep")
+					if (!rgPath) {
+						throw new Error("[copyRipgrep] @vscode/ripgrep did not provide rgPath")
+					}
+					const rgDestDir = path.join(distDir, "bin")
+					fs.mkdirSync(rgDestDir, { recursive: true })
+					const rgDest = path.join(rgDestDir, path.basename(rgPath))
+					fs.copyFileSync(rgPath, rgDest)
+					fs.chmodSync(rgDest, 0o755)
+					console.log(`[copyRipgrep] Copied ${rgPath} to ${rgDest}`)
+				})
+			},
+		},
+		{
 			name: "copyWasms",
 			setup(build) {
 				build.onEnd(() => copyWasms(srcDir, distDir))

--- a/src/package.json
+++ b/src/package.json
@@ -554,6 +554,7 @@
 		"@types/tmp": "^0.2.6",
 		"@types/turndown": "^5.0.5",
 		"@types/vscode": "^1.84.0",
+		"@vscode/ripgrep": "^1.17.0",
 		"@vscode/test-electron": "^2.5.2",
 		"@vscode/vsce": "3.3.2",
 		"ai": "^6.0.75",

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -1,6 +1,16 @@
 // npx vitest run src/services/ripgrep/__tests__/index.spec.ts
 
-import { truncateLine } from "../index"
+import path from "path"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+
+import { truncateLine, getBinPath, bundledRgPath } from "../index"
+import { fileExistsAtPath } from "../../../utils/fs"
+
+vi.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: vi.fn(),
+}))
+
+const mockFileExists = vi.mocked(fileExistsAtPath)
 
 describe("Ripgrep line truncation", () => {
 	// The default MAX_LINE_LENGTH is 500 in the implementation
@@ -46,5 +56,40 @@ describe("Ripgrep line truncation", () => {
 
 		expect(truncated.length).toEqual(customLength + " [truncated...]".length)
 		expect(truncated).toContain("[truncated...]")
+	})
+})
+
+describe("getBinPath bundled-ripgrep fallback", () => {
+	beforeEach(() => {
+		mockFileExists.mockReset()
+	})
+
+	it("falls back to the bundled ripgrep when ripgrep is absent under the VS Code app root", async () => {
+		// VS Code Insiders' staged-install layout: nothing under appRoot.
+		mockFileExists.mockImplementation(async (p: string) => p === bundledRgPath)
+
+		const result = await getBinPath("/fake/vscode/app/root")
+
+		expect(result).toBe(bundledRgPath)
+	})
+
+	it("prefers VS Code's own ripgrep over the bundled copy", async () => {
+		const appRoot = "/fake/vscode/app/root"
+		// Derive the binary name from bundledRgPath so this test tracks the
+		// module's own platform logic instead of duplicating it.
+		const vscodeRg = path.join(appRoot, "node_modules/@vscode/ripgrep/bin", path.basename(bundledRgPath))
+		mockFileExists.mockImplementation(async (p: string) => p === vscodeRg || p === bundledRgPath)
+
+		const result = await getBinPath(appRoot)
+
+		expect(result).toBe(vscodeRg)
+	})
+
+	it("returns undefined when ripgrep exists nowhere", async () => {
+		mockFileExists.mockResolvedValue(false)
+
+		const result = await getBinPath("/fake/vscode/app/root")
+
+		expect(result).toBeUndefined()
 	})
 })

--- a/src/services/ripgrep/__tests__/index.spec.ts
+++ b/src/services/ripgrep/__tests__/index.spec.ts
@@ -92,4 +92,11 @@ describe("getBinPath bundled-ripgrep fallback", () => {
 
 		expect(result).toBeUndefined()
 	})
+
+	it("scopes the bundled ripgrep path to the current platform and arch", () => {
+		// Guards the universal VSIX from handing a wrong-OS binary to the
+		// fallback: the path must carry a <platform>-<arch> segment so a
+		// macOS host never resolves a Linux-built `dist/bin/rg`.
+		expect(bundledRgPath).toContain(path.join("bin", `${process.platform}-${process.arch}`))
+	})
 })

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -103,6 +103,10 @@ export const bundledRgPath = path.join(__dirname, "bin", `${process.platform}-${
  * (e.g. VS Code Insiders' staged-install layout, see microsoft/vscode#252063).
  */
 export async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
+	/**
+	 * Resolve `<pkgFolder>/<binName>` under the VS Code application root,
+	 * returning the absolute path when the ripgrep binary exists there.
+	 */
 	const checkPath = async (pkgFolder: string) => {
 		const fullPath = path.join(vscodeAppRoot, pkgFolder, binName)
 		return (await fileExistsAtPath(fullPath)) ? fullPath : undefined

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -82,12 +82,18 @@ export function truncateLine(line: string, maxLength: number = MAX_LINE_LENGTH):
 /**
  * Path to the ripgrep binary bundled inside the extension itself.
  *
- * esbuild copies the platform `rg`/`rg.exe` into `dist/bin/` at build time
- * (see the `copyRipgrep` plugin in esbuild.mjs). At runtime this module is
- * bundled into `dist/extension.js`, so `__dirname` is the extension's `dist/`
- * directory.
+ * esbuild copies the platform `rg`/`rg.exe` into `dist/bin/<platform>-<arch>/`
+ * at build time (see the `copyRipgrep` plugin in esbuild.mjs). At runtime this
+ * module is bundled into `dist/extension.js`, so `__dirname` is the extension's
+ * `dist/` directory.
+ *
+ * The `<platform>-<arch>` segment is required: the published VSIX is universal
+ * but carries only the build host's binary. Without it, a macOS user would
+ * resolve a Linux-built `dist/bin/rg` (the binary name `rg` is shared by Linux
+ * and macOS) and execute an incompatible binary. With it, the fallback resolves
+ * only on a host matching the bundled binary.
  */
-export const bundledRgPath = path.join(__dirname, "bin", binName)
+export const bundledRgPath = path.join(__dirname, "bin", `${process.platform}-${process.arch}`, binName)
 
 /**
  * Get the path to the ripgrep binary.

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -80,7 +80,21 @@ export function truncateLine(line: string, maxLength: number = MAX_LINE_LENGTH):
 	return line.length > maxLength ? line.substring(0, maxLength) + " [truncated...]" : line
 }
 /**
- * Get the path to the ripgrep binary within the VSCode installation
+ * Path to the ripgrep binary bundled inside the extension itself.
+ *
+ * esbuild copies the platform `rg`/`rg.exe` into `dist/bin/` at build time
+ * (see the `copyRipgrep` plugin in esbuild.mjs). At runtime this module is
+ * bundled into `dist/extension.js`, so `__dirname` is the extension's `dist/`
+ * directory.
+ */
+export const bundledRgPath = path.join(__dirname, "bin", binName)
+
+/**
+ * Get the path to the ripgrep binary.
+ *
+ * Prefers the copy shipped inside the VS Code installation; falls back to the
+ * binary bundled with this extension when the VS Code copy cannot be located
+ * (e.g. VS Code Insiders' staged-install layout, see microsoft/vscode#252063).
  */
 export async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
 	const checkPath = async (pkgFolder: string) => {
@@ -92,7 +106,8 @@ export async function getBinPath(vscodeAppRoot: string): Promise<string | undefi
 		(await checkPath("node_modules/@vscode/ripgrep/bin/")) ||
 		(await checkPath("node_modules/vscode-ripgrep/bin")) ||
 		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||
-		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/"))
+		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/")) ||
+		((await fileExistsAtPath(bundledRgPath)) ? bundledRgPath : undefined)
 	)
 }
 


### PR DESCRIPTION
## Summary

`search_files` and `list_files` fail with `Could not find ripgrep binary` on VS Code Insiders' newer staged-install layout, where program files moved into a per-build subfolder (microsoft/vscode#252063). `getBinPath` only checked four hardcoded paths under `vscode.env.appRoot`, none of which resolve on that layout.

This bundles a ripgrep binary inside the extension and uses it as a fallback:

- Add `@vscode/ripgrep` as a build devDependency.
- New `copyRipgrep` esbuild plugin copies the platform `rg` binary into `dist/bin/` so it ships inside the VSIX.
- `getBinPath` gains a final fallback to the bundled binary; VS Code's own copy is still preferred when present.
- CI asserts the binary is present in the packaged VSIX.

All three `getBinPath` callers (`search_files`, `list_files`, `file-search`) inherit the fix with no changes.

## Scope — PR 1 of 2

The extension ships a single universal VSIX, and `@vscode/ripgrep` installs only the build host's platform binary, so the released VSIX carries `rg` for the CI build platform only. That fully fixes that platform and is a non-regression elsewhere — on a platform whose binary is not bundled, the fallback simply finds nothing, exactly as before this change. A follow-up PR will move to platform-specific VSIXs so every platform ships a usable binary.

## Test plan

- [x] `vitest` — new `getBinPath` tests: fallback used when nothing exists under the app root; VS Code's own copy preferred over the bundled one; `undefined` when ripgrep exists nowhere.
- [x] `pnpm vsix` — the packaged VSIX contains `extension/dist/bin/rg`.
- [ ] Install the built VSIX on a VS Code Insiders machine with the staged-install layout and confirm `search_files` / `list_files` work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bundled a platform/architecture-specific ripgrep binary and added a fallback so search and file-listing work when ripgrep isn't found in some VS Code installs (fixes "Could not find ripgrep binary").
* **Tests**
  * Added coverage to ensure the extension prefers a VS Code-provided ripgrep when present, falls back to the bundled copy, and reports when none are available.
* **Chores**
  * Added a packaged-content check to validate the bundled ripgrep is included in release artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->