### PR TITLE
fix(openai): omit temperature when no custom value is set (#242)

### DIFF
--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -409,13 +409,15 @@ describe("OpenAiHandler", () => {
 			expect(callArgs).not.toHaveProperty("temperature")
 		})
 
-		it("should include temperature by default when supportsTemperature is not set", async () => {
+		it("should omit temperature by default when no custom temperature is set", async () => {
+			// Option A: when "use custom temperature" is off (modelTemperature unset) and the model has no
+			// required default, omit `temperature` so the server's own default applies instead of forcing 0.
 			const stream = handler.createMessage(systemPrompt, messages)
 			for await (const _chunk of stream) {
 			}
 			expect(mockCreate).toHaveBeenCalled()
 			const callArgs = mockCreate.mock.calls[0][0]
-			expect(callArgs).toHaveProperty("temperature")
+			expect(callArgs).not.toHaveProperty("temperature")
 		})
 
 		it("should use the configured modelTemperature when supportsTemperature is not false", async () => {
@@ -436,6 +438,17 @@ describe("OpenAiHandler", () => {
 			expect(mockCreate).toHaveBeenCalled()
 			const callArgs = mockCreate.mock.calls[0][0]
 			expect(callArgs.temperature).toBe(DEEP_SEEK_DEFAULT_TEMPERATURE)
+		})
+
+		it("should still send temperature when the user sets a custom value of 0", async () => {
+			// A deliberate 0 must be distinguished from "unset" — it is sent, not omitted.
+			const zeroTempHandler = new OpenAiHandler({ ...mockOptions, modelTemperature: 0 })
+			const stream = zeroTempHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.temperature).toBe(0)
 		})
 
 		it("should include max_tokens when includeMaxTokens is true", async () => {
@@ -679,7 +692,7 @@ describe("OpenAiHandler", () => {
 					],
 					stream: true,
 					stream_options: { include_usage: true },
-					temperature: 0,
+					// No custom temperature set → `temperature` is omitted.
 					tools: undefined,
 					tool_choice: undefined,
 					parallel_tool_calls: true,

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -155,13 +155,14 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 				model: modelId,
 				// Some OpenAI-Compatible models (e.g. claude-opus-4-7, claude-opus-4-8) reject
-				// `temperature` as deprecated/unsupported. Honor the model's `supportsTemperature`
-				// flag and omit it when explicitly set to false (undefined still sends temperature,
-				// preserving behavior).
-				...(modelInfo.supportsTemperature !== false && {
-					temperature:
-						this.options.modelTemperature ?? (deepseekReasoner ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0),
-				}),
+				// `temperature` as deprecated/unsupported, so honor the model's `supportsTemperature`
+				// flag and omit it when that flag is false. Beyond that, only send `temperature` when
+				// the user set a custom value or the model needs a specific default (deepseek-reasoner);
+				// otherwise omit it so the server's own default applies instead of forcing 0.
+				...(modelInfo.supportsTemperature !== false &&
+					(this.options.modelTemperature != null || deepseekReasoner) && {
+						temperature: this.options.modelTemperature ?? DEEP_SEEK_DEFAULT_TEMPERATURE,
+					}),
 				messages: convertedMessages,
 				stream: true as const,
 				...(isGrokXAI ? {} : { stream_options: { include_usage: true } }),


### PR DESCRIPTION
## Summary

When "use custom temperature" is off, the OpenAI-Compatible provider still sent `temperature: 0` (the fallback), so the model's server-side default never applied. Per the discussion on #242 (option A, which @edelauna preferred), this omits the `temperature` field in that case.

## Behavior

`temperature` is now included only when **either** the user set a custom temperature **or** the model needs a specific default (e.g. `deepseek-reasoner`); otherwise it is omitted.

- Preserves the `supportsTemperature` capability gate from #233 (still omitted when `supportsTemperature === false`).
- Preserves model-required defaults (`deepseek-reasoner` → `DEEP_SEEK_DEFAULT_TEMPERATURE`).
- A deliberately-set `0` is distinguished from "unset" and is still sent.
- Behavioral note: OpenAI-Compatible users who never set a temperature now get the model's server-side default instead of `0`.

## Scope

Targets the OpenAI-Compatible provider (the case reported in #242). The same `?? <default>` pattern exists in the shared `getModelParams` and a few other providers (`lite-llm`, `openai-native`, `lm-studio`, `vercel-ai-gateway`, …); happy to converge them on this behavior in a follow-up — `poe` and `moonshot` already omit, so there is precedent.

## Tests

`api/providers/__tests__/openai.spec.ts`: omitted by default, custom value sent, deliberate `0` sent, `deepseek-reasoner` default preserved, `supportsTemperature === false` still omitted. 53 pass.

Refs #242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature parameter handling in API requests. Temperature is now conditionally omitted when unsupported by the model or when not explicitly provided, while respecting explicit user-set values including zero.

* **Tests**
  * Updated test expectations to reflect refined temperature behavior across different AI service implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->