### PR TITLE
chore: re-enable the no-regex-spaces ESLint rule

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -6,7 +6,6 @@ export default [
 	{
 		rules: {
 			// TODO: These should be fixed and the rules re-enabled.
-			"no-regex-spaces": "off",
 			"no-useless-escape": "off",
 			"no-empty": "off",
 			"prefer-const": "off",

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -5,7 +5,7 @@ export default [
 	...config,
 	{
 		rules: {
-			// TODO: These should be fixed and the rules re-enabled.
+			// TODO: The rules listed below should be re-enabled once their existing violations are fixed.
 			"no-useless-escape": "off",
 			"no-empty": "off",
 			"prefer-const": "off",

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.elixir.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.elixir.spec.ts
@@ -44,46 +44,46 @@ describe("parseSourceCodeDefinitionsForFile with Elixir", () => {
 	})
 
 	it("should parse function definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   def test_function_definition/)
-		expect(parseResult).toMatch(/\d+--\d+ \|   def test_pipeline_definition/)
-		expect(parseResult).toMatch(/\d+--\d+ \|   def test_comprehension_definition/)
-		expect(parseResult).toMatch(/\d+--\d+ \|   def test_sigil_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def test_function_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def test_pipeline_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def test_comprehension_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def test_sigil_definition/)
 		debugLog("Function definitions found:", parseResult.match(/def[\s\S]*?end/g))
 	})
 
 	it("should parse macro definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   defmacro test_macro_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}defmacro test_macro_definition/)
 		debugLog("Macro definitions found:", parseResult.match(/defmacro[\s\S]*?end/g))
 	})
 
 	it("should parse protocol implementations", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   defimpl String\.Chars/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}defimpl String\.Chars/)
 		debugLog("Protocol implementations found:", parseResult.match(/defimpl[\s\S]*?end/g))
 	})
 
 	it("should parse behaviour callbacks", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   @callback test_behaviour_callback/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}@callback test_behaviour_callback/)
 		debugLog("Behaviour callbacks found:", parseResult.match(/@callback[\s\S]*?\)/g))
 	})
 
 	it("should parse struct definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   defstruct \[/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}defstruct \[/)
 		debugLog("Struct definitions found:", parseResult.match(/defstruct[\s\S]*?\]/g))
 	})
 
 	it("should parse guard definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   defguard test_guard_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}defguard test_guard_definition/)
 		debugLog("Guard definitions found:", parseResult.match(/defguard[\s\S]*?end/g))
 	})
 
 	it("should parse module attributes", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   @test_attribute_definition/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}@test_attribute_definition/)
 		expect(parseResult).toMatch(/\d+--\d+ \| @moduledoc/)
 		debugLog("Module attributes found:", parseResult.match(/@[\s\S]*?\]/g))
 	})
 
 	it("should parse test definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   test "test_definition"/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}test "test_definition"/)
 		debugLog("Test definitions found:", parseResult.match(/test[\s\S]*?end/g))
 	})
 })

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.python.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.python.spec.ts
@@ -46,7 +46,7 @@ describe("parseSourceCodeDefinitionsForFile with Python", () => {
 	it("should parse class and method definitions", () => {
 		expect(parseResult).toMatch(/\d+--\d+ \| class MultiLineDecoratedClass:/)
 		expect(parseResult).toMatch(/\d+--\d+ \| class MethodContainer:/)
-		expect(parseResult).toMatch(/\d+--\d+ \|     def multi_line_method\(/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {5}def multi_line_method\(/)
 		debugLog("Class and method definitions found:", parseResult)
 	})
 

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.scala.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.scala.spec.ts
@@ -62,21 +62,21 @@ describe("parseSourceCodeDefinitionsForFile with Scala", () => {
 	})
 
 	it("should parse method declarations", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   def testMatch\(value: Any\): Int = value match/)
-		expect(parseResult).toMatch(/\d+--\d+ \|   def processItems\(items: List\[Int\]\): List\[Int\]/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def testMatch\(value: Any\): Int = value match/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}def processItems\(items: List\[Int\]\): List\[Int\]/)
 	})
 
 	it("should parse value declarations", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   lazy val heavyComputation: Int = \{/)
-		expect(parseResult).toMatch(/\d+--\d+ \|   val immutableValue: Int = 42/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}lazy val heavyComputation: Int = \{/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}val immutableValue: Int = 42/)
 	})
 
 	it("should parse variable declarations", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   var mutableValue: String = "changeable"/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}var mutableValue: String = "changeable"/)
 	})
 
 	it("should parse type definitions", () => {
-		expect(parseResult).toMatch(/\d+--\d+ \|   type StringMap\[T\] = Map\[String, T\]/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {3}type StringMap\[T\] = Map\[String, T\]/)
 	})
 
 	/*

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.solidity.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.solidity.spec.ts
@@ -24,53 +24,51 @@ describe("Solidity Source Code Definition Tests", () => {
 	})
 
 	it("should parse using directives", () => {
-		expect(parseResult).toMatch(/23--23 \|     using MathLib for uint256;/)
+		expect(parseResult).toMatch(/23--23 \| {5}using MathLib for uint256;/)
 	})
 
 	it("should parse type declarations", () => {
-		expect(parseResult).toMatch(/25--30 \|     struct UserInfo {/)
-		expect(parseResult).toMatch(/32--37 \|     enum UserRole {/)
+		expect(parseResult).toMatch(/25--30 \| {5}struct UserInfo {/)
+		expect(parseResult).toMatch(/32--37 \| {5}enum UserRole {/)
 	})
 
 	it("should parse state variable declarations", () => {
-		expect(parseResult).toMatch(/39--39 \|     uint256 private immutable totalSupply;/)
-		expect(parseResult).toMatch(/40--40 \|     mapping\(address => UserInfo\) private users;/)
-		expect(parseResult).toMatch(/41--41 \|     UserRole\[\] private roles;/)
+		expect(parseResult).toMatch(/39--39 \| {5}uint256 private immutable totalSupply;/)
+		expect(parseResult).toMatch(/40--40 \| {5}mapping\(address => UserInfo\) private users;/)
+		expect(parseResult).toMatch(/41--41 \| {5}UserRole\[\] private roles;/)
 	})
 	it("should parse function declarations", () => {
-		expect(parseResult).toMatch(/70--87 \|     function transfer\(/)
-		expect(parseResult).toMatch(/89--93 \|     function interfaceFunction\(/)
+		expect(parseResult).toMatch(/70--87 \| {5}function transfer\(/)
+		expect(parseResult).toMatch(/89--93 \| {5}function interfaceFunction\(/)
+		expect(parseResult).toMatch(/6--6 \| {5}function interfaceFunction\(uint256 value\) external returns \(bool\);/)
 		expect(parseResult).toMatch(
-			/6--6 \|     function interfaceFunction\(uint256 value\) external returns \(bool\);/,
+			/12--14 \| {5}function add\(uint256 a, uint256 b\) internal pure returns \(uint256\) {/,
 		)
 		expect(parseResult).toMatch(
-			/12--14 \|     function add\(uint256 a, uint256 b\) internal pure returns \(uint256\) {/,
-		)
-		expect(parseResult).toMatch(
-			/16--19 \|     function subtract\(uint256 a, uint256 b\) internal pure returns \(uint256\) {/,
+			/16--19 \| {5}function subtract\(uint256 a, uint256 b\) internal pure returns \(uint256\) {/,
 		)
 	})
 
 	it("should parse constructor declarations", () => {
-		expect(parseResult).toMatch(/63--68 \|     constructor\(uint256 _initialSupply\) {/)
+		expect(parseResult).toMatch(/63--68 \| {5}constructor\(uint256 _initialSupply\) {/)
 	})
 
 	it("should parse special function declarations", () => {
-		expect(parseResult).toMatch(/95--97 \|     fallback\(\) external payable {/)
-		expect(parseResult).toMatch(/99--101 \|     receive\(\) external payable {/)
+		expect(parseResult).toMatch(/95--97 \| {5}fallback\(\) external payable {/)
+		expect(parseResult).toMatch(/99--101 \| {5}receive\(\) external payable {/)
 	})
 
 	it("should parse event declarations", () => {
-		expect(parseResult).toMatch(/43--47 \|     event Transfer\(/)
-		expect(parseResult).toMatch(/7--7 \|     event InterfaceEvent\(address indexed sender, uint256 value\);/)
+		expect(parseResult).toMatch(/43--47 \| {5}event Transfer\(/)
+		expect(parseResult).toMatch(/7--7 \| {5}event InterfaceEvent\(address indexed sender, uint256 value\);/)
 	})
 
 	it("should parse error declarations", () => {
-		expect(parseResult).toMatch(/49--53 \|     error InsufficientBalance\(/)
-		expect(parseResult).toMatch(/8--8 \|     error InterfaceError\(string message\);/)
+		expect(parseResult).toMatch(/49--53 \| {5}error InsufficientBalance\(/)
+		expect(parseResult).toMatch(/8--8 \| {5}error InterfaceError\(string message\);/)
 	})
 
 	it("should parse modifier declarations", () => {
-		expect(parseResult).toMatch(/55--61 \|     modifier onlyAdmin\(\) {/)
+		expect(parseResult).toMatch(/55--61 \| {5}modifier onlyAdmin\(\) {/)
 	})
 })

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.toml.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.toml.spec.ts
@@ -41,7 +41,7 @@ describe("TOML Source Code Definition Tests", () => {
 
 	it("should parse table arrays", () => {
 		expect(parseResult).toMatch(/\d+--\d+ \|\s*\[\[products\]\]/)
-		expect(parseResult).toMatch(/\d+--\d+ \|\s*\[\[products\]\]  # Array of tables/)
+		expect(parseResult).toMatch(/\d+--\d+ \|\s*\[\[products\]\] {2}# Array of tables/)
 	})
 
 	it("should parse inline tables", () => {

--- a/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.zig.spec.ts
+++ b/src/services/tree-sitter/__tests__/parseSourceCodeDefinitions.zig.spec.ts
@@ -19,8 +19,8 @@ describe("Zig Source Code Definition Tests", () => {
 
 	it("should parse function definitions", () => {
 		expect(parseResult).toMatch(/\d+--\d+ \| pub fn main\(\) !void/)
-		expect(parseResult).toMatch(/\d+--\d+ \|     pub fn init\(x: f32, y: f32\) Point/)
-		expect(parseResult).toMatch(/\d+--\d+ \|     pub fn distance\(self: Point\) f32/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {5}pub fn init\(x: f32, y: f32\) Point/)
+		expect(parseResult).toMatch(/\d+--\d+ \| {5}pub fn distance\(self: Point\) f32/)
 	})
 
 	it("should parse container definitions", () => {


### PR DESCRIPTION
## Summary

`no-regex-spaces` was disabled in `src/eslint.config.mjs` under a `// TODO: These should be fixed and the rules re-enabled` comment. This re-enables it.

- The 40 violations are auto-fixed (`eslint --fix`): consecutive literal spaces inside a regex are replaced with an explicit `{n}` quantifier (e.g. `/a   b/` → `/a {3}b/`), which matches identically.
- All 40 are in tree-sitter `*.spec.ts` parser tests — no production code changes.
- The `"off"` override is removed; `eslint:recommended` (via the shared base config) enforces the rule again.

## Test plan

- [x] `eslint .` is clean across `src/` with the rule active.
- [x] The fix is semantics-preserving — `{n}` matches the same input as `n` literal spaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated parsing tests for Elixir, Python, Scala, Solidity, TOML, and Zig to use more flexible regex/whitespace matching for definition outputs.

* **Chores**
  * Updated ESLint configuration: removed a disabled spacing rule entry and added a TODO to re-enable listed rules once violations are addressed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->