### PR TITLE
fix: parse JSON-string MCP tool arguments before type check

### DIFF
--- a/src/core/tools/UseMcpToolTool.ts
+++ b/src/core/tools/UseMcpToolTool.ts
@@ -111,7 +111,14 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 			return { isValid: false }
 		}
 
-		// Native-only: arguments are already a structured object.
+		// Some LLMs emit arguments as JSON-encoded strings rather than objects.
+		// Parse them early so the type check below sees the unwrapped object.
+		if (typeof params.arguments === "string") {
+			try {
+				params.arguments = JSON.parse(params.arguments)
+			} catch {}
+		}
+
 		let parsedArguments: Record<string, unknown> | undefined
 		if (params.arguments !== undefined) {
 			if (typeof params.arguments !== "object" || params.arguments === null || Array.isArray(params.arguments)) {

--- a/src/core/tools/__tests__/useMcpToolTool.spec.ts
+++ b/src/core/tools/__tests__/useMcpToolTool.spec.ts
@@ -254,6 +254,53 @@ describe("useMcpToolTool", () => {
 			expect(mockPushToolResult).toHaveBeenCalledWith("Tool result: Tool executed successfully")
 		})
 
+		it("should parse JSON-string arguments and pass parsed object to callTool", async () => {
+			const callToolMock = vi.fn().mockResolvedValue({
+				content: [{ type: "text", text: "Browser session started" }],
+				isError: false,
+			})
+
+			mockProviderRef.deref.mockReturnValue({
+				getMcpHub: () => ({
+					callTool: callToolMock,
+					getAllServers: vi.fn().mockReturnValue([
+						{ name: "test_server", tools: [{ name: "test_tool", description: "Test Tool" }] },
+					]),
+				}),
+				postMessageToWebview: vi.fn(),
+			})
+
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "use_mcp_tool",
+				params: {
+					server_name: "test_server",
+					tool_name: "test_tool",
+					arguments: '{"headless": true}',
+				},
+				nativeArgs: {
+					server_name: "test_server",
+					tool_name: "test_tool",
+					arguments: '{"headless": true}' as unknown as Record<string, unknown>,
+				},
+				partial: false,
+			}
+
+			mockAskApproval.mockResolvedValue(true)
+
+			await useMcpToolTool.handle(mockTask as Task, block as any, {
+				askApproval: mockAskApproval,
+				handleError: mockHandleError,
+				pushToolResult: mockPushToolResult,
+			})
+
+			expect(mockTask.consecutiveMistakeCount).toBe(0)
+			expect(mockTask.recordToolError).not.toHaveBeenCalled()
+			expect(callToolMock).toHaveBeenCalledWith("test_server", "test_tool", { headless: true })
+			expect(mockTask.say).toHaveBeenCalledWith("mcp_server_request_started")
+			expect(mockTask.say).toHaveBeenCalledWith("mcp_server_response", "Browser session started", [])
+		})
+
 		it("should handle user rejection", async () => {
 			const block: ToolUse = {
 				type: "tool_use",


### PR DESCRIPTION
### Related GitHub Issue

Port of the fix for Roo Code issue [#10919](https://github.com/RooCodeInc/Roo-Code/issues/10919) — the same JSON-string arguments bug affects Zoo Code when used with DeepSeek V4 Pro and other LLMs that emit MCP tool call arguments as JSON-encoded strings.

### Description

## Problem

Some LLMs (DeepSeek V4 Pro and others) emit MCP tool call `arguments` as JSON-encoded strings rather than as native objects:

```json
{ "arguments": "{\"headless\": true}" }
```

instead of:

```json
{ "arguments": { "headless": true } }
```

The existing `validateParams()` method in `UseMcpToolTool.ts` rejects these with "Invalid JSON argument" errors because the type check (`typeof params.arguments !== "object"`) fails on strings.

This is the same bug that plagued Roo Code v3.54.0 (see Roo-Code issues #10919 and the archive discussion).

## Fix

Adds a `JSON.parse()` guard before the existing type check. If `arguments` arrives as a string, attempt to parse it into an object. If parsing fails (malformed JSON), we fall through silently and the existing code path handles it as before (rejects with the appropriate error).

## Safety

- The guard is safe for all input types:
  - **Object arguments** (existing correct format): `typeof` check passes the string guard, goes straight to the object type check → **no change**
  - **String arguments** (the bug case): `JSON.parse()` unwraps the string into an object → type check passes → **fix**
  - **Malformed strings**: `JSON.parse()` throws, `catch {}` swallows it → falls through to the existing error path → **graceful rejection**
  - **null / undefined / array**: Not strings → string guard skipped → existing error path → **unchanged**

### Test Procedure

1. **Unit test**: Run `npx vitest run src/core/tools/__tests__/useMcpToolTool.spec.ts`
   - The new test "should parse JSON-string arguments and pass parsed object to callTool" passes `nativeArgs.arguments` as the JSON-encoded string `'{"headless": true}'` and verifies `callTool` receives the parsed object `{ headless: true }`
   - All existing tests continue to pass unchanged

2. **Manual integration test** (DeepSeek V4 Pro or similar model):
   - Configure an MCP server (e.g., playwright-stealth)
   - Ask the model to call an MCP tool (e.g., `browser_navigate` to a URL)
   - Verify no "Invalid JSON argument" errors appear
   - The tool should execute successfully on the first attempt without retries

3. **Regression check**: Existing tool calls with object-format arguments (the normal case) must continue to work without any behavioral change.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR addresses the same bug pattern as Roo Code #10919, ported to Zoo Code
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR)
- [x] **Self-Review**: I have performed a thorough self-review of my code
- [x] **Testing**: New tests have been added to cover the JSON-string argument parsing path
- [x] **Documentation Impact**: No documentation updates required
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This fix has been field-tested on Roo Code v3.54.0 with the identical fix across multiple MCP providers (playwright-stealth, Context7, etc.). The root cause is model behavior, not server-specific — any MCP server can be affected when the LLM emits string-encoded arguments.
