### PR TITLE
fix(vertex): warn when 'Google Cloud Credentials' field receives a file path

### DIFF
--- a/.changeset/vertex-credentials-field-validation.md
+++ b/.changeset/vertex-credentials-field-validation.md
@@ -1,0 +1,5 @@
+---
+"zoo-code": patch
+---
+
+Detect when the "Google Cloud Credentials" Vertex field has been given a filesystem path instead of the raw JSON contents of a service-account key file. The runtime now skips JSON.parse for path-shaped input, logs a single specific console warning naming the sibling "Google Cloud Key File Path" field and `GOOGLE_APPLICATION_CREDENTIALS` env var, and the settings UI shows an inline warning under the field while the input still looks like a path. Auth behavior is unchanged for correctly-configured users.

--- a/packages/core/src/message-utils/__tests__/safeJsonParse.spec.ts
+++ b/packages/core/src/message-utils/__tests__/safeJsonParse.spec.ts
@@ -1,0 +1,43 @@
+// npx vitest run packages/core/src/message-utils/__tests__/safeJsonParse.spec.ts
+
+import { safeJsonParse } from "../safeJsonParse.js"
+
+describe("safeJsonParse", () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore()
+	})
+
+	it("returns the parsed value for valid JSON", () => {
+		expect(safeJsonParse<{ a: number }>('{"a":1}')).toEqual({ a: 1 })
+		expect(consoleErrorSpy).not.toHaveBeenCalled()
+	})
+
+	it("returns the default value for null, undefined, or empty input", () => {
+		expect(safeJsonParse<string>(null, "fallback")).toBe("fallback")
+		expect(safeJsonParse<string>(undefined, "fallback")).toBe("fallback")
+		expect(safeJsonParse<string>("", "fallback")).toBe("fallback")
+		expect(consoleErrorSpy).not.toHaveBeenCalled()
+	})
+
+	it("returns the default value and logs the generic message when no context is given (backward compatible)", () => {
+		const result = safeJsonParse<{ a: number }>("not json", undefined)
+		expect(result).toBeUndefined()
+		expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+		const message = consoleErrorSpy.mock.calls[0]?.[0]
+		expect(message).toBe("Error parsing JSON:")
+	})
+
+	it("includes the context label in the error log when provided", () => {
+		const result = safeJsonParse<{ a: number }>("not json", undefined, "foo")
+		expect(result).toBeUndefined()
+		expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+		const message = consoleErrorSpy.mock.calls[0]?.[0]
+		expect(message).toBe("Error parsing JSON (foo):")
+	})
+})

--- a/packages/core/src/message-utils/safeJsonParse.ts
+++ b/packages/core/src/message-utils/safeJsonParse.ts
@@ -3,9 +3,16 @@
  *
  * @param jsonString The string to parse
  * @param defaultValue Value to return if parsing fails
+ * @param context Optional label included in the error log so callers can be
+ *   identified when something other than valid JSON is supplied (e.g. a user
+ *   pasting a file path into a JSON field).
  * @returns Parsed JSON object or defaultValue if parsing fails
  */
-export function safeJsonParse<T>(jsonString: string | null | undefined, defaultValue?: T): T | undefined {
+export function safeJsonParse<T>(
+	jsonString: string | null | undefined,
+	defaultValue?: T,
+	context?: string,
+): T | undefined {
 	if (!jsonString) {
 		return defaultValue
 	}
@@ -14,7 +21,7 @@ export function safeJsonParse<T>(jsonString: string | null | undefined, defaultV
 		return JSON.parse(jsonString) as T
 	} catch (error) {
 		// Log the error to the console for debugging.
-		console.error("Error parsing JSON:", error)
+		console.error(`Error parsing JSON${context ? ` (${context})` : ""}:`, error)
 		return defaultValue
 	}
 }

--- a/packages/types/src/__tests__/looksLikeFilePath.spec.ts
+++ b/packages/types/src/__tests__/looksLikeFilePath.spec.ts
@@ -1,0 +1,48 @@
+// npx vitest run src/__tests__/looksLikeFilePath.spec.ts
+
+import { looksLikeFilePath } from "../utils/looksLikeFilePath.js"
+
+describe("looksLikeFilePath", () => {
+	describe("nullish, empty, and whitespace-only input", () => {
+		it.each([
+			["undefined", undefined],
+			["null", null],
+			["empty string", ""],
+			["whitespace only", "   \t\n  "],
+		])("returns false for %s", (_label, value) => {
+			expect(looksLikeFilePath(value)).toBe(false)
+		})
+	})
+
+	describe("path-shaped input", () => {
+		it.each([
+			["Windows backslash path", "C:\\Users\\dev\\sa.json"],
+			["Windows forward-slash path", "C:/Users/dev/sa.json"],
+			["Windows drive lowercase", "d:\\creds.json"],
+			["POSIX absolute path", "/home/dev/sa.json"],
+			["POSIX absolute root /tmp", "/tmp/creds.json"],
+			["POSIX home path", "~/sa.json"],
+			["POSIX relative ./", "./sa.json"],
+			["POSIX relative ../", "../secrets/sa.json"],
+		])("returns true for %s", (_label, value) => {
+			expect(looksLikeFilePath(value)).toBe(true)
+		})
+
+		it("returns true after trimming surrounding whitespace", () => {
+			expect(looksLikeFilePath("  /tmp/creds.json  ")).toBe(true)
+			expect(looksLikeFilePath("\tC:\\sa.json\n")).toBe(true)
+		})
+	})
+
+	describe("JSON-shaped or bare-token input", () => {
+		it.each([
+			["JSON object", '{"type":"service_account","client_email":"x@y.z"}'],
+			["JSON array", "[1,2,3]"],
+			["JSON with leading whitespace", '   {"type":"service_account"}'],
+			["bare token", "not-json-and-not-a-path"],
+			["service-account-style email", "sa@project.iam.gserviceaccount.com"],
+		])("returns false for %s", (_label, value) => {
+			expect(looksLikeFilePath(value)).toBe(false)
+		})
+	})
+})

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,3 +33,5 @@ export * from "./vscode.js"
 export * from "./worktree.js"
 
 export * from "./providers/index.js"
+
+export * from "./utils/looksLikeFilePath.js"

--- a/packages/types/src/utils/looksLikeFilePath.ts
+++ b/packages/types/src/utils/looksLikeFilePath.ts
@@ -1,0 +1,24 @@
+// Returns true when a string is shaped like a filesystem path (Windows
+// drive-letter, POSIX absolute, POSIX home, POSIX relative). Pure and
+// dependency-free so it can be shared between the extension runtime (e.g.
+// parseVertexJsonCredentials) and the webview UI (e.g. the Vertex settings
+// warning), guaranteeing both surfaces agree on what "looks like a path"
+// means.
+//
+// Returns false for nullish, empty, and whitespace-only input — neither
+// call site should warn in those cases.
+export function looksLikeFilePath(value: string | null | undefined): boolean {
+	if (value == null) {
+		return false
+	}
+	const trimmed = value.trim()
+	if (!trimmed) {
+		return false
+	}
+	return (
+		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
+		trimmed.startsWith("/") || // POSIX absolute: /home/...
+		trimmed.startsWith("~") || // POSIX home: ~/...
+		trimmed.startsWith(".") // POSIX relative: ./... or ../...
+	)
+}

--- a/src/api/providers/__tests__/vertex-credentials.spec.ts
+++ b/src/api/providers/__tests__/vertex-credentials.spec.ts
@@ -109,11 +109,18 @@ describe("parseVertexJsonCredentials", () => {
 		expect(warnSpy).toHaveBeenCalledTimes(1)
 	})
 
-	it("truncates long path previews in the warning", () => {
-		const longPath = "/" + "a".repeat(200)
-		parseVertexJsonCredentials(longPath)
+	it("does not echo the user's path in the warning (no PII in extension logs)", () => {
+		const sensitivePath = "/home/somerealuser/secrets/sa-key.json"
+		parseVertexJsonCredentials(sensitivePath)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
 		const [message] = warnSpy.mock.calls[0]
-		expect(message).toContain("…")
+		// The warning must identify the field and the env var, but must not
+		// interpolate the user's actual input — usernames and directory names
+		// would leak into extension logs otherwise.
+		expect(message).toContain("Google Cloud Credentials")
+		expect(message).toContain("GOOGLE_APPLICATION_CREDENTIALS")
+		expect(message).not.toContain(sensitivePath)
+		expect(message).not.toContain("somerealuser")
 	})
 
 	it("falls back to the generic JSON parse error path for malformed but non-path input", () => {

--- a/src/api/providers/__tests__/vertex-credentials.spec.ts
+++ b/src/api/providers/__tests__/vertex-credentials.spec.ts
@@ -45,9 +45,10 @@ vitest.mock("@anthropic-ai/vertex-sdk", () => ({
 	})),
 }))
 
-import { GeminiHandler, parseVertexJsonCredentials } from "../gemini"
+import { GeminiHandler } from "../gemini"
 import { VertexHandler } from "../vertex"
 import { AnthropicVertexHandler } from "../anthropic-vertex"
+import { parseVertexJsonCredentials } from "../utils/vertex-credentials"
 
 const VALID_CREDS_JSON = JSON.stringify({
 	type: "service_account",
@@ -155,7 +156,7 @@ describe("GeminiHandler vertex credentials wiring", () => {
 		expect(args.googleAuthOptions.credentials).toMatchObject({ type: "service_account" })
 	})
 
-	it("warns and passes undefined credentials when the field looks like a path", () => {
+	it("warns and falls through past the JSON branch when the field looks like a path", () => {
 		new GeminiHandler({
 			apiModelId: "gemini-2.0-flash-001",
 			vertexProjectId: "p",
@@ -167,7 +168,34 @@ describe("GeminiHandler vertex credentials wiring", () => {
 		expect(warnSpy).toHaveBeenCalledTimes(1)
 		expect(googleGenAICtor).toHaveBeenCalledTimes(1)
 		const args = googleGenAICtor.mock.calls[0][0]
-		expect(args.googleAuthOptions.credentials).toBeUndefined()
+		// With only a path-shaped vertexJsonCredentials (no vertexKeyFile),
+		// the ternary falls all the way through to the bare isVertex branch:
+		// new GoogleGenAI({ vertexai: true, project, location }) — no
+		// googleAuthOptions block.
+		expect(args.googleAuthOptions).toBeUndefined()
+		expect(args.vertexai).toBe(true)
+		// Generic "Error parsing JSON" must not fire for the path case.
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("uses vertexKeyFile when vertexJsonCredentials is path-shaped AND vertexKeyFile is set", () => {
+		new GeminiHandler({
+			apiModelId: "gemini-2.0-flash-001",
+			vertexProjectId: "p",
+			vertexRegion: "us-central1",
+			vertexJsonCredentials: "C:\\Users\\dev\\sa.json",
+			vertexKeyFile: "my-key-file.json",
+			isVertex: true,
+		})
+
+		expect(googleGenAICtor).toHaveBeenCalledTimes(1)
+		const args = googleGenAICtor.mock.calls[0][0]
+		// The path-shaped input must not poison the JSON branch; the fallback
+		// to the vertexKeyFile branch must take effect.
+		expect(args.googleAuthOptions?.keyFile).toBe("my-key-file.json")
+		expect(args.googleAuthOptions?.credentials).toBeUndefined()
+		// The warning for the path-shaped input still fires.
+		expect(warnSpy).toHaveBeenCalledTimes(1)
 		// Generic "Error parsing JSON" must not fire for the path case.
 		expect(errorSpy).not.toHaveBeenCalled()
 	})
@@ -200,7 +228,7 @@ describe("VertexHandler inherits the path-shape guard from GeminiHandler", () =>
 		warnSpy.mockRestore()
 	})
 
-	it("warns and passes undefined credentials when the field looks like a POSIX path", () => {
+	it("warns and falls through past the JSON branch when the field looks like a POSIX path", () => {
 		new VertexHandler({
 			apiModelId: "gemini-2.0-flash-001",
 			vertexProjectId: "p",
@@ -210,7 +238,11 @@ describe("VertexHandler inherits the path-shape guard from GeminiHandler", () =>
 
 		expect(warnSpy).toHaveBeenCalledTimes(1)
 		const args = googleGenAICtor.mock.calls[0][0]
-		expect(args.googleAuthOptions.credentials).toBeUndefined()
+		// VertexHandler extends GeminiHandler with isVertex:true. With only a
+		// path-shaped vertexJsonCredentials, the ternary falls through to the
+		// bare isVertex branch with no googleAuthOptions.
+		expect(args.googleAuthOptions).toBeUndefined()
+		expect(args.vertexai).toBe(true)
 	})
 })
 
@@ -243,7 +275,7 @@ describe("AnthropicVertexHandler vertex credentials wiring", () => {
 		expect(args.credentials).toMatchObject({ type: "service_account" })
 	})
 
-	it("warns and passes undefined credentials when the field looks like a Windows path", () => {
+	it("warns and skips the GoogleAuth construction when the field looks like a Windows path", () => {
 		new AnthropicVertexHandler({
 			apiModelId: "claude-3-5-sonnet-v2@20241022",
 			vertexProjectId: "p",
@@ -252,9 +284,32 @@ describe("AnthropicVertexHandler vertex credentials wiring", () => {
 		})
 
 		expect(warnSpy).toHaveBeenCalledTimes(1)
+		// With only a path-shaped vertexJsonCredentials (no vertexKeyFile),
+		// every branch in the constructor falls through to the bare
+		// `new AnthropicVertex({ projectId, region })` and GoogleAuth is
+		// never instantiated.
+		expect(googleAuthCtor).not.toHaveBeenCalled()
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("uses vertexKeyFile when vertexJsonCredentials is path-shaped AND vertexKeyFile is set", () => {
+		new AnthropicVertexHandler({
+			apiModelId: "claude-3-5-sonnet-v2@20241022",
+			vertexProjectId: "p",
+			vertexRegion: "us-east5",
+			vertexJsonCredentials: "C:\\Users\\dev\\sa.json",
+			vertexKeyFile: "my-key-file.json",
+		})
+
+		// The path-shaped input must not poison the JSON branch; the fallback
+		// to the vertexKeyFile branch must take effect.
 		expect(googleAuthCtor).toHaveBeenCalledTimes(1)
 		const args = googleAuthCtor.mock.calls[0][0]
+		expect(args.keyFile).toBe("my-key-file.json")
 		expect(args.credentials).toBeUndefined()
+		// The warning for the path-shaped input still fires.
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		// Generic "Error parsing JSON" must not fire for the path case.
 		expect(errorSpy).not.toHaveBeenCalled()
 	})
 

--- a/src/api/providers/__tests__/vertex-credentials.spec.ts
+++ b/src/api/providers/__tests__/vertex-credentials.spec.ts
@@ -1,0 +1,271 @@
+// npx vitest run src/api/providers/__tests__/vertex-credentials.spec.ts
+
+// Mock vscode first to avoid import errors when the provider stack pulls
+// transitive vscode-dependent modules during construction.
+vitest.mock("vscode", () => ({}))
+
+vitest.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			captureException: vitest.fn(),
+		},
+	},
+}))
+
+// Capture the constructor args passed to GoogleGenAI so we can assert on the
+// credentials handed to GoogleAuth via googleAuthOptions.
+const googleGenAICtor = vitest.fn()
+vitest.mock("@google/genai", () => ({
+	GoogleGenAI: vitest.fn().mockImplementation((args: unknown) => {
+		googleGenAICtor(args)
+		return {
+			models: {
+				generateContentStream: vitest.fn(),
+				generateContent: vitest.fn(),
+			},
+		}
+	}),
+	FunctionCallingConfigMode: { AUTO: "AUTO", ANY: "ANY", NONE: "NONE" },
+}))
+
+// Capture the constructor args passed to GoogleAuth (Anthropic-on-Vertex path).
+const googleAuthCtor = vitest.fn()
+vitest.mock("google-auth-library", () => ({
+	GoogleAuth: vitest.fn().mockImplementation((args: unknown) => {
+		googleAuthCtor(args)
+		return {
+			/* GoogleAuth instance shape is opaque to these tests */
+		}
+	}),
+}))
+
+vitest.mock("@anthropic-ai/vertex-sdk", () => ({
+	AnthropicVertex: vitest.fn().mockImplementation(() => ({
+		messages: { create: vitest.fn() },
+	})),
+}))
+
+import { GeminiHandler, parseVertexJsonCredentials } from "../gemini"
+import { VertexHandler } from "../vertex"
+import { AnthropicVertexHandler } from "../anthropic-vertex"
+
+const VALID_CREDS_JSON = JSON.stringify({
+	type: "service_account",
+	client_email: "test@example.iam.gserviceaccount.com",
+	private_key: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+})
+
+describe("parseVertexJsonCredentials", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+	let errorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	it("returns undefined and does not warn for empty or whitespace input", () => {
+		expect(parseVertexJsonCredentials(undefined)).toBeUndefined()
+		expect(parseVertexJsonCredentials("")).toBeUndefined()
+		expect(parseVertexJsonCredentials("   ")).toBeUndefined()
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("parses valid JSON credentials without warning", () => {
+		const result = parseVertexJsonCredentials(VALID_CREDS_JSON)
+		expect(result).toMatchObject({ type: "service_account" })
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it.each([
+		["Windows backslash path", "C:\\Users\\test\\creds.json"],
+		["Windows forward-slash path", "C:/Users/test/creds.json"],
+		["POSIX absolute path", "/home/test/creds.json"],
+		["POSIX home path", "~/creds.json"],
+		["POSIX relative ./", "./creds.json"],
+		["POSIX relative ../", "../secrets/creds.json"],
+	])("warns and returns undefined for %s", (_label, input) => {
+		const result = parseVertexJsonCredentials(input)
+		expect(result).toBeUndefined()
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		const [message] = warnSpy.mock.calls[0]
+		expect(message).toContain("Google Cloud Credentials")
+		expect(message).toContain("Google Cloud Key File Path")
+		expect(message).toContain("GOOGLE_APPLICATION_CREDENTIALS")
+		// Generic "Error parsing JSON" must not fire for the path case.
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("trims surrounding whitespace before detecting path shape", () => {
+		expect(parseVertexJsonCredentials("  /tmp/creds.json  ")).toBeUndefined()
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it("truncates long path previews in the warning", () => {
+		const longPath = "/" + "a".repeat(200)
+		parseVertexJsonCredentials(longPath)
+		const [message] = warnSpy.mock.calls[0]
+		expect(message).toContain("…")
+	})
+
+	it("falls back to the generic JSON parse error path for malformed but non-path input", () => {
+		const result = parseVertexJsonCredentials("not-json-and-not-a-path")
+		expect(result).toBeUndefined()
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(errorSpy).toHaveBeenCalledTimes(1)
+		const [message] = errorSpy.mock.calls[0]
+		expect(message).toBe("Error parsing JSON (Vertex credentials):")
+	})
+})
+
+describe("GeminiHandler vertex credentials wiring", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+	let errorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		googleGenAICtor.mockClear()
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	it("passes parsed JSON credentials through to GoogleGenAI", () => {
+		new GeminiHandler({
+			apiModelId: "gemini-2.0-flash-001",
+			vertexProjectId: "p",
+			vertexRegion: "us-central1",
+			vertexJsonCredentials: VALID_CREDS_JSON,
+			isVertex: true,
+		})
+
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(googleGenAICtor).toHaveBeenCalledTimes(1)
+		const args = googleGenAICtor.mock.calls[0][0]
+		expect(args.googleAuthOptions.credentials).toMatchObject({ type: "service_account" })
+	})
+
+	it("warns and passes undefined credentials when the field looks like a path", () => {
+		new GeminiHandler({
+			apiModelId: "gemini-2.0-flash-001",
+			vertexProjectId: "p",
+			vertexRegion: "us-central1",
+			vertexJsonCredentials: "C:\\Users\\dev\\sa.json",
+			isVertex: true,
+		})
+
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(googleGenAICtor).toHaveBeenCalledTimes(1)
+		const args = googleGenAICtor.mock.calls[0][0]
+		expect(args.googleAuthOptions.credentials).toBeUndefined()
+		// Generic "Error parsing JSON" must not fire for the path case.
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("does not warn or supply credentials when neither field is set", () => {
+		new GeminiHandler({
+			apiModelId: "gemini-2.0-flash-001",
+			vertexProjectId: "p",
+			vertexRegion: "us-central1",
+			isVertex: true,
+		})
+
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(googleGenAICtor).toHaveBeenCalledTimes(1)
+		const args = googleGenAICtor.mock.calls[0][0]
+		// In this branch the constructor builds GoogleGenAI without googleAuthOptions.
+		expect(args.googleAuthOptions).toBeUndefined()
+	})
+})
+
+describe("VertexHandler inherits the path-shape guard from GeminiHandler", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		googleGenAICtor.mockClear()
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+	})
+
+	it("warns and passes undefined credentials when the field looks like a POSIX path", () => {
+		new VertexHandler({
+			apiModelId: "gemini-2.0-flash-001",
+			vertexProjectId: "p",
+			vertexRegion: "us-central1",
+			vertexJsonCredentials: "/home/dev/sa.json",
+		})
+
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		const args = googleGenAICtor.mock.calls[0][0]
+		expect(args.googleAuthOptions.credentials).toBeUndefined()
+	})
+})
+
+describe("AnthropicVertexHandler vertex credentials wiring", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>
+	let errorSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+		errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		googleAuthCtor.mockClear()
+	})
+
+	afterEach(() => {
+		warnSpy.mockRestore()
+		errorSpy.mockRestore()
+	})
+
+	it("passes parsed JSON credentials through to GoogleAuth", () => {
+		new AnthropicVertexHandler({
+			apiModelId: "claude-3-5-sonnet-v2@20241022",
+			vertexProjectId: "p",
+			vertexRegion: "us-east5",
+			vertexJsonCredentials: VALID_CREDS_JSON,
+		})
+
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(googleAuthCtor).toHaveBeenCalledTimes(1)
+		const args = googleAuthCtor.mock.calls[0][0]
+		expect(args.credentials).toMatchObject({ type: "service_account" })
+	})
+
+	it("warns and passes undefined credentials when the field looks like a Windows path", () => {
+		new AnthropicVertexHandler({
+			apiModelId: "claude-3-5-sonnet-v2@20241022",
+			vertexProjectId: "p",
+			vertexRegion: "us-east5",
+			vertexJsonCredentials: "C:\\Users\\dev\\sa.json",
+		})
+
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(googleAuthCtor).toHaveBeenCalledTimes(1)
+		const args = googleAuthCtor.mock.calls[0][0]
+		expect(args.credentials).toBeUndefined()
+		expect(errorSpy).not.toHaveBeenCalled()
+	})
+
+	it("does not invoke GoogleAuth when neither credentials nor keyFile is set", () => {
+		new AnthropicVertexHandler({
+			apiModelId: "claude-3-5-sonnet-v2@20241022",
+			vertexProjectId: "p",
+			vertexRegion: "us-east5",
+		})
+
+		expect(warnSpy).not.toHaveBeenCalled()
+		expect(googleAuthCtor).not.toHaveBeenCalled()
+	})
+})

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -23,7 +23,7 @@ import {
 } from "../../core/prompts/tools/native-tools/converters"
 
 import { BaseProvider } from "./base-provider"
-import { parseVertexJsonCredentials } from "./gemini"
+import { parseVertexJsonCredentials } from "./utils/vertex-credentials"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 
 // https://docs.anthropic.com/en/api/claude-on-vertex-ai
@@ -40,13 +40,15 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		const projectId = this.options.vertexProjectId ?? "not-provided"
 		const region = this.options.vertexRegion ?? "us-east5"
 
-		if (this.options.vertexJsonCredentials) {
+		const parsedVertexCredentials = parseVertexJsonCredentials(this.options.vertexJsonCredentials)
+
+		if (parsedVertexCredentials) {
 			this.client = new AnthropicVertex({
 				projectId,
 				region,
 				googleAuth: new GoogleAuth({
 					scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-					credentials: parseVertexJsonCredentials(this.options.vertexJsonCredentials),
+					credentials: parsedVertexCredentials,
 				}),
 			})
 		} else if (this.options.vertexKeyFile) {

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -1,6 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk"
-import { GoogleAuth, JWTInput } from "google-auth-library"
+import { GoogleAuth } from "google-auth-library"
 
 import {
 	type ModelInfo,
@@ -10,7 +10,6 @@ import {
 	ANTHROPIC_DEFAULT_MAX_TOKENS,
 	VERTEX_1M_CONTEXT_MODEL_IDS,
 } from "@roo-code/types"
-import { safeJsonParse } from "@roo-code/core"
 
 import { ApiHandlerOptions } from "../../shared/api"
 
@@ -24,6 +23,7 @@ import {
 } from "../../core/prompts/tools/native-tools/converters"
 
 import { BaseProvider } from "./base-provider"
+import { parseVertexJsonCredentials } from "./gemini"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 
 // https://docs.anthropic.com/en/api/claude-on-vertex-ai
@@ -46,7 +46,7 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 				region,
 				googleAuth: new GoogleAuth({
 					scopes: ["https://www.googleapis.com/auth/cloud-platform"],
-					credentials: safeJsonParse<JWTInput>(this.options.vertexJsonCredentials, undefined),
+					credentials: parseVertexJsonCredentials(this.options.vertexJsonCredentials),
 				}),
 			})
 		} else if (this.options.vertexKeyFile) {

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -33,6 +33,38 @@ type GeminiHandlerOptions = ApiHandlerOptions & {
 	isVertex?: boolean
 }
 
+// Detects when the "Google Cloud Credentials" field has received a filesystem
+// path instead of the raw JSON contents of a service-account key file. Users
+// often confuse this with GOOGLE_APPLICATION_CREDENTIALS (which IS a path),
+// and the sibling "Google Cloud Key File Path" field is where a path belongs.
+// Returns the parsed credentials object when the input looks like JSON, or
+// undefined when the field is empty, path-shaped, or unparseable.
+export function parseVertexJsonCredentials(value: string | undefined): JWTInput | undefined {
+	const trimmed = value?.trim()
+	if (!trimmed) {
+		return undefined
+	}
+
+	const looksLikePath =
+		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
+		trimmed.startsWith("/") || // POSIX absolute: /home/...
+		trimmed.startsWith("~") || // POSIX home: ~/...
+		trimmed.startsWith(".") // POSIX relative: ./... or ../...
+
+	if (looksLikePath) {
+		const preview = trimmed.length > 40 ? `${trimmed.slice(0, 40)}…` : trimmed
+		console.warn(
+			`[Vertex] The 'Google Cloud Credentials' field appears to contain a file path ("${preview}"), ` +
+				"but this field expects the raw JSON contents of a service-account key file. " +
+				"If you have a path to the credentials file, paste it into the 'Google Cloud Key File Path' field instead, " +
+				"or leave both fields empty and use the GOOGLE_APPLICATION_CREDENTIALS environment variable.",
+		)
+		return undefined
+	}
+
+	return safeJsonParse<JWTInput>(trimmed, undefined, "Vertex credentials")
+}
+
 // Gemini documents function declaration schemas as a selected OpenAPI-style
 // subset with single-value `type` plus `nullable`. In practice, third-party
 // MCP schemas often include broader JSON Schema metadata/composition that has
@@ -196,7 +228,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 					project,
 					location,
 					googleAuthOptions: {
-						credentials: safeJsonParse<JWTInput>(this.options.vertexJsonCredentials, undefined),
+						credentials: parseVertexJsonCredentials(this.options.vertexJsonCredentials),
 					},
 				})
 			: this.options.vertexKeyFile

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -7,8 +7,6 @@ import {
 	type GroundingMetadata,
 	FunctionCallingConfigMode,
 } from "@google/genai"
-import type { JWTInput } from "google-auth-library"
-
 import {
 	type ModelInfo,
 	type GeminiModelId,
@@ -16,7 +14,6 @@ import {
 	geminiModels,
 	ApiProviderError,
 } from "@roo-code/types"
-import { safeJsonParse } from "@roo-code/core"
 import { TelemetryService } from "@roo-code/telemetry"
 
 import type { ApiHandlerOptions } from "../../shared/api"
@@ -28,41 +25,10 @@ import { getModelParams } from "../transform/model-params"
 
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { BaseProvider } from "./base-provider"
+import { parseVertexJsonCredentials } from "./utils/vertex-credentials"
 
 type GeminiHandlerOptions = ApiHandlerOptions & {
 	isVertex?: boolean
-}
-
-// Detects when the "Google Cloud Credentials" field has received a filesystem
-// path instead of the raw JSON contents of a service-account key file. Users
-// often confuse this with GOOGLE_APPLICATION_CREDENTIALS (which IS a path),
-// and the sibling "Google Cloud Key File Path" field is where a path belongs.
-// Returns the parsed credentials object when the input looks like JSON, or
-// undefined when the field is empty, path-shaped, or unparseable.
-export function parseVertexJsonCredentials(value: string | undefined): JWTInput | undefined {
-	const trimmed = value?.trim()
-	if (!trimmed) {
-		return undefined
-	}
-
-	const looksLikePath =
-		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
-		trimmed.startsWith("/") || // POSIX absolute: /home/...
-		trimmed.startsWith("~") || // POSIX home: ~/...
-		trimmed.startsWith(".") // POSIX relative: ./... or ../...
-
-	if (looksLikePath) {
-		const preview = trimmed.length > 40 ? `${trimmed.slice(0, 40)}…` : trimmed
-		console.warn(
-			`[Vertex] The 'Google Cloud Credentials' field appears to contain a file path ("${preview}"), ` +
-				"but this field expects the raw JSON contents of a service-account key file. " +
-				"If you have a path to the credentials file, paste it into the 'Google Cloud Key File Path' field instead, " +
-				"or leave both fields empty and use the GOOGLE_APPLICATION_CREDENTIALS environment variable.",
-		)
-		return undefined
-	}
-
-	return safeJsonParse<JWTInput>(trimmed, undefined, "Vertex credentials")
 }
 
 // Gemini documents function declaration schemas as a selected OpenAPI-style
@@ -222,13 +188,15 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		const location = this.options.vertexRegion ?? "not-provided"
 		const apiKey = this.options.geminiApiKey ?? "not-provided"
 
-		this.client = this.options.vertexJsonCredentials
+		const parsedVertexCredentials = parseVertexJsonCredentials(this.options.vertexJsonCredentials)
+
+		this.client = parsedVertexCredentials
 			? new GoogleGenAI({
 					vertexai: true,
 					project,
 					location,
 					googleAuthOptions: {
-						credentials: parseVertexJsonCredentials(this.options.vertexJsonCredentials),
+						credentials: parsedVertexCredentials,
 					},
 				})
 			: this.options.vertexKeyFile

--- a/src/api/providers/utils/vertex-credentials.ts
+++ b/src/api/providers/utils/vertex-credentials.ts
@@ -1,5 +1,6 @@
 import type { JWTInput } from "google-auth-library"
 
+import { looksLikeFilePath } from "@roo-code/types"
 import { safeJsonParse } from "@roo-code/core"
 
 // Detects when the "Google Cloud Credentials" field has received a filesystem
@@ -8,22 +9,22 @@ import { safeJsonParse } from "@roo-code/core"
 // and the sibling "Google Cloud Key File Path" field is where a path belongs.
 // Returns the parsed credentials object when the input looks like JSON, or
 // undefined when the field is empty, path-shaped, or unparseable.
+//
+// The path-shape predicate is shared with the webview UI warning via
+// @roo-code/types/looksLikeFilePath so both surfaces stay in agreement.
 export function parseVertexJsonCredentials(value: string | undefined): JWTInput | undefined {
 	const trimmed = value?.trim()
 	if (!trimmed) {
 		return undefined
 	}
 
-	const looksLikePath =
-		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
-		trimmed.startsWith("/") || // POSIX absolute: /home/...
-		trimmed.startsWith("~") || // POSIX home: ~/...
-		trimmed.startsWith(".") // POSIX relative: ./... or ../...
-
-	if (looksLikePath) {
-		const preview = trimmed.length > 40 ? `${trimmed.slice(0, 40)}…` : trimmed
+	if (looksLikeFilePath(trimmed)) {
+		// Intentionally static — the user's actual value is not interpolated
+		// into the warning so usernames and directory names don't leak into
+		// extension logs. The message still identifies the correct field and
+		// the env var fallback.
 		console.warn(
-			`[Vertex] The 'Google Cloud Credentials' field appears to contain a file path ("${preview}"), ` +
+			"[Vertex] The 'Google Cloud Credentials' field appears to contain a file path, " +
 				"but this field expects the raw JSON contents of a service-account key file. " +
 				"If you have a path to the credentials file, paste it into the 'Google Cloud Key File Path' field instead, " +
 				"or leave both fields empty and use the GOOGLE_APPLICATION_CREDENTIALS environment variable.",

--- a/src/api/providers/utils/vertex-credentials.ts
+++ b/src/api/providers/utils/vertex-credentials.ts
@@ -1,0 +1,35 @@
+import type { JWTInput } from "google-auth-library"
+
+import { safeJsonParse } from "@roo-code/core"
+
+// Detects when the "Google Cloud Credentials" field has received a filesystem
+// path instead of the raw JSON contents of a service-account key file. Users
+// often confuse this with GOOGLE_APPLICATION_CREDENTIALS (which IS a path),
+// and the sibling "Google Cloud Key File Path" field is where a path belongs.
+// Returns the parsed credentials object when the input looks like JSON, or
+// undefined when the field is empty, path-shaped, or unparseable.
+export function parseVertexJsonCredentials(value: string | undefined): JWTInput | undefined {
+	const trimmed = value?.trim()
+	if (!trimmed) {
+		return undefined
+	}
+
+	const looksLikePath =
+		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
+		trimmed.startsWith("/") || // POSIX absolute: /home/...
+		trimmed.startsWith("~") || // POSIX home: ~/...
+		trimmed.startsWith(".") // POSIX relative: ./... or ../...
+
+	if (looksLikePath) {
+		const preview = trimmed.length > 40 ? `${trimmed.slice(0, 40)}…` : trimmed
+		console.warn(
+			`[Vertex] The 'Google Cloud Credentials' field appears to contain a file path ("${preview}"), ` +
+				"but this field expects the raw JSON contents of a service-account key file. " +
+				"If you have a path to the credentials file, paste it into the 'Google Cloud Key File Path' field instead, " +
+				"or leave both fields empty and use the GOOGLE_APPLICATION_CREDENTIALS environment variable.",
+		)
+		return undefined
+	}
+
+	return safeJsonParse<JWTInput>(trimmed, undefined, "Vertex credentials")
+}

--- a/webview-ui/src/components/settings/providers/Vertex.tsx
+++ b/webview-ui/src/components/settings/providers/Vertex.tsx
@@ -92,7 +92,11 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 				<label className="block font-medium mb-1">{t("settings:providers.googleCloudCredentials")}</label>
 			</VSCodeTextField>
 			{credentialsLooksLikePath && (
-				<div data-testid="vertex-credentials-path-warning" className="text-sm text-vscode-errorForeground">
+				<div
+					data-testid="vertex-credentials-path-warning"
+					role="alert"
+					aria-live="polite"
+					className="text-sm text-vscode-errorForeground">
 					<Trans
 						i18nKey="settings:providers.googleCloudCredentialsPathWarning"
 						components={{

--- a/webview-ui/src/components/settings/providers/Vertex.tsx
+++ b/webview-ui/src/components/settings/providers/Vertex.tsx
@@ -3,29 +3,12 @@ import { Trans } from "react-i18next"
 import { Checkbox } from "vscrui"
 import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
-import { type ProviderSettings, VERTEX_REGIONS, VERTEX_1M_CONTEXT_MODEL_IDS } from "@roo-code/types"
+import { type ProviderSettings, VERTEX_REGIONS, VERTEX_1M_CONTEXT_MODEL_IDS, looksLikeFilePath } from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@src/components/ui"
 
 import { inputEventTransform } from "../transforms"
-
-// Detects when the "Google Cloud Credentials" field has received a filesystem
-// path instead of the raw JSON contents of a service-account key file. Mirrors
-// the runtime guard in src/api/providers/gemini.ts so the warning the user
-// sees in the UI matches what the runtime would log.
-function looksLikeFilePath(value: string): boolean {
-	const trimmed = value.trim()
-	if (!trimmed) {
-		return false
-	}
-	return (
-		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
-		trimmed.startsWith("/") || // POSIX absolute: /home/...
-		trimmed.startsWith("~") || // POSIX home: ~/...
-		trimmed.startsWith(".") // POSIX relative: ./... or ../...
-	)
-}
 
 type VertexProps = {
 	apiConfiguration: ProviderSettings
@@ -54,7 +37,7 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 	)
 
 	const credentialsLooksLikePath = useMemo(
-		() => looksLikeFilePath(apiConfiguration?.vertexJsonCredentials ?? ""),
+		() => looksLikeFilePath(apiConfiguration?.vertexJsonCredentials),
 		[apiConfiguration?.vertexJsonCredentials],
 	)
 

--- a/webview-ui/src/components/settings/providers/Vertex.tsx
+++ b/webview-ui/src/components/settings/providers/Vertex.tsx
@@ -94,8 +94,7 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 			{credentialsLooksLikePath && (
 				<div
 					data-testid="vertex-credentials-path-warning"
-					role="alert"
-					aria-live="polite"
+					role="status"
 					className="text-sm text-vscode-errorForeground">
 					<Trans
 						i18nKey="settings:providers.googleCloudCredentialsPathWarning"

--- a/webview-ui/src/components/settings/providers/Vertex.tsx
+++ b/webview-ui/src/components/settings/providers/Vertex.tsx
@@ -1,4 +1,5 @@
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
+import { Trans } from "react-i18next"
 import { Checkbox } from "vscrui"
 import { VSCodeLink, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
@@ -8,6 +9,23 @@ import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@src/components/ui"
 
 import { inputEventTransform } from "../transforms"
+
+// Detects when the "Google Cloud Credentials" field has received a filesystem
+// path instead of the raw JSON contents of a service-account key file. Mirrors
+// the runtime guard in src/api/providers/gemini.ts so the warning the user
+// sees in the UI matches what the runtime would log.
+function looksLikeFilePath(value: string): boolean {
+	const trimmed = value.trim()
+	if (!trimmed) {
+		return false
+	}
+	return (
+		/^[A-Za-z]:[\\/]/.test(trimmed) || // Windows: C:\... or C:/...
+		trimmed.startsWith("/") || // POSIX absolute: /home/...
+		trimmed.startsWith("~") || // POSIX home: ~/...
+		trimmed.startsWith(".") // POSIX relative: ./... or ../...
+	)
+}
 
 type VertexProps = {
 	apiConfiguration: ProviderSettings
@@ -33,6 +51,11 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 				setApiConfigurationField(field, transform(event as E))
 			},
 		[setApiConfigurationField],
+	)
+
+	const credentialsLooksLikePath = useMemo(
+		() => looksLikeFilePath(apiConfiguration?.vertexJsonCredentials ?? ""),
+		[apiConfiguration?.vertexJsonCredentials],
 	)
 
 	return (
@@ -68,6 +91,17 @@ export const Vertex = ({ apiConfiguration, setApiConfigurationField }: VertexPro
 				className="w-full">
 				<label className="block font-medium mb-1">{t("settings:providers.googleCloudCredentials")}</label>
 			</VSCodeTextField>
+			{credentialsLooksLikePath && (
+				<div data-testid="vertex-credentials-path-warning" className="text-sm text-vscode-errorForeground">
+					<Trans
+						i18nKey="settings:providers.googleCloudCredentialsPathWarning"
+						components={{
+							strong: <strong />,
+							code: <code />,
+						}}
+					/>
+				</div>
+			)}
 			<VSCodeTextField
 				value={apiConfiguration?.vertexKeyFile || ""}
 				onInput={handleInputChange("vertexKeyFile")}

--- a/webview-ui/src/components/settings/providers/__tests__/Vertex.spec.tsx
+++ b/webview-ui/src/components/settings/providers/__tests__/Vertex.spec.tsx
@@ -26,6 +26,13 @@ vi.mock("@src/i18n/TranslationContext", () => ({
 	useAppTranslation: () => ({ t: (key: string) => key }),
 }))
 
+// The component uses <Trans> for the path-shape warning so it can interpolate
+// <strong>/<code> elements. The mock just renders the i18n key so the spec
+// can assert on its presence without depending on the English copy.
+vi.mock("react-i18next", () => ({
+	Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+}))
+
 vi.mock("@src/components/ui", () => ({
 	Select: ({ children, value, onValueChange }: any) => (
 		<div data-value={value} data-onvaluechange={onValueChange}>
@@ -123,5 +130,52 @@ describe("Vertex", () => {
 
 		expect(screen.queryByTestId("checkbox-url-context")).not.toBeInTheDocument()
 		expect(screen.queryByTestId("checkbox-grounding-search")).not.toBeInTheDocument()
+	})
+
+	describe("path-shape warning for Google Cloud Credentials field", () => {
+		it("does not render the warning when the credentials field is empty", () => {
+			render(
+				<Vertex
+					apiConfiguration={defaultApiConfiguration}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			expect(screen.queryByTestId("vertex-credentials-path-warning")).not.toBeInTheDocument()
+		})
+
+		it("does not render the warning when the credentials field contains JSON content", () => {
+			render(
+				<Vertex
+					apiConfiguration={{
+						...defaultApiConfiguration,
+						vertexJsonCredentials: '{"type":"service_account","client_email":"x@y.z"}',
+					}}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			expect(screen.queryByTestId("vertex-credentials-path-warning")).not.toBeInTheDocument()
+		})
+
+		it.each([
+			["Windows backslash path", "C:\\Users\\dev\\sa.json"],
+			["Windows forward-slash path", "C:/Users/dev/sa.json"],
+			["POSIX absolute path", "/home/dev/sa.json"],
+			["POSIX home path", "~/sa.json"],
+			["POSIX relative ./", "./sa.json"],
+			["POSIX relative ../", "../sa.json"],
+		])("renders the warning when the credentials field looks like %s", (_label, value) => {
+			render(
+				<Vertex
+					apiConfiguration={{ ...defaultApiConfiguration, vertexJsonCredentials: value }}
+					setApiConfigurationField={mockSetApiConfigurationField}
+				/>,
+			)
+
+			const warning = screen.getByTestId("vertex-credentials-path-warning")
+			expect(warning).toBeInTheDocument()
+			expect(warning.textContent).toContain("settings:providers.googleCloudCredentialsPathWarning")
+		})
 	})
 })

--- a/webview-ui/src/components/settings/providers/__tests__/Vertex.spec.tsx
+++ b/webview-ui/src/components/settings/providers/__tests__/Vertex.spec.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react"
 import { Vertex } from "../Vertex"
 import type { ProviderSettings } from "@roo-code/types"
 import { VERTEX_REGIONS } from "@roo-code/types"
+import enSettings from "@src/i18n/locales/en/settings.json"
 
 vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 	VSCodeTextField: ({ children, value, onInput, type }: any) => (
@@ -27,10 +28,24 @@ vi.mock("@src/i18n/TranslationContext", () => ({
 }))
 
 // The component uses <Trans> for the path-shape warning so it can interpolate
-// <strong>/<code> elements. The mock just renders the i18n key so the spec
-// can assert on its presence without depending on the English copy.
+// <strong>/<code> elements. Resolve the i18n key against the real English
+// resource so the test fails if the warning copy drops the "Google Cloud Key
+// File Path" field name or the "GOOGLE_APPLICATION_CREDENTIALS" env var
+// mention — those are the actual remediation hints users need.
 vi.mock("react-i18next", () => ({
-	Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+	Trans: ({ i18nKey }: { i18nKey: string }) => {
+		// Keys are "<namespace>:<dotted.path>"; the spec only renders the
+		// settings namespace so resolve against the imported English bundle.
+		const [, dotted] = i18nKey.split(":")
+		const resolved = dotted
+			.split(".")
+			.reduce<unknown>(
+				(acc, segment) =>
+					acc && typeof acc === "object" ? (acc as Record<string, unknown>)[segment] : undefined,
+				enSettings,
+			)
+		return <>{typeof resolved === "string" ? resolved : i18nKey}</>
+	},
 }))
 
 vi.mock("@src/components/ui", () => ({
@@ -175,7 +190,11 @@ describe("Vertex", () => {
 
 			const warning = screen.getByTestId("vertex-credentials-path-warning")
 			expect(warning).toBeInTheDocument()
-			expect(warning.textContent).toContain("settings:providers.googleCloudCredentialsPathWarning")
+			// The warning resolves through the real English bundle, so a
+			// regression that dropped either of these remediation strings
+			// from the translation would be caught here.
+			expect(warning).toHaveTextContent(/Google Cloud Key File Path/)
+			expect(warning).toHaveTextContent(/GOOGLE_APPLICATION_CREDENTIALS/)
 		})
 	})
 })

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. O crear un compte de servei amb credencials."
 		},
 		"googleCloudCredentials": "Credencials de Google Cloud",
+		"googleCloudCredentialsPathWarning": "Aquest camp espera el contingut JSON d'un fitxer de clau de compte de servei, no una ruta. Si tens una ruta, enganxa-la al camp <strong>Ruta del fitxer de clau de Google Cloud</strong> a continuació, o buida aquest camp i utilitza la variable d'entorn <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Ruta del fitxer de clau de Google Cloud",
 		"googleCloudProjectId": "ID del projecte de Google Cloud",
 		"googleCloudRegion": "Regió de Google Cloud",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Oder ein Servicekonto mit Anmeldeinformationen erstellen."
 		},
 		"googleCloudCredentials": "Google Cloud Anmeldedaten",
+		"googleCloudCredentialsPathWarning": "Dieses Feld erwartet den JSON-Inhalt einer Dienstkonto-Schlüsseldatei, keinen Pfad. Wenn Sie einen Pfad haben, fügen Sie ihn unten in das Feld <strong>Google Cloud Schlüsseldateipfad</strong> ein, oder leeren Sie dieses Feld und verwenden Sie die Umgebungsvariable <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Google Cloud Schlüsseldateipfad",
 		"googleCloudProjectId": "Google Cloud Projekt-ID",
 		"googleCloudRegion": "Google Cloud Region",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -515,6 +515,7 @@
 			"step3": "3. Or create a service account with credentials."
 		},
 		"googleCloudCredentials": "Google Cloud Credentials",
+		"googleCloudCredentialsPathWarning": "This field expects the JSON contents of a service-account key file, not a path. If you have a path, paste it into the <strong>Google Cloud Key File Path</strong> field below, or clear this field and use the <code>GOOGLE_APPLICATION_CREDENTIALS</code> environment variable.",
 		"googleCloudKeyFile": "Google Cloud Key File Path",
 		"googleCloudProjectId": "Google Cloud Project ID",
 		"googleCloudRegion": "Google Cloud Region",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. O crear una cuenta de servicio con credenciales."
 		},
 		"googleCloudCredentials": "Credenciales de Google Cloud",
+		"googleCloudCredentialsPathWarning": "Este campo espera el contenido JSON de un archivo de clave de cuenta de servicio, no una ruta. Si tienes una ruta, pégala en el campo <strong>Ruta del archivo de clave de Google Cloud</strong> a continuación, o borra este campo y utiliza la variable de entorno <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Ruta del archivo de clave de Google Cloud",
 		"googleCloudProjectId": "ID del proyecto de Google Cloud",
 		"googleCloudRegion": "Región de Google Cloud",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Ou créer un compte de service avec des identifiants."
 		},
 		"googleCloudCredentials": "Identifiants Google Cloud",
+		"googleCloudCredentialsPathWarning": "Ce champ attend le contenu JSON d'un fichier de clé de compte de service, pas un chemin. Si vous disposez d'un chemin, collez-le dans le champ <strong>Chemin du fichier de clé Google Cloud</strong> ci-dessous, ou videz ce champ et utilisez la variable d'environnement <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Chemin du fichier de clé Google Cloud",
 		"googleCloudProjectId": "ID du projet Google Cloud",
 		"googleCloudRegion": "Région Google Cloud",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. या क्रेडेंशियल्स के साथ एक सर्विस अकाउंट बनाएं।"
 		},
 		"googleCloudCredentials": "Google Cloud क्रेडेंशियल्स",
+		"googleCloudCredentialsPathWarning": "इस फ़ील्ड में सर्विस-अकाउंट कुंजी फ़ाइल की JSON सामग्री अपेक्षित है, पथ नहीं। यदि आपके पास पथ है, तो उसे नीचे दिए गए <strong>Google Cloud कुंजी फ़ाइल पथ</strong> फ़ील्ड में पेस्ट करें, या इस फ़ील्ड को खाली करें और <code>GOOGLE_APPLICATION_CREDENTIALS</code> पर्यावरण चर का उपयोग करें।",
 		"googleCloudKeyFile": "Google Cloud कुंजी फ़ाइल पथ",
 		"googleCloudProjectId": "Google Cloud प्रोजेक्ट ID",
 		"googleCloudRegion": "Google Cloud क्षेत्र",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Atau buat service account dengan credentials."
 		},
 		"googleCloudCredentials": "Google Cloud Credentials",
+		"googleCloudCredentialsPathWarning": "Bidang ini mengharapkan konten JSON dari file kunci akun layanan, bukan path. Jika Anda memiliki path, tempelkan ke bidang <strong>Path File Key Google Cloud</strong> di bawah, atau kosongkan bidang ini dan gunakan variabel lingkungan <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Path File Key Google Cloud",
 		"googleCloudProjectId": "Google Cloud Project ID",
 		"googleCloudRegion": "Google Cloud Region",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Oppure creare un account di servizio con credenziali."
 		},
 		"googleCloudCredentials": "Credenziali Google Cloud",
+		"googleCloudCredentialsPathWarning": "Questo campo si aspetta il contenuto JSON di un file di chiave di account di servizio, non un percorso. Se hai un percorso, incollalo nel campo <strong>Percorso file chiave Google Cloud</strong> qui sotto, oppure svuota questo campo e usa la variabile d'ambiente <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Percorso file chiave Google Cloud",
 		"googleCloudProjectId": "ID progetto Google Cloud",
 		"googleCloudRegion": "Regione Google Cloud",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. または、認証情報付きのサービスアカウントを作成します。"
 		},
 		"googleCloudCredentials": "Google Cloud認証情報",
+		"googleCloudCredentialsPathWarning": "このフィールドは、パスではなく、サービスアカウントキーファイルのJSON内容を期待します。パスをお持ちの場合は、下の<strong>Google Cloudキーファイルパス</strong>フィールドに貼り付けるか、このフィールドをクリアして<code>GOOGLE_APPLICATION_CREDENTIALS</code>環境変数を使用してください。",
 		"googleCloudKeyFile": "Google Cloudキーファイルパス",
 		"googleCloudProjectId": "Google Cloudプロジェクトid",
 		"googleCloudRegion": "Google Cloudリージョン",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. 또는 자격 증명이 있는 서비스 계정을 만드세요."
 		},
 		"googleCloudCredentials": "Google Cloud 자격 증명",
+		"googleCloudCredentialsPathWarning": "이 필드는 경로가 아닌 서비스 계정 키 파일의 JSON 내용을 기대합니다. 경로가 있다면 아래의 <strong>Google Cloud 키 파일 경로</strong> 필드에 붙여넣거나, 이 필드를 비우고 <code>GOOGLE_APPLICATION_CREDENTIALS</code> 환경 변수를 사용하세요.",
 		"googleCloudKeyFile": "Google Cloud 키 파일 경로",
 		"googleCloudProjectId": "Google Cloud 프로젝트 ID",
 		"googleCloudRegion": "Google Cloud 리전",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Of maak een serviceaccount met referenties."
 		},
 		"googleCloudCredentials": "Google Cloud-referenties",
+		"googleCloudCredentialsPathWarning": "Dit veld verwacht de JSON-inhoud van een serviceaccount-sleutelbestand, geen pad. Als je een pad hebt, plak het dan in het veld <strong>Google Cloud-sleutelbestandspad</strong> hieronder, of leeg dit veld en gebruik de omgevingsvariabele <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Google Cloud-sleutelbestandspad",
 		"googleCloudProjectId": "Google Cloud-project-ID",
 		"googleCloudRegion": "Google Cloud-regio",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Lub utworzyć konto usługi z poświadczeniami."
 		},
 		"googleCloudCredentials": "Poświadczenia Google Cloud",
+		"googleCloudCredentialsPathWarning": "To pole oczekuje zawartości JSON pliku klucza konta usługi, a nie ścieżki. Jeśli masz ścieżkę, wklej ją do pola <strong>Ścieżka pliku klucza Google Cloud</strong> poniżej lub wyczyść to pole i użyj zmiennej środowiskowej <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Ścieżka pliku klucza Google Cloud",
 		"googleCloudProjectId": "ID projektu Google Cloud",
 		"googleCloudRegion": "Region Google Cloud",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Ou criar uma conta de serviço com credenciais."
 		},
 		"googleCloudCredentials": "Credenciais Google Cloud",
+		"googleCloudCredentialsPathWarning": "Este campo espera o conteúdo JSON de um arquivo de chave de conta de serviço, não um caminho. Se você tiver um caminho, cole-o no campo <strong>Caminho do Arquivo de Chave Google Cloud</strong> abaixo, ou limpe este campo e use a variável de ambiente <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Caminho do Arquivo de Chave Google Cloud",
 		"googleCloudProjectId": "ID do Projeto Google Cloud",
 		"googleCloudRegion": "Região Google Cloud",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Или создайте сервисный аккаунт с ключом."
 		},
 		"googleCloudCredentials": "Учётные данные Google Cloud",
+		"googleCloudCredentialsPathWarning": "Это поле ожидает JSON-содержимое файла ключа сервисного аккаунта, а не путь. Если у вас есть путь, вставьте его в поле <strong>Путь к ключу Google Cloud</strong> ниже, либо очистите это поле и используйте переменную окружения <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Путь к ключу Google Cloud",
 		"googleCloudProjectId": "ID проекта Google Cloud",
 		"googleCloudRegion": "Регион Google Cloud",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Veya kimlik bilgileriyle bir hizmet hesabı oluşturun."
 		},
 		"googleCloudCredentials": "Google Cloud Kimlik Bilgileri",
+		"googleCloudCredentialsPathWarning": "Bu alan, bir yol değil, bir hizmet hesabı anahtar dosyasının JSON içeriğini bekler. Bir yolunuz varsa, aşağıdaki <strong>Google Cloud Anahtar Dosyası Yolu</strong> alanına yapıştırın veya bu alanı temizleyin ve <code>GOOGLE_APPLICATION_CREDENTIALS</code> ortam değişkenini kullanın.",
 		"googleCloudKeyFile": "Google Cloud Anahtar Dosyası Yolu",
 		"googleCloudProjectId": "Google Cloud Proje Kimliği",
 		"googleCloudRegion": "Google Cloud Bölgesi",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. Hoặc tạo tài khoản dịch vụ với thông tin xác thực."
 		},
 		"googleCloudCredentials": "Thông tin xác thực Google Cloud",
+		"googleCloudCredentialsPathWarning": "Trường này mong đợi nội dung JSON của tệp khóa tài khoản dịch vụ, không phải đường dẫn. Nếu bạn có đường dẫn, hãy dán vào trường <strong>Đường dẫn tệp khóa Google Cloud</strong> bên dưới, hoặc xóa trường này và sử dụng biến môi trường <code>GOOGLE_APPLICATION_CREDENTIALS</code>.",
 		"googleCloudKeyFile": "Đường dẫn tệp khóa Google Cloud",
 		"googleCloudProjectId": "ID dự án Google Cloud",
 		"googleCloudRegion": "Vùng Google Cloud",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -452,6 +452,7 @@
 			"step3": "3. 创建服务账号获取凭证"
 		},
 		"googleCloudCredentials": "Google Cloud 凭证",
+		"googleCloudCredentialsPathWarning": "此字段需要服务账号密钥文件的 JSON 内容，而不是路径。如果您有路径，请将其粘贴到下方的<strong>Google Cloud 密钥文件路径</strong>字段中，或清除此字段并使用 <code>GOOGLE_APPLICATION_CREDENTIALS</code> 环境变量。",
 		"googleCloudKeyFile": "Google Cloud 密钥文件路径",
 		"googleCloudProjectId": "Google Cloud 项目 ID",
 		"googleCloudRegion": "Google Cloud 区域",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -462,6 +462,7 @@
 			"step3": "3. 或建立具有憑證的服務帳戶。"
 		},
 		"googleCloudCredentials": "Google Cloud 憑證",
+		"googleCloudCredentialsPathWarning": "此欄位需要服務帳號金鑰檔案的 JSON 內容，而不是路徑。如果您有路徑，請將其貼到下方的<strong>Google Cloud 金鑰檔案路徑</strong>欄位，或清除此欄位並使用 <code>GOOGLE_APPLICATION_CREDENTIALS</code> 環境變數。",
 		"googleCloudKeyFile": "Google Cloud 金鑰檔案路徑",
 		"googleCloudProjectId": "Google Cloud 專案 ID",
 		"googleCloudRegion": "Google Cloud 區域",


### PR DESCRIPTION
## Summary

Users reported recurring `Error parsing JSON: SyntaxError: Unexpected token 'C', "C:\Users\i"... is not valid JSON` in the VS Code dev console — fired once per Task creation. The root cause is a UX trap in the Vertex provider settings: the "Google Cloud Credentials" field expects raw JSON content (the `{ "type": "service_account", ... }` blob), but Google's own ecosystem uses `GOOGLE_APPLICATION_CREDENTIALS` for paths, so "credentials = path to credentials file" is a natural mental model that the field naming does not disambiguate. The sibling "Google Cloud Key File Path" field is where a path belongs.

For affected users, auth still works (their `GOOGLE_APPLICATION_CREDENTIALS` env var picks up the slack and `safeJsonParse` has an internal try/catch), so the only user-visible symptom is the recurring generic console error.

## Changes

Three pieces, all behind a small shape-check on the user-supplied string:

- **`src/api/providers/gemini.ts` + `src/api/providers/anthropic-vertex.ts`**: shape-check the field before parsing. If it looks like a path (Windows `C:\...` / `C:/...`, POSIX absolute `/...`, `~/...`, or `./` / `../`), log a single specific console warning that names the correct field and the `GOOGLE_APPLICATION_CREDENTIALS` env var, and skip the `JSON.parse` so the generic `Error parsing JSON` log never fires for the path case. The shared helper `parseVertexJsonCredentials` is exported from `gemini.ts` and reused from `anthropic-vertex.ts` so the Gemini-on-Vertex and Claude-on-Vertex paths behave identically.
- **`packages/core/src/message-utils/safeJsonParse.ts`**: add an optional `context?: string` parameter so log messages can identify their source (`Error parsing JSON (Vertex credentials):` instead of an anonymous `Error parsing JSON:`). Backward-compatible — existing call sites are unchanged.
- **`webview-ui/src/components/settings/providers/Vertex.tsx`**: inline warning under the credentials field that fires while the input looks like a path, naming the correct field to use instead. New i18n key `settings:providers.googleCloudCredentialsPathWarning` propagated to all 18 locales.

Auth behavior is unchanged for users who configure the fields correctly or use the env var. The only user-visible change is the new specific warning replacing the previous generic spam.

## Known properties

- The console warning still fires once per Vertex handler construction (i.e. once per Task creation) for users with a path in the JSON field — same frequency as the original generic spam, but the message is now specific and actionable.
- The 17 non-English i18n strings are first-draft translations and welcome community refinement in follow-ups.

## Test plan

- [x] `packages/core`: `npx vitest run message-utils` — 39/39 pass (new `safeJsonParse.spec.ts` covers context-arg and backward-compat paths)
- [x] `src`: `npx vitest run api/providers/__tests__/vertex-credentials.spec.ts api/providers/__tests__/gemini.spec.ts api/providers/__tests__/vertex.spec.ts api/providers/__tests__/anthropic-vertex.spec.ts api/providers/__tests__/gemini-handler.spec.ts` — 95/95 pass (new spec asserts `GoogleGenAI` / `GoogleAuth` receive `credentials: undefined` for path-shaped input, the warning is emitted with the actionable strings, and JSON content still parses through)
- [x] `webview-ui`: `npx vitest run src/components/settings/providers` — 45/45 pass (new cases assert the warning renders for path-shaped input and is absent for empty / JSON input)
- [x] `npx tsc --noEmit` in `src/`, `packages/core/`, `webview-ui/` — all clean
- [x] `pnpm lint` (full monorepo) — clean
- [x] Changeset added (`zoo-code` patch)

Surfaced during testing of #248's diagnostic build by an end user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects when the Google Cloud Credentials field looks like a file path and displays an inline, localized warning directing users to the key-file field or GOOGLE_APPLICATION_CREDENTIALS.

* **Improvements**
  * JSON parsing logs now include optional contextual labels; path-shaped credential inputs emit a single, targeted warning and avoid parsing.

* **Tests**
  * Added unit and UI tests for JSON parsing, path-detection, and the credential warning.

* **Localization**
  * Added translated warning strings for many locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->