### PR TITLE
chore: enforce no-floating-promises in activate/

### DIFF
--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -221,7 +221,27 @@ describe("registerCommands handlers", () => {
 	})
 
 	it("toggleAutoApprove awaits postMessage with toggleAutoApprove action", async () => {
-		await handlers["zoo-code.toggleAutoApprove"]()
+		// Deferred-promise pattern: pin that the handler actually awaits
+		// postMessageToWebview rather than fire-and-forgetting it. If `await`
+		// were dropped in the handler, handlerPromise would resolve before
+		// resolvePost() is called and `settled` would flip true at the
+		// microtask flush below, failing the pending-state assertion.
+		let resolvePost!: () => void
+		const postPromise = new Promise<void>((resolve) => {
+			resolvePost = resolve
+		})
+		mockVisibleProvider.postMessageToWebview.mockReturnValueOnce(postPromise)
+
+		const handlerPromise = handlers["zoo-code.toggleAutoApprove"]() as Promise<unknown>
+		let settled = false
+		void handlerPromise.then(() => {
+			settled = true
+		})
+		await Promise.resolve()
+		expect(settled).toBe(false)
+
+		resolvePost()
+		await handlerPromise
 
 		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",
@@ -233,7 +253,28 @@ describe("registerCommands handlers", () => {
 		const fakeSidebar = {} as vscode.WebviewView
 		setPanel(fakeSidebar, "sidebar")
 
-		await handlers["zoo-code.focusInput"]()
+		// Same deferred-promise pattern as above. focusInput first awaits
+		// focusPanel() (mocked to resolve sync) and then awaits
+		// provider.postMessageToWebview — so we flush two microtasks before
+		// asserting the pending state, to let the handler advance past the
+		// focusPanel await and suspend on the deferred postPromise.
+		let resolvePost!: () => void
+		const postPromise = new Promise<void>((resolve) => {
+			resolvePost = resolve
+		})
+		mockProvider.postMessageToWebview.mockReturnValueOnce(postPromise)
+
+		const handlerPromise = handlers["zoo-code.focusInput"]() as Promise<unknown>
+		let settled = false
+		void handlerPromise.then(() => {
+			settled = true
+		})
+		await Promise.resolve()
+		await Promise.resolve()
+		expect(settled).toBe(false)
+
+		resolvePost()
+		await handlerPromise
 
 		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -246,4 +246,28 @@ describe("registerCommands handlers", () => {
 
 		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
+
+	// Representative coverage for the .catch arm on all five void-prefixed
+	// postMessageToWebview sites in registerCommands.ts (settingsButtonClicked
+	// posts twice, plus historyButtonClicked, marketplaceButtonClicked, and
+	// acceptInput). Each handler is synchronous, so the .catch arm runs on a
+	// microtask; awaiting Promise.resolve() flushes it before we assert.
+	it.each([
+		{ command: "zoo-code.settingsButtonClicked", expectedCalls: 2 },
+		{ command: "zoo-code.historyButtonClicked", expectedCalls: 1 },
+		{ command: "zoo-code.marketplaceButtonClicked", expectedCalls: 1 },
+		{ command: "zoo-code.acceptInput", expectedCalls: 1 },
+	])("$command logs to outputChannel when postMessageToWebview rejects", async ({ command, expectedCalls }) => {
+		const boom = new Error("boom")
+		mockVisibleProvider.postMessageToWebview.mockReset()
+		mockVisibleProvider.postMessageToWebview.mockRejectedValue(boom)
+
+		handlers[command]()
+
+		// Flush microtasks so the chained .catch arm runs.
+		await new Promise((resolve) => setImmediate(resolve))
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(expectedCalls)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(`postMessageToWebview failed: ${boom}`)
+	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -292,7 +292,7 @@ describe("registerCommands handlers", () => {
 	// postMessageToWebview sites in registerCommands.ts (settingsButtonClicked
 	// posts twice, plus historyButtonClicked, marketplaceButtonClicked, and
 	// acceptInput). Each handler is synchronous, so the .catch arm runs on a
-	// microtask; awaiting Promise.resolve() flushes it before we assert. The
+	// microtask; setImmediate ensures all microtasks are flushed before we assert. The
 	// log messages carry a `[<handlerName>]` prefix so multi-failure logs
 	// remain unambiguous; the prefix is per-handler, not per-call (both of
 	// settingsButtonClicked's posts share the same prefix).

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -2,7 +2,7 @@ import type { Mock } from "vitest"
 import * as vscode from "vscode"
 import { ClineProvider } from "../../core/webview/ClineProvider"
 
-import { getVisibleProviderOrLog } from "../registerCommands"
+import { getVisibleProviderOrLog, registerCommands, setPanel } from "../registerCommands"
 
 vi.mock("execa", () => ({
 	execa: vi.fn(),
@@ -25,9 +25,61 @@ vi.mock("vscode", () => ({
 			},
 		],
 	},
+	commands: {
+		registerCommand: vi.fn(),
+		executeCommand: vi.fn(),
+	},
 }))
 
 vi.mock("../../core/webview/ClineProvider")
+
+vi.mock("../../shared/package", () => ({
+	Package: {
+		name: "zoo-code",
+	},
+}))
+
+vi.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			captureTitleButtonClicked: vi.fn(),
+		},
+	},
+}))
+
+vi.mock("../../utils/focusPanel", () => ({
+	focusPanel: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("../handleTask", () => ({
+	handleNewTask: vi.fn(),
+}))
+
+vi.mock("../../core/config/importExport", () => ({
+	importSettingsWithFeedback: vi.fn(),
+}))
+
+vi.mock("../../services/code-index/manager", () => ({
+	CodeIndexManager: {
+		getInstance: vi.fn(),
+	},
+}))
+
+vi.mock("../../services/mdm/MdmService", () => ({
+	MdmService: {
+		getInstance: vi.fn(),
+	},
+}))
+
+vi.mock("../../core/config/ContextProxy", () => ({
+	ContextProxy: {
+		getInstance: vi.fn(),
+	},
+}))
+
+vi.mock("../../i18n", () => ({
+	t: (key: string) => key,
+}))
 
 describe("getVisibleProviderOrLog", () => {
 	let mockOutputChannel: vscode.OutputChannel
@@ -63,5 +115,135 @@ describe("getVisibleProviderOrLog", () => {
 
 		expect(result).toBeUndefined()
 		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Roo Code instances.")
+	})
+})
+
+describe("registerCommands handlers", () => {
+	let mockOutputChannel: vscode.OutputChannel
+	let mockContext: vscode.ExtensionContext
+	let mockVisibleProvider: { postMessageToWebview: Mock }
+	let mockProvider: { postMessageToWebview: Mock }
+	let handlers: Record<string, (...args: unknown[]) => unknown>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		handlers = {}
+
+		mockOutputChannel = {
+			appendLine: vi.fn(),
+			append: vi.fn(),
+			clear: vi.fn(),
+			hide: vi.fn(),
+			name: "mock",
+			replace: vi.fn(),
+			show: vi.fn(),
+			dispose: vi.fn(),
+		}
+
+		mockContext = {
+			subscriptions: [],
+		} as unknown as vscode.ExtensionContext
+
+		mockVisibleProvider = {
+			postMessageToWebview: vi.fn().mockResolvedValue(undefined),
+		}
+
+		mockProvider = {
+			postMessageToWebview: vi.fn().mockResolvedValue(undefined),
+		}
+		;(ClineProvider.getVisibleInstance as Mock).mockReturnValue(mockVisibleProvider)
+		;(vscode.commands.registerCommand as Mock).mockImplementation(
+			(id: string, cb: (...args: unknown[]) => unknown) => {
+				handlers[id] = cb
+				return { dispose: vi.fn() }
+			},
+		)
+
+		registerCommands({
+			context: mockContext,
+			outputChannel: mockOutputChannel,
+			provider: mockProvider as unknown as ClineProvider,
+		})
+	})
+
+	afterEach(() => {
+		// Reset module-level panel state to prevent leakage between tests.
+		setPanel(undefined, "sidebar")
+		setPanel(undefined, "tab")
+	})
+
+	it("settingsButtonClicked posts both settingsButtonClicked and didBecomeVisible actions", () => {
+		handlers["zoo-code.settingsButtonClicked"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "settingsButtonClicked",
+		})
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "didBecomeVisible",
+		})
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledTimes(2)
+	})
+
+	it("settingsButtonClicked is a no-op when no visible provider", () => {
+		;(ClineProvider.getVisibleInstance as Mock).mockReturnValue(undefined)
+
+		handlers["zoo-code.settingsButtonClicked"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
+	})
+
+	it("historyButtonClicked posts historyButtonClicked action", () => {
+		handlers["zoo-code.historyButtonClicked"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "historyButtonClicked",
+		})
+	})
+
+	it("marketplaceButtonClicked posts marketplaceButtonClicked action", () => {
+		handlers["zoo-code.marketplaceButtonClicked"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "marketplaceButtonClicked",
+		})
+	})
+
+	it("acceptInput posts acceptInput message", () => {
+		handlers["zoo-code.acceptInput"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "acceptInput",
+		})
+	})
+
+	it("toggleAutoApprove awaits postMessage with toggleAutoApprove action", async () => {
+		await handlers["zoo-code.toggleAutoApprove"]()
+
+		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "toggleAutoApprove",
+		})
+	})
+
+	it("focusInput awaits postMessage on the registered provider when a sidebar panel is active", async () => {
+		const fakeSidebar = {} as vscode.WebviewView
+		setPanel(fakeSidebar, "sidebar")
+
+		await handlers["zoo-code.focusInput"]()
+
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "focusInput",
+		})
+	})
+
+	it("focusInput does not post when no sidebar panel is active", async () => {
+		await handlers["zoo-code.focusInput"]()
+
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -292,23 +292,48 @@ describe("registerCommands handlers", () => {
 	// postMessageToWebview sites in registerCommands.ts (settingsButtonClicked
 	// posts twice, plus historyButtonClicked, marketplaceButtonClicked, and
 	// acceptInput). Each handler is synchronous, so the .catch arm runs on a
-	// microtask; awaiting Promise.resolve() flushes it before we assert.
+	// microtask; awaiting Promise.resolve() flushes it before we assert. The
+	// log messages carry a `[<handlerName>]` prefix so multi-failure logs
+	// remain unambiguous; the prefix is per-handler, not per-call (both of
+	// settingsButtonClicked's posts share the same prefix).
 	it.each([
-		{ command: "zoo-code.settingsButtonClicked", expectedCalls: 2 },
-		{ command: "zoo-code.historyButtonClicked", expectedCalls: 1 },
-		{ command: "zoo-code.marketplaceButtonClicked", expectedCalls: 1 },
-		{ command: "zoo-code.acceptInput", expectedCalls: 1 },
-	])("$command logs to outputChannel when postMessageToWebview rejects", async ({ command, expectedCalls }) => {
+		{ command: "zoo-code.settingsButtonClicked", prefix: "settingsButtonClicked", expectedCalls: 2 },
+		{ command: "zoo-code.historyButtonClicked", prefix: "historyButtonClicked", expectedCalls: 1 },
+		{ command: "zoo-code.marketplaceButtonClicked", prefix: "marketplaceButtonClicked", expectedCalls: 1 },
+		{ command: "zoo-code.acceptInput", prefix: "acceptInput", expectedCalls: 1 },
+	])(
+		"$command logs to outputChannel when postMessageToWebview rejects",
+		async ({ command, prefix, expectedCalls }) => {
+			const boom = new Error("boom")
+			mockVisibleProvider.postMessageToWebview.mockReset()
+			mockVisibleProvider.postMessageToWebview.mockRejectedValue(boom)
+
+			handlers[command]()
+
+			// Flush microtasks so the chained .catch arm runs.
+			await new Promise((resolve) => setImmediate(resolve))
+
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(expectedCalls)
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+				`[${prefix}] postMessageToWebview failed: ${boom}`,
+			)
+		},
+	)
+
+	it("toggleAutoApprove logs to outputChannel when postMessageToWebview rejects", async () => {
+		// toggleAutoApprove is `async` and awaits postMessageToWebview inside a
+		// try/catch (rather than relying on a `.catch` microtask like the
+		// void-prefixed sites), so awaiting the handler itself is sufficient to
+		// observe the appendLine call.
 		const boom = new Error("boom")
 		mockVisibleProvider.postMessageToWebview.mockReset()
 		mockVisibleProvider.postMessageToWebview.mockRejectedValue(boom)
 
-		handlers[command]()
+		await handlers["zoo-code.toggleAutoApprove"]()
 
-		// Flush microtasks so the chained .catch arm runs.
-		await new Promise((resolve) => setImmediate(resolve))
-
-		expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(expectedCalls)
-		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(`postMessageToWebview failed: ${boom}`)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(1)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			`[toggleAutoApprove] postMessageToWebview failed: ${boom}`,
+		)
 	})
 })

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -103,9 +103,9 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
+		void visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
 		// Also explicitly post the visibility message to trigger scroll reliably
-		visibleProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+		void visibleProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
 	},
 	historyButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -116,12 +116,12 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
+		void visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 	},
 	marketplaceButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
 		if (!visibleProvider) return
-		visibleProvider.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
+		void visibleProvider.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
 	},
 	newTask: handleNewTask,
 	setCustomStoragePath: async () => {
@@ -150,7 +150,7 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 			// Send focus input message only for sidebar panels
 			if (sidebarPanel && getPanel() === sidebarPanel) {
-				provider.postMessageToWebview({ type: "action", action: "focusInput" })
+				await provider.postMessageToWebview({ type: "action", action: "focusInput" })
 			}
 		} catch (error) {
 			outputChannel.appendLine(`Error focusing input: ${error}`)
@@ -170,7 +170,7 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			return
 		}
 
-		visibleProvider.postMessageToWebview({ type: "acceptInput" })
+		void visibleProvider.postMessageToWebview({ type: "acceptInput" })
 	},
 	toggleAutoApprove: async () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -179,7 +179,7 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			return
 		}
 
-		visibleProvider.postMessageToWebview({
+		await visibleProvider.postMessageToWebview({
 			type: "action",
 			action: "toggleAutoApprove",
 		})

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -105,11 +105,11 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		void visibleProvider
 			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
+			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
 		// Also explicitly post the visibility message to trigger scroll reliably
 		void visibleProvider
 			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
+			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
 	},
 	historyButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -122,14 +122,16 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		void visibleProvider
 			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
+			.catch((error) => outputChannel.appendLine(`[historyButtonClicked] postMessageToWebview failed: ${error}`))
 	},
 	marketplaceButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
 		if (!visibleProvider) return
 		void visibleProvider
 			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
+			.catch((error) =>
+				outputChannel.appendLine(`[marketplaceButtonClicked] postMessageToWebview failed: ${error}`),
+			)
 	},
 	newTask: handleNewTask,
 	setCustomStoragePath: async () => {
@@ -180,7 +182,7 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		void visibleProvider
 			.postMessageToWebview({ type: "acceptInput" })
-			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
+			.catch((error) => outputChannel.appendLine(`[acceptInput] postMessageToWebview failed: ${error}`))
 	},
 	toggleAutoApprove: async () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -189,10 +191,14 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			return
 		}
 
-		await visibleProvider.postMessageToWebview({
-			type: "action",
-			action: "toggleAutoApprove",
-		})
+		try {
+			await visibleProvider.postMessageToWebview({
+				type: "action",
+				action: "toggleAutoApprove",
+			})
+		} catch (error) {
+			outputChannel.appendLine(`[toggleAutoApprove] postMessageToWebview failed: ${error}`)
+		}
 	},
 })
 

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -103,9 +103,13 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		void visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
+		void visibleProvider
+			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
+			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
 		// Also explicitly post the visibility message to trigger scroll reliably
-		void visibleProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+		void visibleProvider
+			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
 	},
 	historyButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -116,12 +120,16 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		void visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
+		void visibleProvider
+			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
+			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
 	},
 	marketplaceButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
 		if (!visibleProvider) return
-		void visibleProvider.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
+		void visibleProvider
+			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
+			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
 	},
 	newTask: handleNewTask,
 	setCustomStoragePath: async () => {
@@ -170,7 +178,9 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			return
 		}
 
-		void visibleProvider.postMessageToWebview({ type: "acceptInput" })
+		void visibleProvider
+			.postMessageToWebview({ type: "acceptInput" })
+			.catch((error) => outputChannel.appendLine(`postMessageToWebview failed: ${error}`))
 	},
 	toggleAutoApprove: async () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)

--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -30,6 +30,20 @@ export default [
 		},
 	},
 	{
+		// Ratchet: enforce no-floating-promises directory by directory. Each
+		// directory is added here once its floating promises are resolved.
+		files: ["activate/**/*.ts"],
+		languageOptions: {
+			parserOptions: {
+				project: true,
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+		rules: {
+			"@typescript-eslint/no-floating-promises": "error",
+		},
+	},
+	{
 		ignores: ["webview-ui", "out"],
 	},
 ]


### PR DESCRIPTION
## Summary

First slice of a ratchet that re-enables `@typescript-eslint/no-floating-promises` directory by directory.

The repo's lint is zero-tolerance (`eslint --max-warnings=0` + the `only-warn` plugin), so the rule can't be enabled globally without first clearing all ~194 floating promises across `src/`. Instead, this enables the rule **scoped to `activate/**`** via a `files`-block in `eslint.config.mjs` (with type-aware parsing for that scope). `pnpm lint` stays green; subsequent PRs widen the scope until it's global.

## Fixes

`activate/registerCommands.ts` had 7 un-awaited `postMessageToWebview(...)` calls (fire-and-forget UI messages):

- **5 marked `void`** — in synchronous command handlers (`settingsButtonClicked`, `historyButtonClicked`, `marketplaceButtonClicked`, `acceptInput`); these are intentional fire-and-forget and the handler is not `async`.
- **2 awaited** — in handlers that are already `async` (`focusInput`, `toggleAutoApprove`). `focusInput`'s call sits inside a `try/catch`, so awaiting routes a rejected post into the existing error handler.

No sync→async handler conversions; behavior is unchanged.

## Test plan

- [x] `eslint activate/` clean.
- [x] `eslint . --ext=ts --max-warnings=0` (the repo lint command) passes.
- [x] `tsc --noEmit` clean.
- [x] `activate/` test suite passes (12 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI command handling: message posting now properly awaits or logs errors as appropriate, and visibility/focus signaling is more consistent for settings, history, marketplace, input, and focus actions.

* **Chores**
  * Enabled stricter linting to catch unhandled promises.

* **Tests**
  * Added tests for command handlers, visibility/focus behavior, message-posting success/failure paths, and test-state isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->