### PR TITLE
[1/4] Add Git context collector for commit messages

### DIFF
--- a/src/services/git-context/GitContextCollector.ts
+++ b/src/services/git-context/GitContextCollector.ts
@@ -1,0 +1,524 @@
+import * as path from "path"
+import { promises as fs } from "fs"
+import { spawn } from "child_process"
+import {
+	GitContextCollection,
+	GitContextCollectorOptions,
+	GitChange,
+	GitDiffContextOptions,
+	GitContextOptions,
+	GitRecentCommitContextOptions,
+	GitContextResult,
+	GitStatus,
+} from "./types"
+
+export type {
+	GitChange,
+	GitContextCollection,
+	GitContextCollectorOptions,
+	GitDiffContextOptions,
+	GitContextOptions,
+	GitRecentCommitContextOptions,
+	GitContextResult,
+} from "./types"
+
+const DEFAULT_RECENT_COMMIT_COUNT = 5
+const DEFAULT_RECENT_COMMIT_DIFF_COUNT = 1
+
+export class GitContextCollector {
+	constructor(private workspaceRoot: string) {}
+
+	public async gatherChanges(options: GitContextCollectorOptions): Promise<GitChange[]> {
+		const statusOutput = await this.getStatus(options)
+		if (!statusOutput) {
+			return []
+		}
+
+		return options.staged ? this.parseNameStatus(statusOutput, true) : this.parsePorcelainStatus(statusOutput)
+	}
+
+	public async collect(options: GitContextCollectorOptions, specificFiles?: string[]): Promise<GitContextCollection> {
+		const changes = await this.gatherChanges(options)
+		const result = await this.collectContext(changes, options, specificFiles)
+
+		return { ...result, changes }
+	}
+
+	private async runGit(args: string[]): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const child = spawn("git", args, {
+				cwd: this.workspaceRoot,
+				stdio: ["ignore", "pipe", "pipe"],
+			})
+			let stdout = ""
+			let stderr = ""
+
+			child.stdout.setEncoding("utf8")
+			child.stderr.setEncoding("utf8")
+			child.stdout.on("data", (chunk) => (stdout += chunk))
+			child.stderr.on("data", (chunk) => (stderr += chunk))
+			child.on("error", reject)
+			child.on("close", (code) => {
+				if (code === 0) {
+					resolve(stdout)
+					return
+				}
+
+				reject(new Error(`Git command failed (${args.join(" ")}): ${stderr.trim() || `exit code ${code}`}`))
+			})
+		})
+	}
+
+	private async getDiffForChanges(changes: GitChange[], options: GitContextCollectorOptions): Promise<string> {
+		if (changes.length === 0) {
+			return ""
+		}
+
+		const binaryChanges = await this.findBinaryChanges(changes, options.staged)
+		const diffableChanges = changes.filter((change) => change.status !== "?" && !binaryChanges.has(change.filePath))
+		const untrackedFiles = changes.filter((change) => change.status === "?")
+		const parts: string[] = []
+
+		if (diffableChanges.length > 0) {
+			const diffArgs = this.buildDiffArgs(options.staged, diffableChanges, [], options.diff)
+			const diff = await this.runGit(diffArgs)
+			if (diff.trim()) {
+				parts.push(diff)
+			}
+		}
+
+		if (untrackedFiles.length > 0) {
+			parts.push(await this.getUntrackedFileDiffs(untrackedFiles))
+		}
+
+		if (binaryChanges.size > 0) {
+			parts.push(
+				changes
+					.filter((change) => binaryChanges.has(change.filePath))
+					.map(
+						(change) =>
+							`Binary file ${this.getReadableStatus(change.status).toLowerCase()}: ${this.getRelativePath(change.filePath)}`,
+					)
+					.join("\n"),
+			)
+		}
+
+		options.onProgress?.(100)
+		return parts.join("\n")
+	}
+
+	private async getDiffStats(changes: GitChange[], options: GitContextCollectorOptions): Promise<string> {
+		const trackedChanges = changes.filter((change) => change.status !== "?")
+		const untrackedChanges = changes.filter((change) => change.status === "?")
+		const parts: string[] = []
+
+		if (trackedChanges.length > 0) {
+			const args = this.buildDiffArgs(options.staged, trackedChanges, ["--stat"])
+			const stats = await this.runGit(args)
+			if (stats.trim()) {
+				parts.push(stats.trim())
+			}
+		}
+
+		for (const change of untrackedChanges) {
+			parts.push(await this.getUntrackedFileStat(change))
+		}
+
+		return parts.join("\n")
+	}
+
+	private async getUntrackedFileStat(change: GitChange): Promise<string> {
+		const relativePath = this.getRelativePath(change.filePath)
+		if (await this.isProbablyBinaryFile(change.filePath)) {
+			return `${relativePath} | Bin 0 -> ${await this.getFileSize(change.filePath)} bytes`
+		}
+
+		const content = await fs.readFile(change.filePath, "utf8")
+		const normalizedContent = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+		const lineCount = normalizedContent.length === 0 ? 0 : normalizedContent.split("\n").filter(Boolean).length
+		return `${relativePath} | ${lineCount} ${"+".repeat(Math.min(lineCount, 60))}`
+	}
+
+	private async getFileSize(filePath: string): Promise<number> {
+		return (await fs.stat(filePath)).size
+	}
+
+	private async findBinaryChanges(changes: GitChange[], staged: boolean): Promise<Set<string>> {
+		const binaryFiles = new Set<string>()
+
+		for (const change of changes) {
+			if (change.status === "?") {
+				continue
+			}
+
+			const args = this.buildNumstatArgs(staged, change)
+			const output = await this.runGit(args)
+			if (output.includes("-\t-\t")) {
+				binaryFiles.add(change.filePath)
+			}
+		}
+
+		return binaryFiles
+	}
+
+	private buildNumstatArgs(staged: boolean, change: GitChange): string[] {
+		const args = staged ? ["diff", "--cached", "--numstat"] : ["diff", "--numstat"]
+		return [...args, "--", this.getRelativePath(change.filePath)]
+	}
+
+	private async isProbablyBinaryFile(filePath: string): Promise<boolean> {
+		const fileHandle = await fs.open(filePath, "r")
+		try {
+			const buffer = Buffer.alloc(8000)
+			const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0)
+			return buffer.subarray(0, bytesRead).includes(0)
+		} finally {
+			await fileHandle.close()
+		}
+	}
+
+	private async getUntrackedFileDiffs(changes: GitChange[]): Promise<string> {
+		const diffs: string[] = []
+
+		for (const change of changes) {
+			if (await this.isProbablyBinaryFile(change.filePath)) {
+				diffs.push(`Binary file added: ${this.getRelativePath(change.filePath)}`)
+				continue
+			}
+
+			diffs.push(await this.createNewFileDiff(change.filePath))
+		}
+
+		return diffs.join("\n")
+	}
+
+	private async createNewFileDiff(filePath: string): Promise<string> {
+		const relativePath = this.getRelativePath(filePath)
+		const content = await fs.readFile(filePath, "utf8")
+		const normalizedContent = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+
+		if (normalizedContent.length === 0) {
+			return [
+				`diff --git a/${relativePath} b/${relativePath}`,
+				"new file mode 100644",
+				"--- /dev/null",
+				`+++ b/${relativePath}`,
+			].join("\n")
+		}
+
+		const hasTrailingNewline = normalizedContent.endsWith("\n")
+		const lines = (hasTrailingNewline ? normalizedContent.slice(0, -1) : normalizedContent).split("\n")
+		const diffLines = [
+			`diff --git a/${relativePath} b/${relativePath}`,
+			"new file mode 100644",
+			"--- /dev/null",
+			`+++ b/${relativePath}`,
+			`@@ -0,0 +1,${lines.length} @@`,
+			...lines.map((line) => `+${line}`),
+		]
+
+		if (!hasTrailingNewline) {
+			diffLines.push("\\ No newline at end of file")
+		}
+
+		return diffLines.join("\n")
+	}
+
+	private async getStatus(options: GitContextOptions): Promise<string> {
+		return options.staged
+			? this.runGit(["diff", "--name-status", "--cached", "-z"])
+			: this.runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"])
+	}
+
+	private async getCurrentBranch(): Promise<string> {
+		return this.runGit(["branch", "--show-current"])
+	}
+
+	private async getRecentCommits(options: GitRecentCommitContextOptions): Promise<string> {
+		const count = this.clampNumber(options.count, 1, 20, DEFAULT_RECENT_COMMIT_COUNT)
+		const args = options.includeBodies
+			? ["log", `-${count}`, "--format=commit %h%nSubject: %s%nBody:%n%b"]
+			: ["log", "--oneline", `-${count}`]
+
+		if (options.includeStats) {
+			args.push("--stat")
+		}
+
+		const parts = [await this.runGit(args)]
+
+		if (options.includeDiffs) {
+			const diffCount = this.clampNumber(options.diffCount, 1, 5, DEFAULT_RECENT_COMMIT_DIFF_COUNT)
+			const hashes = (await this.runGit(["log", `-${diffCount}`, "--format=%H"]))
+				.split("\n")
+				.map((hash) => hash.trim())
+				.filter(Boolean)
+
+			for (const hash of hashes) {
+				parts.push(await this.runGit(["show", "--format=commit %h%nSubject: %s%n%b", "--patch", hash]))
+			}
+		}
+
+		return parts.join("\n")
+	}
+
+	public async collectContext(
+		changes: GitChange[],
+		options: GitContextCollectorOptions,
+		specificFiles?: string[],
+	): Promise<GitContextResult> {
+		const { includeBranch = false, recentCommits } = options
+		let context = "## Git Context\n\n"
+		const warnings: string[] = []
+
+		const targetChanges = this.filterChanges(changes, specificFiles)
+		const fileInfo = specificFiles ? ` (${specificFiles.length} selected files)` : ""
+		const allStaged = targetChanges.every((change) => change.staged)
+		const allUnstaged = targetChanges.every((change) => !change.staged)
+		const changeDescriptor = allStaged ? "Staged" : allUnstaged ? "Unstaged" : "Selected"
+
+		if (options.diff?.includeStats) {
+			const stats = await this.getDiffStats(targetChanges, options)
+			if (stats.trim()) {
+				context += `### Diff Stats${fileInfo}\n\`\`\`\n${stats.trim()}\n\`\`\`\n\n`
+			}
+		}
+
+		const diff = await this.getDiffForChanges(targetChanges, options)
+		context += `### Full Diff of ${changeDescriptor} Changes${fileInfo}\n\`\`\`diff\n${diff}\n\`\`\`\n\n`
+
+		if (targetChanges.length > 0) {
+			const summaryLines = targetChanges.map((change) => {
+				const relativePath = this.getRelativePath(change.filePath)
+				const scope = change.staged ? "staged" : "unstaged"
+				const status = this.getReadableStatus(change.status)
+
+				if (change.oldFilePath) {
+					const oldRelativePath = this.getRelativePath(change.oldFilePath)
+					return `${status} (${scope}): ${oldRelativePath} -> ${relativePath}`
+				}
+
+				return `${status} (${scope}): ${relativePath}`
+			})
+
+			context += "### Change Summary\n```\n" + summaryLines.join("\n") + "\n```\n\n"
+		} else {
+			context += "### Change Summary\n```\n(No changes matched selection)\n```\n\n"
+		}
+
+		if (includeBranch || recentCommits?.include) {
+			context += "### Repository Context\n\n"
+		}
+
+		if (includeBranch) {
+			try {
+				const currentBranch = await this.getCurrentBranch()
+				if (currentBranch) {
+					context += "**Current branch:** `" + currentBranch.trim() + "`\n\n"
+				}
+			} catch (error) {
+				warnings.push(`Current branch unavailable: ${this.getErrorMessage(error)}`)
+			}
+		}
+
+		if (recentCommits?.include) {
+			try {
+				const recentCommitContext = await this.getRecentCommits(recentCommits)
+				if (recentCommitContext) {
+					context += "**Recent commits:**\n```\n" + recentCommitContext + "\n```\n"
+				}
+			} catch (error) {
+				warnings.push(`Recent commits unavailable: ${this.getErrorMessage(error)}`)
+			}
+		}
+
+		if (warnings.length > 0) {
+			context += "\n### Git Context Warnings\n```\n" + warnings.join("\n") + "\n```\n"
+		}
+
+		return { context, warnings }
+	}
+
+	public async getContext(
+		changes: GitChange[],
+		options: GitContextCollectorOptions,
+		specificFiles?: string[],
+	): Promise<string> {
+		return (await this.collectContext(changes, options, specificFiles)).context
+	}
+
+	private getErrorMessage(error: unknown): string {
+		return error instanceof Error ? error.message : String(error)
+	}
+
+	private parseNameStatus(output: string, staged: boolean): GitChange[] {
+		const fields = this.splitNullDelimited(output)
+		const changes: GitChange[] = []
+
+		for (let index = 0; index < fields.length; index++) {
+			const statusCode = fields[index]
+			const status = this.getChangeStatusFromCode(statusCode)
+
+			if (status === "R" || status === "C") {
+				const oldFilePath = fields[++index]
+				const filePath = fields[++index]
+				if (oldFilePath && filePath) {
+					changes.push({
+						filePath: path.join(this.workspaceRoot, filePath),
+						oldFilePath: path.join(this.workspaceRoot, oldFilePath),
+						status,
+						staged,
+					})
+				}
+				continue
+			}
+
+			const filePath = fields[++index]
+			if (filePath) {
+				changes.push({
+					filePath: path.join(this.workspaceRoot, filePath),
+					status,
+					staged,
+				})
+			}
+		}
+
+		return changes
+	}
+
+	private parsePorcelainStatus(output: string): GitChange[] {
+		const fields = this.splitNullDelimited(output)
+		const changes: GitChange[] = []
+
+		for (let index = 0; index < fields.length; index++) {
+			const entry = fields[index]
+			if (entry.length < 4) {
+				continue
+			}
+
+			const indexStatus = entry.charAt(0)
+			const workingStatus = entry.charAt(1)
+			const statusCode = indexStatus === "?" && workingStatus === "?" ? "?" : workingStatus.trim() || indexStatus
+			const status = this.getChangeStatusFromCode(statusCode)
+			const filePath = entry.substring(3)
+
+			if (status === "R" || status === "C") {
+				const oldFilePath = fields[++index]
+				changes.push({
+					filePath: path.join(this.workspaceRoot, filePath),
+					oldFilePath: oldFilePath ? path.join(this.workspaceRoot, oldFilePath) : undefined,
+					status,
+					staged: false,
+				})
+				continue
+			}
+
+			changes.push({
+				filePath: path.join(this.workspaceRoot, filePath),
+				status,
+				staged: false,
+			})
+		}
+
+		return changes
+	}
+
+	private splitNullDelimited(output: string): string[] {
+		return output.split("\0").filter(Boolean)
+	}
+
+	private filterChanges(changes: GitChange[], specificFiles?: string[]): GitChange[] {
+		if (!specificFiles || specificFiles.length === 0) {
+			return changes
+		}
+
+		return changes.filter((change) => {
+			const absolutePath = change.filePath
+			const relativePath = this.getRelativePath(absolutePath)
+			return specificFiles.some((file) => {
+				const normalizedFile = path.normalize(file).replace(/\\/g, "/")
+				return (
+					file === absolutePath ||
+					file === relativePath ||
+					absolutePath.endsWith(file) ||
+					relativePath === normalizedFile
+				)
+			})
+		})
+	}
+
+	private buildDiffArgs(
+		staged: boolean,
+		changes: GitChange[],
+		extraArgs: string[] = [],
+		diffOptions?: GitDiffContextOptions,
+	): string[] {
+		const args = staged ? ["diff", "--cached"] : ["diff"]
+		const contextLines =
+			!extraArgs.includes("--stat") && diffOptions?.contextLines !== undefined
+				? [`--unified=${this.clampNumber(diffOptions.contextLines, 0, 20, 3)}`]
+				: []
+		const paths = Array.from(
+			new Set(
+				changes.flatMap((change) =>
+					[change.filePath, change.oldFilePath]
+						.filter((filePath): filePath is string => Boolean(filePath))
+						.map((filePath) => this.getRelativePath(filePath)),
+				),
+			),
+		)
+
+		return paths.length > 0 ? [...args, ...extraArgs, ...contextLines, "--", ...paths] : [...args, ...extraArgs]
+	}
+
+	private clampNumber(value: number | undefined, min: number, max: number, fallback: number): number {
+		if (typeof value !== "number" || !Number.isFinite(value)) {
+			return fallback
+		}
+
+		return Math.min(Math.max(Math.trunc(value), min), max)
+	}
+
+	private getRelativePath(filePath: string): string {
+		return path.relative(this.workspaceRoot, filePath).replace(/\\/g, "/")
+	}
+
+	private getChangeStatusFromCode(code: string): GitStatus {
+		const status = code.charAt(0)
+		switch (status) {
+			case "M":
+			case "A":
+			case "D":
+			case "R":
+			case "C":
+			case "U":
+			case "?":
+				return status as GitStatus
+			default:
+				return "Unknown"
+		}
+	}
+
+	private getReadableStatus(status: GitStatus): string {
+		switch (status) {
+			case "M":
+				return "Modified"
+			case "A":
+				return "Added"
+			case "D":
+				return "Deleted"
+			case "R":
+				return "Renamed"
+			case "C":
+				return "Copied"
+			case "U":
+				return "Updated"
+			case "?":
+				return "Untracked"
+			case "Unknown":
+			default:
+				return "Unknown"
+		}
+	}
+
+	public dispose(): void {}
+}

--- a/src/services/git-context/GitContextCollector.ts
+++ b/src/services/git-context/GitContextCollector.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import { promises as fs } from "fs"
 import { spawn } from "child_process"
-import {
+import type {
 	GitContextCollection,
 	GitContextCollectorOptions,
 	GitChange,
@@ -12,22 +12,15 @@ import {
 	GitStatus,
 } from "./types"
 
-export type {
-	GitChange,
-	GitContextCollection,
-	GitContextCollectorOptions,
-	GitDiffContextOptions,
-	GitContextOptions,
-	GitRecentCommitContextOptions,
-	GitContextResult,
-} from "./types"
-
 const DEFAULT_RECENT_COMMIT_COUNT = 5
 const DEFAULT_RECENT_COMMIT_DIFF_COUNT = 1
 
+/** Collects Git status, diff, and repository metadata for commit-message generation. */
 export class GitContextCollector {
+	/** Creates a collector scoped to one workspace repository root. */
 	constructor(private workspaceRoot: string) {}
 
+	/** Returns changed files from staged or unstaged Git state. */
 	public async gatherChanges(options: GitContextCollectorOptions): Promise<GitChange[]> {
 		const statusOutput = await this.getStatus(options)
 		if (!statusOutput) {
@@ -37,6 +30,7 @@ export class GitContextCollector {
 		return options.staged ? this.parseNameStatus(statusOutput, true) : this.parsePorcelainStatus(statusOutput)
 	}
 
+	/** Gathers changes and formats their Git context in one call. */
 	public async collect(options: GitContextCollectorOptions, specificFiles?: string[]): Promise<GitContextCollection> {
 		const changes = await this.gatherChanges(options)
 		const result = await this.collectContext(changes, options, specificFiles)
@@ -44,6 +38,7 @@ export class GitContextCollector {
 		return { ...result, changes }
 	}
 
+	/** Runs a Git subprocess in the workspace root and returns stdout. */
 	private async runGit(args: string[]): Promise<string> {
 		return new Promise((resolve, reject) => {
 			const child = spawn("git", args, {
@@ -69,12 +64,16 @@ export class GitContextCollector {
 		})
 	}
 
+	/** Builds full diff text for tracked, untracked, and binary changes. */
 	private async getDiffForChanges(changes: GitChange[], options: GitContextCollectorOptions): Promise<string> {
+		options.onProgress?.(0)
 		if (changes.length === 0) {
+			options.onProgress?.(100)
 			return ""
 		}
 
 		const binaryChanges = await this.findBinaryChanges(changes, options.staged)
+		options.onProgress?.(25)
 		const diffableChanges = changes.filter((change) => change.status !== "?" && !binaryChanges.has(change.filePath))
 		const untrackedFiles = changes.filter((change) => change.status === "?")
 		const parts: string[] = []
@@ -86,10 +85,12 @@ export class GitContextCollector {
 				parts.push(diff)
 			}
 		}
+		options.onProgress?.(65)
 
 		if (untrackedFiles.length > 0) {
 			parts.push(await this.getUntrackedFileDiffs(untrackedFiles))
 		}
+		options.onProgress?.(85)
 
 		if (binaryChanges.size > 0) {
 			parts.push(
@@ -107,6 +108,7 @@ export class GitContextCollector {
 		return parts.join("\n")
 	}
 
+	/** Builds diff-stat text for tracked changes and synthesized untracked files. */
 	private async getDiffStats(changes: GitChange[], options: GitContextCollectorOptions): Promise<string> {
 		const trackedChanges = changes.filter((change) => change.status !== "?")
 		const untrackedChanges = changes.filter((change) => change.status === "?")
@@ -127,6 +129,7 @@ export class GitContextCollector {
 		return parts.join("\n")
 	}
 
+	/** Returns a Git-style stat summary for an untracked working-tree file. */
 	private async getUntrackedFileStat(change: GitChange): Promise<string> {
 		const relativePath = this.getRelativePath(change.filePath)
 		if (await this.isProbablyBinaryFile(change.filePath)) {
@@ -135,25 +138,34 @@ export class GitContextCollector {
 
 		const content = await fs.readFile(change.filePath, "utf8")
 		const normalizedContent = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
-		const lineCount = normalizedContent.length === 0 ? 0 : normalizedContent.split("\n").filter(Boolean).length
+		const lineCount = this.countTextLines(normalizedContent)
 		return `${relativePath} | ${lineCount} ${"+".repeat(Math.min(lineCount, 60))}`
 	}
 
+	/** Returns the byte size for a file on disk. */
 	private async getFileSize(filePath: string): Promise<number> {
 		return (await fs.stat(filePath)).size
 	}
 
+	/** Detects binary tracked changes with a single numstat invocation. */
 	private async findBinaryChanges(changes: GitChange[], staged: boolean): Promise<Set<string>> {
 		const binaryFiles = new Set<string>()
+		const trackedChanges = changes.filter((change) => change.status !== "?")
+		if (trackedChanges.length === 0) {
+			return binaryFiles
+		}
 
-		for (const change of changes) {
-			if (change.status === "?") {
-				continue
-			}
+		const args = this.buildNumstatArgs(staged, trackedChanges)
+		const output = await this.runGit(args)
+		const binaryRelativePaths = output
+			.split("\n")
+			.map((line) => line.split("\t"))
+			.filter(([added, deleted, filePath]) => added === "-" && deleted === "-" && Boolean(filePath))
+			.map(([, , ...filePathParts]) => filePathParts.join("\t"))
 
-			const args = this.buildNumstatArgs(staged, change)
-			const output = await this.runGit(args)
-			if (output.includes("-\t-\t")) {
+		for (const change of trackedChanges) {
+			const relativePath = this.getRelativePath(change.filePath)
+			if (binaryRelativePaths.includes(relativePath)) {
 				binaryFiles.add(change.filePath)
 			}
 		}
@@ -161,11 +173,13 @@ export class GitContextCollector {
 		return binaryFiles
 	}
 
-	private buildNumstatArgs(staged: boolean, change: GitChange): string[] {
+	/** Builds path-limited numstat arguments for binary detection. */
+	private buildNumstatArgs(staged: boolean, changes: GitChange[]): string[] {
 		const args = staged ? ["diff", "--cached", "--numstat"] : ["diff", "--numstat"]
-		return [...args, "--", this.getRelativePath(change.filePath)]
+		return [...args, "--", ...changes.map((change) => this.getRelativePath(change.filePath))]
 	}
 
+	/** Checks the first bytes of a file for NUL bytes. */
 	private async isProbablyBinaryFile(filePath: string): Promise<boolean> {
 		const fileHandle = await fs.open(filePath, "r")
 		try {
@@ -177,6 +191,7 @@ export class GitContextCollector {
 		}
 	}
 
+	/** Builds synthesized diff text for untracked files. */
 	private async getUntrackedFileDiffs(changes: GitChange[]): Promise<string> {
 		const diffs: string[] = []
 
@@ -192,6 +207,7 @@ export class GitContextCollector {
 		return diffs.join("\n")
 	}
 
+	/** Creates a unified new-file diff from working-tree file content. */
 	private async createNewFileDiff(filePath: string): Promise<string> {
 		const relativePath = this.getRelativePath(filePath)
 		const content = await fs.readFile(filePath, "utf8")
@@ -224,16 +240,19 @@ export class GitContextCollector {
 		return diffLines.join("\n")
 	}
 
+	/** Returns raw Git status output for staged or unstaged collection. */
 	private async getStatus(options: GitContextOptions): Promise<string> {
 		return options.staged
 			? this.runGit(["diff", "--name-status", "--cached", "-z"])
 			: this.runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"])
 	}
 
+	/** Returns the currently checked-out branch name. */
 	private async getCurrentBranch(): Promise<string> {
 		return this.runGit(["branch", "--show-current"])
 	}
 
+	/** Returns recent commit summaries and optional stats or patch context. */
 	private async getRecentCommits(options: GitRecentCommitContextOptions): Promise<string> {
 		const count = this.clampNumber(options.count, 1, 20, DEFAULT_RECENT_COMMIT_COUNT)
 		const args = options.includeBodies
@@ -261,6 +280,7 @@ export class GitContextCollector {
 		return parts.join("\n")
 	}
 
+	/** Formats collected changes as Markdown context for prompt input. */
 	public async collectContext(
 		changes: GitChange[],
 		options: GitContextCollectorOptions,
@@ -338,6 +358,7 @@ export class GitContextCollector {
 		return { context, warnings }
 	}
 
+	/** Formats collected changes and returns only the Markdown context body. */
 	public async getContext(
 		changes: GitChange[],
 		options: GitContextCollectorOptions,
@@ -346,10 +367,12 @@ export class GitContextCollector {
 		return (await this.collectContext(changes, options, specificFiles)).context
 	}
 
+	/** Normalizes unknown thrown values into displayable error messages. */
 	private getErrorMessage(error: unknown): string {
 		return error instanceof Error ? error.message : String(error)
 	}
 
+	/** Parses NUL-delimited git diff --name-status output. */
 	private parseNameStatus(output: string, staged: boolean): GitChange[] {
 		const fields = this.splitNullDelimited(output)
 		const changes: GitChange[] = []
@@ -359,6 +382,10 @@ export class GitContextCollector {
 			const status = this.getChangeStatusFromCode(statusCode)
 
 			if (status === "R" || status === "C") {
+				if (index + 2 >= fields.length) {
+					break
+				}
+
 				const oldFilePath = fields[++index]
 				const filePath = fields[++index]
 				if (oldFilePath && filePath) {
@@ -370,6 +397,10 @@ export class GitContextCollector {
 					})
 				}
 				continue
+			}
+
+			if (index + 1 >= fields.length) {
+				break
 			}
 
 			const filePath = fields[++index]
@@ -385,6 +416,7 @@ export class GitContextCollector {
 		return changes
 	}
 
+	/** Parses NUL-delimited git status --porcelain=v1 output for unstaged changes. */
 	private parsePorcelainStatus(output: string): GitChange[] {
 		const fields = this.splitNullDelimited(output)
 		const changes: GitChange[] = []
@@ -397,12 +429,18 @@ export class GitContextCollector {
 
 			const indexStatus = entry.charAt(0)
 			const workingStatus = entry.charAt(1)
-			const statusCode = indexStatus === "?" && workingStatus === "?" ? "?" : workingStatus.trim() || indexStatus
+			const isUntracked = indexStatus === "?" && workingStatus === "?"
+			const worktreeStatus = workingStatus.trim()
+			if (!isUntracked && !worktreeStatus) {
+				continue
+			}
+
+			const statusCode = isUntracked ? "?" : worktreeStatus
 			const status = this.getChangeStatusFromCode(statusCode)
 			const filePath = entry.substring(3)
 
 			if (status === "R" || status === "C") {
-				const oldFilePath = fields[++index]
+				const oldFilePath = index + 1 < fields.length ? fields[++index] : undefined
 				changes.push({
 					filePath: path.join(this.workspaceRoot, filePath),
 					oldFilePath: oldFilePath ? path.join(this.workspaceRoot, oldFilePath) : undefined,
@@ -422,30 +460,38 @@ export class GitContextCollector {
 		return changes
 	}
 
+	/** Splits NUL-delimited Git output and drops the trailing empty field. */
 	private splitNullDelimited(output: string): string[] {
 		return output.split("\0").filter(Boolean)
 	}
 
+	/** Applies exact path or basename-only file selection to collected changes. */
 	private filterChanges(changes: GitChange[], specificFiles?: string[]): GitChange[] {
 		if (!specificFiles || specificFiles.length === 0) {
 			return changes
 		}
 
 		return changes.filter((change) => {
-			const absolutePath = change.filePath
-			const relativePath = this.getRelativePath(absolutePath)
+			const absolutePath = this.normalizePath(change.filePath)
+			const relativePath = this.getRelativePath(change.filePath)
 			return specificFiles.some((file) => {
 				const normalizedFile = path.normalize(file).replace(/\\/g, "/")
+				const absoluteFile = this.normalizePath(
+					path.isAbsolute(file) ? file : path.join(this.workspaceRoot, file),
+				)
+				const isBasenameOnly = !normalizedFile.includes("/")
+
 				return (
-					file === absolutePath ||
-					file === relativePath ||
-					absolutePath.endsWith(file) ||
-					relativePath === normalizedFile
+					absoluteFile === absolutePath ||
+					relativePath === normalizedFile ||
+					// Basename-only matching is intentional for SCM selections that pass only file names.
+					(isBasenameOnly && path.basename(relativePath) === normalizedFile)
 				)
 			})
 		})
 	}
 
+	/** Builds path-limited diff arguments for the requested change set. */
 	private buildDiffArgs(
 		staged: boolean,
 		changes: GitChange[],
@@ -470,6 +516,7 @@ export class GitContextCollector {
 		return paths.length > 0 ? [...args, ...extraArgs, ...contextLines, "--", ...paths] : [...args, ...extraArgs]
 	}
 
+	/** Clamps a numeric option to an integer range with fallback handling. */
 	private clampNumber(value: number | undefined, min: number, max: number, fallback: number): number {
 		if (typeof value !== "number" || !Number.isFinite(value)) {
 			return fallback
@@ -478,10 +525,12 @@ export class GitContextCollector {
 		return Math.min(Math.max(Math.trunc(value), min), max)
 	}
 
+	/** Converts an absolute file path to a slash-normalized repository-relative path. */
 	private getRelativePath(filePath: string): string {
 		return path.relative(this.workspaceRoot, filePath).replace(/\\/g, "/")
 	}
 
+	/** Converts a Git status code into the collector's status enum. */
 	private getChangeStatusFromCode(code: string): GitStatus {
 		const status = code.charAt(0)
 		switch (status) {
@@ -498,6 +547,7 @@ export class GitContextCollector {
 		}
 	}
 
+	/** Converts a status enum to a human-readable label. */
 	private getReadableStatus(status: GitStatus): string {
 		switch (status) {
 			case "M":
@@ -520,5 +570,17 @@ export class GitContextCollector {
 		}
 	}
 
-	public dispose(): void {}
+	/** Counts text lines while preserving blank lines and ignoring a final newline terminator. */
+	private countTextLines(content: string): number {
+		if (content.length === 0) {
+			return 0
+		}
+
+		return (content.endsWith("\n") ? content.slice(0, -1) : content).split("\n").length
+	}
+
+	/** Normalizes absolute paths for platform-independent comparisons. */
+	private normalizePath(filePath: string): string {
+		return path.normalize(filePath).replace(/\\/g, "/")
+	}
 }

--- a/src/services/git-context/GitContextCollector.ts
+++ b/src/services/git-context/GitContextCollector.ts
@@ -570,6 +570,9 @@ export class GitContextCollector {
 		}
 	}
 
+	/** Keeps collector cleanup compatible with provider lifecycle hooks. */
+	public dispose(): void {}
+
 	/** Counts text lines while preserving blank lines and ignoring a final newline terminator. */
 	private countTextLines(content: string): number {
 		if (content.length === 0) {

--- a/src/services/git-context/__tests__/GitContextCollector.spec.ts
+++ b/src/services/git-context/__tests__/GitContextCollector.spec.ts
@@ -1,0 +1,218 @@
+import * as os from "os"
+import * as path from "path"
+import { EventEmitter } from "events"
+import { promises as fs } from "fs"
+import { spawn } from "child_process"
+
+import { GitContextCollector } from "../GitContextCollector"
+
+vi.mock("child_process", () => ({
+	spawn: vi.fn(),
+}))
+
+const mockSpawn = vi.mocked(spawn)
+const workspaceRoot = path.resolve("/repo")
+const requiredContextOnly = { includeBranch: false, recentCommits: { include: false } }
+
+function mockGitCommand(stdout: string, stderr = "", code = 0) {
+	mockSpawn.mockImplementationOnce((() => {
+		const child = new EventEmitter() as EventEmitter & {
+			stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+			stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+		}
+
+		child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+		child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+
+		queueMicrotask(() => {
+			if (stdout) {
+				child.stdout.emit("data", stdout)
+			}
+
+			if (stderr) {
+				child.stderr.emit("data", stderr)
+			}
+
+			child.emit("close", code)
+		})
+
+		return child
+	}) as unknown as typeof spawn)
+}
+
+describe("GitContextCollector", () => {
+	beforeEach(() => {
+		mockSpawn.mockReset()
+	})
+
+	it("parses staged name-status output including renames and copies", async () => {
+		mockGitCommand(
+			["M", "src/file.ts", "R100", "src/old.ts", "src/new.ts", "C075", "src/a.ts", "src/b.ts", ""].join("\0"),
+		)
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const changes = await collector.gatherChanges({ staged: true })
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"git",
+			["diff", "--name-status", "--cached", "-z"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(changes).toEqual([
+			{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true },
+			{
+				filePath: path.join(workspaceRoot, "src/new.ts"),
+				oldFilePath: path.join(workspaceRoot, "src/old.ts"),
+				status: "R",
+				staged: true,
+			},
+			{
+				filePath: path.join(workspaceRoot, "src/b.ts"),
+				oldFilePath: path.join(workspaceRoot, "src/a.ts"),
+				status: "C",
+				staged: true,
+			},
+		])
+	})
+
+	it("requests all untracked files instead of collapsed untracked directories", async () => {
+		mockGitCommand(["?? src/new.ts", ""].join("\0"))
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const changes = await collector.gatherChanges({ staged: false })
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"git",
+			["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(changes).toEqual([{ filePath: path.join(workspaceRoot, "src/new.ts"), status: "?", staged: false }])
+	})
+
+	it("keeps lockfiles in git context because git state is authoritative", async () => {
+		mockGitCommand("1\t1\tpackage-lock.json\n")
+		mockGitCommand("diff --git a/package-lock.json b/package-lock.json\n")
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const context = await collector.getContext(
+			[{ filePath: path.join(workspaceRoot, "package-lock.json"), status: "M", staged: true }],
+			{ staged: true, ...requiredContextOnly },
+		)
+
+		expect(context).toContain("diff --git a/package-lock.json b/package-lock.json")
+		expect(context).toContain("Modified (staged): package-lock.json")
+	})
+
+	it("can gather changes and collect context in one reusable call", async () => {
+		mockGitCommand(["M", "src/file.ts", ""].join("\0"))
+		mockGitCommand("1\t1\tsrc/file.ts\n")
+		mockGitCommand("diff --git a/src/file.ts b/src/file.ts\n")
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const result = await collector.collect({ staged: true, ...requiredContextOnly })
+
+		expect(result.changes).toEqual([
+			{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true },
+		])
+		expect(result.context).toContain("diff --git a/src/file.ts b/src/file.ts")
+		expect(result.warnings).toEqual([])
+	})
+
+	it("uses requested diff context lines and includes diff stats", async () => {
+		mockGitCommand("src/file.ts | 3 ++-\n")
+		mockGitCommand("2\t1\tsrc/file.ts\n")
+		mockGitCommand("diff --git a/src/file.ts b/src/file.ts\n")
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const context = await collector.getContext(
+			[{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true }],
+			{ staged: true, ...requiredContextOnly, diff: { contextLines: 0, includeStats: true } },
+		)
+
+		expect(mockSpawn).toHaveBeenNthCalledWith(
+			3,
+			"git",
+			["diff", "--cached", "--unified=0", "--", "src/file.ts"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(context).toContain("### Diff Stats")
+		expect(context).toContain("src/file.ts | 3 ++-")
+	})
+
+	it("includes full new-file diffs for untracked text files", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-git-context-"))
+		try {
+			const filePath = path.join(tempRoot, "src", "new.ts")
+			await fs.mkdir(path.dirname(filePath), { recursive: true })
+			await fs.writeFile(filePath, "export const value = 1\n")
+
+			const collector = new GitContextCollector(tempRoot)
+			const context = await collector.getContext([{ filePath, status: "?", staged: false }], {
+				staged: false,
+				...requiredContextOnly,
+			})
+
+			expect(mockSpawn).not.toHaveBeenCalled()
+			expect(context).toContain("diff --git a/src/new.ts b/src/new.ts")
+			expect(context).toContain("--- /dev/null")
+			expect(context).toContain("+export const value = 1")
+			expect(context).toContain("Untracked (unstaged): src/new.ts")
+		} finally {
+			await fs.rm(tempRoot, { recursive: true, force: true })
+		}
+	})
+
+	it("summarizes untracked binary files without binary payload", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-git-context-"))
+		try {
+			const filePath = path.join(tempRoot, "image.bin")
+			await fs.writeFile(filePath, Buffer.from([0, 1, 2, 3]))
+
+			const collector = new GitContextCollector(tempRoot)
+			const context = await collector.getContext([{ filePath, status: "?", staged: false }], {
+				staged: false,
+				...requiredContextOnly,
+			})
+
+			expect(context).toContain("Binary file added: image.bin")
+			expect(context).not.toContain("@@ -0,0")
+			expect(context).toContain("Untracked (unstaged): image.bin")
+		} finally {
+			await fs.rm(tempRoot, { recursive: true, force: true })
+		}
+	})
+
+	it("fails required diff collection instead of emitting partial context", async () => {
+		mockGitCommand("1\t1\tsrc/file.ts\n")
+		mockGitCommand("", "fatal: bad revision", 128)
+
+		const collector = new GitContextCollector(workspaceRoot)
+
+		await expect(
+			collector.getContext([{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true }], {
+				staged: true,
+				...requiredContextOnly,
+			}),
+		).rejects.toThrow("fatal: bad revision")
+	})
+
+	it("returns warnings when supplemental repository context is unavailable", async () => {
+		mockGitCommand("1\t1\tsrc/file.ts\n")
+		mockGitCommand("diff --git a/src/file.ts b/src/file.ts\n")
+		mockGitCommand("", "fatal: branch unavailable", 128)
+		mockGitCommand("", "fatal: log unavailable", 128)
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const result = await collector.collectContext(
+			[{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true }],
+			{ staged: true, includeBranch: true, recentCommits: { include: true } },
+		)
+
+		expect(result.warnings).toEqual([
+			expect.stringContaining("Current branch unavailable"),
+			expect.stringContaining("Recent commits unavailable"),
+		])
+		expect(result.context).toContain("### Git Context Warnings")
+		expect(result.context).toContain("diff --git a/src/file.ts b/src/file.ts")
+	})
+})

--- a/src/services/git-context/__tests__/GitContextCollector.spec.ts
+++ b/src/services/git-context/__tests__/GitContextCollector.spec.ts
@@ -14,6 +14,7 @@ const mockSpawn = vi.mocked(spawn)
 const workspaceRoot = path.resolve("/repo")
 const requiredContextOnly = { includeBranch: false, recentCommits: { include: false } }
 
+/** Queues a mocked Git subprocess response for the next spawn call. */
 function mockGitCommand(stdout: string, stderr = "", code = 0) {
 	mockSpawn.mockImplementationOnce((() => {
 		const child = new EventEmitter() as EventEmitter & {
@@ -75,6 +76,23 @@ describe("GitContextCollector", () => {
 		])
 	})
 
+	it("parses staged paths with spaces, special characters, and deleted status", async () => {
+		mockGitCommand(["M", "src/file with spaces.ts", "D", "src/old'file.ts", ""].join("\0"))
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const changes = await collector.gatherChanges({ staged: true })
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"git",
+			["diff", "--name-status", "--cached", "-z"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(changes).toEqual([
+			{ filePath: path.join(workspaceRoot, "src/file with spaces.ts"), status: "M", staged: true },
+			{ filePath: path.join(workspaceRoot, "src/old'file.ts"), status: "D", staged: true },
+		])
+	})
+
 	it("requests all untracked files instead of collapsed untracked directories", async () => {
 		mockGitCommand(["?? src/new.ts", ""].join("\0"))
 
@@ -87,6 +105,29 @@ describe("GitContextCollector", () => {
 			expect.objectContaining({ cwd: workspaceRoot }),
 		)
 		expect(changes).toEqual([{ filePath: path.join(workspaceRoot, "src/new.ts"), status: "?", staged: false }])
+	})
+
+	it("ignores staged-only entries when gathering unstaged changes", async () => {
+		mockGitCommand(["M  src/staged.ts", ""].join("\0"))
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const changes = await collector.gatherChanges({ staged: false })
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"git",
+			["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(changes).toEqual([])
+	})
+
+	it("skips malformed staged name-status entries without reading past the output", async () => {
+		mockGitCommand(["R100", "src/old.ts", ""].join("\0"))
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const changes = await collector.gatherChanges({ staged: true })
+
+		expect(changes).toEqual([])
 	})
 
 	it("keeps lockfiles in git context because git state is authoritative", async () => {
@@ -139,6 +180,54 @@ describe("GitContextCollector", () => {
 		expect(context).toContain("src/file.ts | 3 ++-")
 	})
 
+	it("batches binary detection for tracked changes", async () => {
+		mockGitCommand("-\t-\tsrc/image.png\n1\t1\tsrc/file.ts\n")
+		mockGitCommand("diff --git a/src/file.ts b/src/file.ts\n")
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const context = await collector.getContext(
+			[
+				{ filePath: path.join(workspaceRoot, "src/image.png"), status: "M", staged: true },
+				{ filePath: path.join(workspaceRoot, "src/file.ts"), status: "M", staged: true },
+			],
+			{ staged: true, ...requiredContextOnly },
+		)
+
+		expect(mockSpawn).toHaveBeenNthCalledWith(
+			1,
+			"git",
+			["diff", "--cached", "--numstat", "--", "src/image.png", "src/file.ts"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(mockSpawn).toHaveBeenCalledTimes(2)
+		expect(context).toContain("Binary file modified: src/image.png")
+		expect(context).toContain("diff --git a/src/file.ts b/src/file.ts")
+	})
+
+	it("matches selected files by exact path or basename without suffix matching", async () => {
+		mockGitCommand("1\t1\tsrc/test.ts\n")
+		mockGitCommand("diff --git a/src/test.ts b/src/test.ts\n")
+
+		const collector = new GitContextCollector(workspaceRoot)
+		const context = await collector.getContext(
+			[
+				{ filePath: path.join(workspaceRoot, "src/mytest.ts"), status: "M", staged: true },
+				{ filePath: path.join(workspaceRoot, "src/test.ts"), status: "M", staged: true },
+			],
+			{ staged: true, ...requiredContextOnly },
+			["test.ts"],
+		)
+
+		expect(mockSpawn).toHaveBeenNthCalledWith(
+			2,
+			"git",
+			["diff", "--cached", "--", "src/test.ts"],
+			expect.objectContaining({ cwd: workspaceRoot }),
+		)
+		expect(context).toContain("Modified (staged): src/test.ts")
+		expect(context).not.toContain("src/mytest.ts")
+	})
+
 	it("includes full new-file diffs for untracked text files", async () => {
 		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-git-context-"))
 		try {
@@ -152,11 +241,30 @@ describe("GitContextCollector", () => {
 				...requiredContextOnly,
 			})
 
-			expect(mockSpawn).not.toHaveBeenCalled()
 			expect(context).toContain("diff --git a/src/new.ts b/src/new.ts")
 			expect(context).toContain("--- /dev/null")
 			expect(context).toContain("+export const value = 1")
 			expect(context).toContain("Untracked (unstaged): src/new.ts")
+		} finally {
+			await fs.rm(tempRoot, { recursive: true, force: true })
+		}
+	})
+
+	it("counts blank lines in untracked text file stats", async () => {
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "zoo-git-context-"))
+		try {
+			const filePath = path.join(tempRoot, "src", "new.ts")
+			await fs.mkdir(path.dirname(filePath), { recursive: true })
+			await fs.writeFile(filePath, "first\n\nthird\n")
+
+			const collector = new GitContextCollector(tempRoot)
+			const context = await collector.getContext([{ filePath, status: "?", staged: false }], {
+				staged: false,
+				...requiredContextOnly,
+				diff: { includeStats: true },
+			})
+
+			expect(context).toContain("src/new.ts | 3 +++")
 		} finally {
 			await fs.rm(tempRoot, { recursive: true, force: true })
 		}

--- a/src/services/git-context/index.ts
+++ b/src/services/git-context/index.ts
@@ -1,0 +1,11 @@
+export { GitContextCollector } from "./GitContextCollector"
+export type {
+	GitChange,
+	GitContextCollection,
+	GitContextCollectorOptions,
+	GitDiffContextOptions,
+	GitContextOptions,
+	GitRecentCommitContextOptions,
+	GitContextResult,
+	GitStatus,
+} from "./types"

--- a/src/services/git-context/types.ts
+++ b/src/services/git-context/types.ts
@@ -1,42 +1,70 @@
+/** Git status code emitted by porcelain and name-status commands. */
 export type GitStatus = "M" | "A" | "D" | "R" | "C" | "U" | "?" | "Unknown"
 
+/** One repository file change selected for commit-message context. */
 export interface GitChange {
+	/** Absolute path to the changed file. */
 	filePath: string
+	/** Absolute previous path for rename or copy changes. */
 	oldFilePath?: string
+	/** Parsed Git status for the changed file. */
 	status: GitStatus
+	/** Whether this change came from the index instead of the working tree. */
 	staged: boolean
 }
 
+/** Formatted Git context and non-fatal supplemental context warnings. */
 export interface GitContextResult {
+	/** Markdown context suitable for commit-message prompt input. */
 	context: string
+	/** Warnings from optional branch or recent-commit collection. */
 	warnings: string[]
 }
 
+/** Combined change discovery and formatted context result. */
 export interface GitContextCollection extends GitContextResult {
+	/** File changes used to build the formatted context. */
 	changes: GitChange[]
 }
 
+/** Base Git collection mode options. */
 export interface GitContextOptions {
+	/** Collect staged changes when true, otherwise collect unstaged changes. */
 	staged: boolean
 }
 
+/** Diff formatting options for collected changes. */
 export interface GitDiffContextOptions {
+	/** Number of unchanged context lines around each hunk. */
 	contextLines?: number
+	/** Include diff-stat output before the full diff. */
 	includeStats?: boolean
 }
 
+/** Recent-commit context options appended to formatted Git context. */
 export interface GitRecentCommitContextOptions {
+	/** Include recent commit context when true. */
 	include?: boolean
+	/** Number of recent commits to include. */
 	count?: number
+	/** Include commit body text when true. */
 	includeBodies?: boolean
+	/** Include recent commit stats when true. */
 	includeStats?: boolean
+	/** Include recent commit patches when true. */
 	includeDiffs?: boolean
+	/** Number of recent commit patches to include. */
 	diffCount?: number
 }
 
+/** Full collector options for change discovery and context formatting. */
 export interface GitContextCollectorOptions extends GitContextOptions {
+	/** Receives coarse progress percentages during diff collection. */
 	onProgress?: (percentage: number) => void
+	/** Controls full-diff and stat formatting. */
 	diff?: GitDiffContextOptions
+	/** Include the current branch name when true. */
 	includeBranch?: boolean
+	/** Controls recent commit context inclusion. */
 	recentCommits?: GitRecentCommitContextOptions
 }

--- a/src/services/git-context/types.ts
+++ b/src/services/git-context/types.ts
@@ -1,0 +1,42 @@
+export type GitStatus = "M" | "A" | "D" | "R" | "C" | "U" | "?" | "Unknown"
+
+export interface GitChange {
+	filePath: string
+	oldFilePath?: string
+	status: GitStatus
+	staged: boolean
+}
+
+export interface GitContextResult {
+	context: string
+	warnings: string[]
+}
+
+export interface GitContextCollection extends GitContextResult {
+	changes: GitChange[]
+}
+
+export interface GitContextOptions {
+	staged: boolean
+}
+
+export interface GitDiffContextOptions {
+	contextLines?: number
+	includeStats?: boolean
+}
+
+export interface GitRecentCommitContextOptions {
+	include?: boolean
+	count?: number
+	includeBodies?: boolean
+	includeStats?: boolean
+	includeDiffs?: boolean
+	diffCount?: number
+}
+
+export interface GitContextCollectorOptions extends GitContextOptions {
+	onProgress?: (percentage: number) => void
+	diff?: GitDiffContextOptions
+	includeBranch?: boolean
+	recentCommits?: GitRecentCommitContextOptions
+}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #282

Part of: #145

Replaces part of: #146

### Description

This is part 1 of the split commit-message generation stack. It adds the reusable Git context collection layer that later PRs use to generate commit messages from the user's actual Git state.

This PR adds `GitContextCollector` under `src/services/git-context` and keeps it independent from AI generation, VS Code SCM command wiring, and settings UI. The collector uses Git as the source of truth rather than Zoo file ignore filters, because commit-message generation should describe what the user staged or modified for Git.

Key implementation details:

- Adds `GitContextCollector` plus exported Git context/change/result types.
- Parses staged changes from `git diff --name-status --cached -z`.
- Parses unstaged and untracked changes from `git status --porcelain=v1 -z --untracked-files=all`.
- Handles modified, added, deleted, renamed, copied, unknown, and untracked files.
- Handles untracked text files by creating synthetic new-file diffs.
- Handles binary files without embedding binary payloads into prompt context.
- Supports diff stats, configurable diff context lines, current branch, recent commits, recent commit stats, and recent commit diffs.
- Returns non-fatal warnings for supplemental repository context failures while preserving required diff failures.
- Adds focused tests for parsing, untracked files, binary handling, warnings, and context output.

Reviewers should focus on path-safe Git parsing, rename/copy handling, binary/untracked behavior, and whether the collector contract is reusable enough for the following PRs.

This aligns with Zoo Code's reliability-first roadmap by isolating the Git-source-of-truth behavior in a tested service before connecting it to UI or model calls.

### Test Procedure

Automated verification run before opening the split PR stack:

- `pnpm --dir src exec vitest run services/git-context/__tests__/GitContextCollector.spec.ts`
- Split verification agent checked that this PR only contains `src/services/git-context/**` and has no generator, SCM command, package manifest, state, or UI wiring.
- Pre-push typecheck completed successfully through the repository hook.

Reviewer verification:

- Inspect `src/services/git-context/GitContextCollector.ts` and `src/services/git-context/__tests__/GitContextCollector.spec.ts`.
- Confirm staged name-status parsing handles rename/copy entries.
- Confirm untracked files are expanded via `--untracked-files=all` and represented in context.
- Confirm binary files are summarized without binary payload.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

Not applicable. This PR adds a non-UI service layer.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

Stack order:

1. This PR: Git context collector.
2. #299: Commit message prompt and generator service.
3. #300: VS Code SCM integration.
4. #301: Settings, profiles, attribution, and localization.

This PR intentionally does not expose user-facing behavior by itself. It provides the reviewable Git context foundation for the rest of the feature.

### Get in Touch

Discord: Mirrowel <@214161976534892545>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git repository context collection: gathers changed files, unified diffs (including untracked/new-file cases), optional diff stats, and optional branch/recent-commit context; supports scoping to specific files and surfaces warnings when supplemental info can’t be fetched.
* **Tests**
  * Added comprehensive tests covering staged/unstaged/untracked scenarios, binary handling, diff options, path scoping, and error/warning behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->