### PR TITLE
fix(api): identify as Zoo Code in outbound provider request headers

### DIFF
--- a/src/api/providers/__tests__/constants.spec.ts
+++ b/src/api/providers/__tests__/constants.spec.ts
@@ -11,16 +11,16 @@ describe("DEFAULT_HEADERS", () => {
 	})
 
 	it("should have correct HTTP-Referer value", () => {
-		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://github.com/RooVetGit/Roo-Cline")
+		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://github.com/Zoo-Code-Org/Zoo-Code")
 	})
 
 	it("should have correct X-Title value", () => {
-		expect(DEFAULT_HEADERS["X-Title"]).toBe("Roo Code")
+		expect(DEFAULT_HEADERS["X-Title"]).toBe("Zoo Code")
 	})
 
 	it("should have correct User-Agent format", () => {
 		const userAgent = DEFAULT_HEADERS["User-Agent"]
-		expect(userAgent).toBe(`RooCode/${Package.version}`)
+		expect(userAgent).toBe(`ZooCode/${Package.version}`)
 
 		// Verify it follows the tool_name/version pattern
 		expect(userAgent).toMatch(/^[a-zA-Z-]+\/\d+\.\d+\.\d+$/)
@@ -28,7 +28,7 @@ describe("DEFAULT_HEADERS", () => {
 
 	it("should have User-Agent with correct tool name", () => {
 		const userAgent = DEFAULT_HEADERS["User-Agent"]
-		expect(userAgent.startsWith("RooCode/")).toBe(true)
+		expect(userAgent.startsWith("ZooCode/")).toBe(true)
 	})
 
 	it("should have User-Agent with semantic version format", () => {

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -111,9 +111,9 @@ describe("OpenAiHandler", () => {
 				baseURL: expect.any(String),
 				apiKey: expect.any(String),
 				defaultHeaders: {
-					"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-					"X-Title": "Roo Code",
-					"User-Agent": `RooCode/${Package.version}`,
+					"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+					"X-Title": "Zoo Code",
+					"User-Agent": `ZooCode/${Package.version}`,
 				},
 				timeout: expect.any(Number),
 			})

--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -100,9 +100,9 @@ describe("OpenRouterHandler", () => {
 			baseURL: "https://openrouter.ai/api/v1",
 			apiKey: mockOptions.openRouterApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
-				"User-Agent": `RooCode/${Package.version}`,
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
+				"User-Agent": `ZooCode/${Package.version}`,
 			},
 		})
 	})

--- a/src/api/providers/__tests__/requesty.spec.ts
+++ b/src/api/providers/__tests__/requesty.spec.ts
@@ -58,9 +58,9 @@ describe("RequestyHandler", () => {
 			baseURL: "https://router.requesty.ai/v1",
 			apiKey: mockOptions.requestyApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
-				"User-Agent": `RooCode/${Package.version}`,
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
+				"User-Agent": `ZooCode/${Package.version}`,
 			},
 		})
 	})
@@ -73,9 +73,9 @@ describe("RequestyHandler", () => {
 			baseURL: "https://custom.requesty.ai/v1",
 			apiKey: mockOptions.requestyApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
-				"User-Agent": `RooCode/${Package.version}`,
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
+				"User-Agent": `ZooCode/${Package.version}`,
 			},
 		})
 	})

--- a/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
+++ b/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
@@ -96,9 +96,9 @@ describe("VercelAiGatewayHandler", () => {
 			baseURL: "https://ai-gateway.vercel.sh/v1",
 			apiKey: mockOptions.vercelAiGatewayApiKey,
 			defaultHeaders: expect.objectContaining({
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
-				"User-Agent": expect.stringContaining("RooCode/"),
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
+				"User-Agent": expect.stringContaining("ZooCode/"),
 			}),
 		})
 	})

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -252,7 +252,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		this.costModelConfig = this.getModel()
 
 		const clientConfig: BedrockRuntimeClientConfig = {
-			userAgentAppId: `RooCode#${Package.version}`,
+			userAgentAppId: `ZooCode#${Package.version}`,
 			region: this.options.awsRegion,
 			// Add the endpoint configuration when specified and enabled
 			...(this.options.awsBedrockEndpoint &&

--- a/src/api/providers/constants.ts
+++ b/src/api/providers/constants.ts
@@ -1,7 +1,7 @@
 import { Package } from "../../shared/package"
 
 export const DEFAULT_HEADERS = {
-	"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-	"X-Title": "Roo Code",
-	"User-Agent": `RooCode/${Package.version}`,
+	"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+	"X-Title": "Zoo Code",
+	"User-Agent": `ZooCode/${Package.version}`,
 }

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -360,7 +360,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				const codexHeaders: Record<string, string> = {
 					originator: "roo-code",
 					session_id: taskId || this.sessionId,
-					"User-Agent": `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
+					"User-Agent": `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
 					...(accountId ? { "ChatGPT-Account-Id": accountId } : {}),
 				}
 
@@ -505,7 +505,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 			Authorization: `Bearer ${accessToken}`,
 			originator: "roo-code",
 			session_id: taskId || this.sessionId,
-			"User-Agent": `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
+			"User-Agent": `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
 		}
 
 		// Add ChatGPT-Account-Id if available (required for organization subscriptions)
@@ -1201,7 +1201,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				Authorization: `Bearer ${accessToken}`,
 				originator: "roo-code",
 				session_id: this.sessionId,
-				"User-Agent": `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
+				"User-Agent": `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`,
 			}
 
 			// Add ChatGPT-Account-Id if available

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -95,7 +95,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 		}
 		const apiKey = this.options.openAiNativeApiKey ?? "not-provided"
 		// Include originator, session_id, and User-Agent headers for API tracking and debugging
-		const userAgent = `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
+		const userAgent = `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
 		this.client = new OpenAI({
 			baseURL: this.options.openAiNativeBaseUrl || undefined,
 			apiKey,
@@ -415,7 +415,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 
 		// Build per-request headers using taskId when available, falling back to sessionId
 		const taskId = metadata?.taskId
-		const userAgent = `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
+		const userAgent = `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
 		const requestHeaders: Record<string, string> = {
 			originator: "roo-code",
 			session_id: taskId || this.sessionId,
@@ -563,7 +563,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 
 		// Build per-request headers using taskId when available, falling back to sessionId
 		const taskId = metadata?.taskId
-		const userAgent = `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
+		const userAgent = `zoo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
 
 		try {
 			const response = await fetch(url, {

--- a/src/api/providers/utils/image-generation.ts
+++ b/src/api/providers/utils/image-generation.ts
@@ -70,8 +70,8 @@ export async function generateImageWithProvider(options: ImageGenerationOptions)
 			headers: {
 				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Code",
-				"X-Title": "Roo Code",
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
 			},
 			body: JSON.stringify({
 				model,
@@ -216,8 +216,8 @@ export async function generateImageWithImagesApi(options: ImagesApiOptions): Pro
 			headers: {
 				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Code",
-				"X-Title": "Roo Code",
+				"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+				"X-Title": "Zoo Code",
 			},
 			body: JSON.stringify(requestBody),
 		}

--- a/src/services/code-index/embedders/__tests__/openrouter.spec.ts
+++ b/src/services/code-index/embedders/__tests__/openrouter.spec.ts
@@ -90,8 +90,8 @@ describe("OpenRouterEmbedder", () => {
 				baseURL: "https://openrouter.ai/api/v1",
 				apiKey: mockApiKey,
 				defaultHeaders: {
-					"HTTP-Referer": "https://github.com/RooCodeInc/Roo-Code",
-					"X-Title": "Roo Code",
+					"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+					"X-Title": "Zoo Code",
 				},
 			})
 		})

--- a/src/services/code-index/embedders/bedrock.ts
+++ b/src/services/code-index/embedders/bedrock.ts
@@ -41,7 +41,7 @@ export class BedrockEmbedder implements IEmbedder {
 		const credentials = this.profile ? fromIni({ profile: this.profile }) : fromNodeProviderChain()
 
 		this.bedrockClient = new BedrockRuntimeClient({
-			userAgentAppId: `RooCode#${Package.version}`,
+			userAgentAppId: `ZooCode#${Package.version}`,
 			region: this.region,
 			credentials,
 		})

--- a/src/services/code-index/embedders/openrouter.ts
+++ b/src/services/code-index/embedders/openrouter.ts
@@ -76,8 +76,8 @@ export class OpenRouterEmbedder implements IEmbedder {
 				baseURL: this.baseUrl,
 				apiKey: apiKey,
 				defaultHeaders: {
-					"HTTP-Referer": "https://github.com/RooCodeInc/Roo-Code",
-					"X-Title": "Roo Code",
+					"HTTP-Referer": "https://github.com/Zoo-Code-Org/Zoo-Code",
+					"X-Title": "Zoo Code",
 				},
 			})
 		} catch (error) {

--- a/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
+++ b/src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts
@@ -79,7 +79,7 @@ describe("QdrantVectorStore", () => {
 			port: 6333,
 			apiKey: mockApiKey,
 			headers: {
-				"User-Agent": "Roo-Code",
+				"User-Agent": "Zoo-Code",
 			},
 		})
 		expect(createHash).toHaveBeenCalledWith("sha256")
@@ -98,7 +98,7 @@ describe("QdrantVectorStore", () => {
 			port: 6333,
 			apiKey: undefined,
 			headers: {
-				"User-Agent": "Roo-Code",
+				"User-Agent": "Zoo-Code",
 			},
 		})
 	})
@@ -112,7 +112,7 @@ describe("QdrantVectorStore", () => {
 			port: 6333,
 			apiKey: undefined,
 			headers: {
-				"User-Agent": "Roo-Code",
+				"User-Agent": "Zoo-Code",
 			},
 		})
 	})
@@ -132,7 +132,7 @@ describe("QdrantVectorStore", () => {
 					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("https://qdrant.ashbyfam.com")
@@ -147,7 +147,7 @@ describe("QdrantVectorStore", () => {
 					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("https://example.com:9000")
@@ -166,7 +166,7 @@ describe("QdrantVectorStore", () => {
 					prefix: "/api/v1", // Should have prefix
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("https://example.com/api/v1?key=value")
@@ -183,7 +183,7 @@ describe("QdrantVectorStore", () => {
 					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://example.com")
@@ -198,7 +198,7 @@ describe("QdrantVectorStore", () => {
 					prefix: undefined, // No prefix for root path
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:8080")
@@ -217,7 +217,7 @@ describe("QdrantVectorStore", () => {
 					prefix: "/api/v1", // Should have prefix
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://example.com/api/v1?key=value")
@@ -233,7 +233,7 @@ describe("QdrantVectorStore", () => {
 					port: 80,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://qdrant.example.com")
@@ -247,7 +247,7 @@ describe("QdrantVectorStore", () => {
 					port: 6333,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:6333")
@@ -261,7 +261,7 @@ describe("QdrantVectorStore", () => {
 					port: 9000,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:9000")
@@ -277,7 +277,7 @@ describe("QdrantVectorStore", () => {
 					port: 80,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://192.168.1.100")
@@ -291,7 +291,7 @@ describe("QdrantVectorStore", () => {
 					port: 6333,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://192.168.1.100:6333")
@@ -307,7 +307,7 @@ describe("QdrantVectorStore", () => {
 					port: 6333,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:6333")
@@ -321,7 +321,7 @@ describe("QdrantVectorStore", () => {
 					port: 6333,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:6333")
@@ -335,7 +335,7 @@ describe("QdrantVectorStore", () => {
 					port: 6333,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://localhost:6333")
@@ -351,7 +351,7 @@ describe("QdrantVectorStore", () => {
 					port: 80,
 					apiKey: undefined,
 					headers: {
-						"User-Agent": "Roo-Code",
+						"User-Agent": "Zoo-Code",
 					},
 				})
 				expect((vectorStore as any).qdrantUrl).toBe("http://invalid-url-format")
@@ -373,7 +373,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/some/path",
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithPrefix as any).qdrantUrl).toBe("http://localhost:6333/some/path")
@@ -392,7 +392,7 @@ describe("QdrantVectorStore", () => {
 				prefix: undefined,
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithoutPrefix as any).qdrantUrl).toBe("http://localhost:6333/")
@@ -411,7 +411,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/api",
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithHttpsPrefix as any).qdrantUrl).toBe("https://qdrant.ashbyfam.com/api")
@@ -430,7 +430,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/api", // Trailing slash should be removed
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithTrailingSlash as any).qdrantUrl).toBe("http://localhost:6333/api/")
@@ -449,7 +449,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/api", // All trailing slashes should be removed
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithMultipleTrailingSlashes as any).qdrantUrl).toBe("http://localhost:6333/api///")
@@ -468,7 +468,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/api/v1/qdrant",
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithMultiSegment as any).qdrantUrl).toBe("http://localhost:6333/api/v1/qdrant")
@@ -484,7 +484,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/ollama/api/v1", // Trailing slash removed, query/fragment ignored
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreComplex as any).qdrantUrl).toBe(complexUrl)
@@ -503,7 +503,7 @@ describe("QdrantVectorStore", () => {
 				prefix: "/api/path", // Query params and fragment should be ignored
 				apiKey: undefined,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 			expect((vectorStoreWithQueryParams as any).qdrantUrl).toBe(

--- a/src/services/code-index/vector-store/qdrant-client.ts
+++ b/src/services/code-index/vector-store/qdrant-client.ts
@@ -62,7 +62,7 @@ export class QdrantVectorStore implements IVectorStore {
 				prefix: urlObj.pathname === "/" ? undefined : urlObj.pathname.replace(/\/+$/, ""),
 				apiKey,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 		} catch (urlError) {
@@ -72,7 +72,7 @@ export class QdrantVectorStore implements IVectorStore {
 				url: parsedUrl,
 				apiKey,
 				headers: {
-					"User-Agent": "Roo-Code",
+					"User-Agent": "Zoo-Code",
 				},
 			})
 		}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #203

### Description

Zoo Code still identified itself as "Roo Code" / "RooCode" in the self-identification strings it sends to AI providers. This updates those outbound identifiers to "Zoo Code".

The "how":

- `src/api/providers/constants.ts` — `DEFAULT_HEADERS`: `HTTP-Referer` -> `https://github.com/Zoo-Code-Org/Zoo-Code`, `X-Title` -> `Zoo Code`, `User-Agent` -> `ZooCode/<version>`.
- `src/api/providers/utils/image-generation.ts` — `HTTP-Referer` / `X-Title` on both image endpoints.
- `src/services/code-index/embedders/openrouter.ts` — `HTTP-Referer` / `X-Title`.
- `src/api/providers/openai-native.ts` and `src/api/providers/openai-codex.ts` — `User-Agent` (`roo-code/...` -> `zoo-code/...`).
- `src/api/providers/bedrock.ts` and `src/services/code-index/embedders/bedrock.ts` — AWS SDK `userAgentAppId` (`RooCode#...` -> `ZooCode#...`).
- `src/services/code-index/vector-store/qdrant-client.ts` — `User-Agent` (`Roo-Code` -> `Zoo-Code`).

Deliberately left unchanged (out of scope / would break things):

- The Codex `originator: "roo-code"` value — this is a protocol-level identifier the ChatGPT/Codex backend recognizes for auth/routing; changing it risks breaking authorization (as the issue itself cautions).
- Internal config/storage paths (`/Library/Application Support/RooCode/...`, `~/.local/share/Roo-Code/MCP`, `/etc/roo-code/...`) — changing these would orphan existing user data.
- Internal log labels and code comments referencing upstream Roo issues.
- Internal package scopes such as `@roo-code/types`.

Aligns with the roadmap's "Reliability First" goal (accurate self-identification eases debugging and is respectful of the upstream project).

### Test Procedure

- Updated the existing unit assertions that pin these header values: `src/api/providers/__tests__/constants.spec.ts`, `openai.spec.ts`, `openrouter.spec.ts`, `requesty.spec.ts`, `vercel-ai-gateway.spec.ts`, `src/services/code-index/embedders/__tests__/openrouter.spec.ts`, and `src/services/code-index/vector-store/__tests__/qdrant-client.spec.ts`.
- Reviewers can verify by running the scoped suites, e.g. `cd src && npx vitest run providers/__tests__/constants.spec.ts` (and the other updated specs), plus `pnpm --filter <pkg> check-types`.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to issue #203.
- [x] **Scope**: Changes are focused solely on the linked issue.
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: Existing tests that assert these values were updated to match.
- [x] **Documentation Impact**: No user-facing documentation changes required.
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

Self-identification strings only; no behavioral/auth changes. The Codex `originator` field was intentionally preserved to avoid breaking backend authorization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated HTTP headers (Referer, Title) and user agent strings across multiple API provider integrations, embedders, and vector store clients.

* **Tests**
  * Updated test expectations across provider and embedder tests to verify revised HTTP header and user agent values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->