### PR TITLE
fix(terminal): terminate running process when task is cancelled (#245)

### DIFF
--- a/.changeset/terminate-process-on-cancel.md
+++ b/.changeset/terminate-process-on-cancel.md
@@ -1,0 +1,5 @@
+---
+"zoo-code": patch
+---
+
+Terminate the running command when a task is cancelled or torn down (#245). Pressing cancel (✕) now aborts the underlying terminal process instead of leaving it running while the terminal stays stuck "busy" until a manual kill.

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -284,6 +284,22 @@ export class TerminalRegistry {
 	public static releaseTerminalsForTask(taskId: string): void {
 		this.terminals.forEach((terminal) => {
 			if (terminal.taskId === taskId) {
+				// #245: If the terminal is still executing a command when its task is torn
+				// down (user pressed cancel ✕, or the task was switched/removed), abort the
+				// process. Otherwise the command keeps running orphaned and the terminal stays
+				// stuck "busy" — the cancel-doesn't-terminate bug. abort() is safe when idle
+				// (Ctrl+C is gated on an active stream; Execa abort is idempotent).
+				if (terminal.busy) {
+					try {
+						terminal.process?.abort()
+					} catch (error) {
+						console.error(
+							`[TerminalRegistry] Error aborting process for terminal ${terminal.id} on release:`,
+							error,
+						)
+					}
+				}
+
 				terminal.taskId = undefined
 			}
 		})

--- a/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
@@ -123,4 +123,66 @@ describe("TerminalRegistry", () => {
 			}
 		})
 	})
+
+	describe("releaseTerminalsForTask", () => {
+		it("aborts a busy terminal's running process and disassociates it from the task (#245)", () => {
+			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode")
+			const abort = vi.fn()
+			terminal.taskId = "task-245"
+			terminal.busy = true
+			terminal.process = { abort } as any
+
+			TerminalRegistry.releaseTerminalsForTask("task-245")
+
+			expect(abort).toHaveBeenCalledTimes(1)
+			expect(terminal.taskId).toBeUndefined()
+		})
+
+		it("does not abort an idle (not busy) terminal but still disassociates it", () => {
+			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode")
+			const abort = vi.fn()
+			terminal.taskId = "task-idle"
+			terminal.busy = false
+			terminal.process = { abort } as any
+
+			TerminalRegistry.releaseTerminalsForTask("task-idle")
+
+			expect(abort).not.toHaveBeenCalled()
+			expect(terminal.taskId).toBeUndefined()
+		})
+
+		it("only releases terminals belonging to the given task", () => {
+			const a = TerminalRegistry.createTerminal("/a", "vscode")
+			const b = TerminalRegistry.createTerminal("/b", "vscode")
+			const abortA = vi.fn()
+			const abortB = vi.fn()
+			a.taskId = "task-A"
+			a.busy = true
+			a.process = { abort: abortA } as any
+			b.taskId = "task-B"
+			b.busy = true
+			b.process = { abort: abortB } as any
+
+			TerminalRegistry.releaseTerminalsForTask("task-A")
+
+			expect(abortA).toHaveBeenCalledTimes(1)
+			expect(a.taskId).toBeUndefined()
+			expect(abortB).not.toHaveBeenCalled()
+			expect(b.taskId).toBe("task-B")
+		})
+
+		it("swallows errors thrown by process.abort() and still disassociates the terminal", () => {
+			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode")
+			terminal.taskId = "task-throw"
+			terminal.busy = true
+			terminal.process = {
+				abort: vi.fn(() => {
+					throw new Error("boom")
+				}),
+			} as any
+
+			expect(() => TerminalRegistry.releaseTerminalsForTask("task-throw")).not.toThrow()
+			expect(terminal.taskId).toBeUndefined()
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #245. Pressing cancel (✕) on a running command didn't terminate the underlying process — the terminal stayed `busy` and the window stayed blocked until a manual kill. Several users hit this (also surfaced in #general-contributors).

**Root cause:** when a task is torn down (cancel ✕, task switch/removal), `Task.dispose()` → `TerminalRegistry.releaseTerminalsForTask()` only disassociated the terminal (`taskId = undefined`) without aborting a still-running command, leaving the process orphaned and the terminal stuck `busy`.

## Fix

In `releaseTerminalsForTask`, abort the running process for any terminal still `busy` before disassociating it. The abort path already exists on both backends and is a no-op when idle:

- `ExecaTerminalProcess.abort()` → SIGINT → SIGKILL on the owned subprocess
- `TerminalProcess.abort()` → Ctrl+C (`\x03`), gated on an active stream

Wrapped in try/catch so a failing abort never blocks task teardown.

## Testing

Adds 4 `TerminalRegistry` tests: busy terminal → process aborted + disassociated; idle terminal → not aborted; only the target task's terminals are released; `abort()` errors are swallowed. Full terminal suite green locally (92 passed).

## Notes

This is the **short-term** layer of the two-layer approach discussed with @edelauna in #general-contributors: make ✕ reliably terminate the process today. The **long-term** direction — owning process lifecycle via the VS Code Task API + `CustomExecution` for deterministic cross-platform process-tree termination — is a natural follow-up and fits the portable-core/runtime direction. Happy to take a first pass at that separately so it doesn't block this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cancelling or tearing down a task would leave the underlying terminal process running in a busy state. Terminal processes are now properly aborted when a task is cancelled or torn down, preventing hung processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->