### PR TITLE
fix(openai-codex): use full ~1M context window for gpt-5.5

### DIFF
--- a/packages/types/src/providers/openai-codex.ts
+++ b/packages/types/src/providers/openai-codex.ts
@@ -174,7 +174,7 @@ export const openAiCodexModels = {
 	},
 	"gpt-5.5": {
 		maxTokens: 128000,
-		contextWindow: 400000,
+		contextWindow: 1_050_000,
 		includedTools: ["apply_patch"],
 		excludedTools: ["apply_diff", "write_to_file"],
 		supportsImages: true,

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -41,4 +41,12 @@ describe("OpenAiCodexHandler.getModel", () => {
 		expect(model.id).toBe("gpt-5.4-mini")
 		expect(model.info).toBeDefined()
 	})
+
+	it("should expose the full ~1M context window for GPT-5.5", () => {
+		const handler = new OpenAiCodexHandler({ apiModelId: "gpt-5.5" })
+		const model = handler.getModel()
+
+		expect(model.id).toBe("gpt-5.5")
+		expect(model.info.contextWindow).toBe(1_050_000)
+	})
 })


### PR DESCRIPTION
## Summary

GPT-5.5 via the Codex OAuth (ChatGPT subscription) connection supports a ~1.05M token context window, but its model metadata in `openAiCodexModels` capped `contextWindow` at 400000. This truncated the usable context to 400K, as reported in #237.

This change aligns gpt-5.5's `contextWindow` with the equivalent `gpt-5.4` entry (`1_050_000`). The handler reads `contextWindow` directly from this metadata (`getModel()` returns `openAiCodexModels[id]` unmodified), so this is the only place the cap originated; there is no separate clamping.

## Changes
- `packages/types/src/providers/openai-codex.ts`: `gpt-5.5` `contextWindow` 400000 -> 1_050_000
- `src/api/providers/__tests__/openai-codex.spec.ts`: regression test asserting gpt-5.5 exposes the ~1M window

Closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Increased GPT-5.5 model context window from 400,000 to 1,050,000 tokens, enabling support for longer inputs and larger documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->