### PR TITLE
feat(bedrock): full support for Claude Opus 4.7 (registry + API compat layer)

### DIFF
--- a/packages/types/src/providers/bedrock.ts
+++ b/packages/types/src/providers/bedrock.ts
@@ -167,6 +167,30 @@ export const bedrockModels = {
 			},
 		],
 	},
+	"anthropic.claude-opus-4-7": {
+		maxTokens: 8192,
+		contextWindow: 200_000, // Default 200K, extendable to 1M with beta flag 'context-1m-2025-08-07'
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningBudget: true,
+		inputPrice: 5.0, // $5 per million input tokens (≤200K context) — verify against Bedrock console
+		outputPrice: 25.0, // $25 per million output tokens (≤200K context) — verify against Bedrock console
+		cacheWritesPrice: 6.25, // $6.25 per million tokens
+		cacheReadsPrice: 0.5, // $0.50 per million tokens
+		minTokensPerCachePoint: 1024,
+		maxCachePoints: 4,
+		cachableFields: ["system", "messages", "tools"],
+		// Tiered pricing for extended context (requires beta flag 'context-1m-2025-08-07')
+		tiers: [
+			{
+				contextWindow: 1_000_000, // 1M tokens with beta flag
+				inputPrice: 10.0, // $10 per million input tokens (>200K context)
+				outputPrice: 37.5, // $37.50 per million output tokens (>200K context)
+				cacheWritesPrice: 12.5, // $12.50 per million tokens (>200K context)
+				cacheReadsPrice: 1.0, // $1.00 per million tokens (>200K context)
+			},
+		],
+	},
 	"anthropic.claude-opus-4-5-20251101-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 200_000,
@@ -525,6 +549,7 @@ export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
 	"anthropic.claude-sonnet-4-6",
 	"anthropic.claude-opus-4-6-v1",
+	"anthropic.claude-opus-4-7",
 ] as const
 
 // Amazon Bedrock models that support Global Inference profiles
@@ -535,6 +560,7 @@ export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 // - Claude Haiku 4.5
 // - Claude Opus 4.5
 // - Claude Opus 4.6
+// - Claude Opus 4.7
 export const BEDROCK_GLOBAL_INFERENCE_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -542,6 +568,7 @@ export const BEDROCK_GLOBAL_INFERENCE_MODEL_IDS = [
 	"anthropic.claude-haiku-4-5-20251001-v1:0",
 	"anthropic.claude-opus-4-5-20251101-v1:0",
 	"anthropic.claude-opus-4-6-v1",
+	"anthropic.claude-opus-4-7",
 ] as const
 
 // Amazon Bedrock Service Tier types

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -61,9 +61,20 @@ interface BedrockInferenceConfig {
 // Define interface for Bedrock additional model request fields
 // This includes thinking configuration, 1M context beta, and other model-specific parameters
 interface BedrockAdditionalModelFields {
-	thinking?: {
-		type: "enabled"
-		budget_tokens: number
+	thinking?:
+		| {
+				type: "enabled"
+				budget_tokens: number
+		  }
+		| {
+				// Claude 4.7+ adaptive thinking — no budget_tokens, uses output_config.effort instead
+				type: "adaptive"
+				// "summarized" shows thinking content in UI; omit to keep thinking internal only
+				display?: "summarized" | "none"
+		  }
+	output_config?: {
+		// Claude 4.7+ effort levels: "low" | "medium" | "high" | "xhigh" | "max"
+		effort: string
 	}
 	anthropic_beta?: string[]
 	[key: string]: any // Add index signature to be compatible with DocumentType
@@ -381,6 +392,11 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		let additionalModelRequestFields: BedrockAdditionalModelFields | undefined
 		let thinkingEnabled = false
 
+		// Detect model generation for API compatibility
+		// Claude 4.7+ removed sampling params (temperature/top_p/top_k) and uses adaptive thinking
+		const baseModelId = this.parseBaseModelId(modelConfig.id)
+		const isGen47Model = baseModelId.includes("opus-4-7") || baseModelId.includes("sonnet-4-7")
+
 		// Determine if thinking should be enabled
 		// metadata?.thinking?.enabled: Explicitly enabled through API metadata (direct request)
 		// shouldUseReasoningBudget(): Enabled through user settings (enableReasoningEffort = true)
@@ -392,27 +408,38 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 
 		if ((isThinkingExplicitlyEnabled || isThinkingEnabledBySettings) && modelConfig.info.supportsReasoningBudget) {
 			thinkingEnabled = true
-			additionalModelRequestFields = {
-				thinking: {
-					type: "enabled",
-					budget_tokens: metadata?.thinking?.maxThinkingTokens || modelConfig.reasoningBudget || 4096,
-				},
+			if (isGen47Model) {
+				// Claude 4.7+ uses adaptive thinking with effort levels — budget_tokens causes 400 error
+				// display: "summarized" surfaces thinking content in Zoo Code UI
+				additionalModelRequestFields = {
+					thinking: { type: "adaptive", display: "summarized" },
+					output_config: { effort: "xhigh" },
+				}
+			} else {
+				additionalModelRequestFields = {
+					thinking: {
+						type: "enabled",
+						budget_tokens: metadata?.thinking?.maxThinkingTokens || modelConfig.reasoningBudget || 4096,
+					},
+				}
 			}
 			logger.info("Extended thinking enabled for Bedrock request", {
 				ctx: "bedrock",
 				modelId: modelConfig.id,
-				thinking: additionalModelRequestFields.thinking,
+				thinking: additionalModelRequestFields?.thinking,
 			})
 		}
 
 		const inferenceConfig: BedrockInferenceConfig = {
 			maxTokens: modelConfig.maxTokens || (modelConfig.info.maxTokens as number),
-			temperature: modelConfig.temperature ?? (this.options.modelTemperature as number),
+			// Claude 4.7+ removed temperature parameter entirely — causes 400 error if sent
+			...(isGen47Model
+				? {}
+				: { temperature: modelConfig.temperature ?? (this.options.modelTemperature as number) }),
 		}
 
 		// Check if 1M context is enabled for supported Claude 4 models
-		// Use parseBaseModelId to handle cross-region inference prefixes
-		const baseModelId = this.parseBaseModelId(modelConfig.id)
+		// Use parseBaseModelId to handle cross-region inference prefixes (computed above)
 		const is1MContextEnabled =
 			BEDROCK_1M_CONTEXT_MODEL_IDS.includes(baseModelId as any) && this.options.awsBedrock1MContext
 


### PR DESCRIPTION
## Summary

Adds full support for `anthropic.claude-opus-4-7` (and future Sonnet 4.7) on AWS Bedrock — both **model registry** and **API compatibility layer**.

This PR contains 2 commits:

1. **`feat(bedrock): add anthropic.claude-opus-4-7 to native model registry`** — Adds the model entry to `bedrockModels` with full ModelInfo configuration
2. **`feat(bedrock): support Claude 4.7+ adaptive thinking and remove temperature`** — Updates the provider logic to handle the breaking API changes introduced by Claude 4.7+

## Problem

When using `anthropic.claude-opus-4-7` as a custom model in Zoo Code with AWS Bedrock provider, **two layers of issues** exist:

### Layer 1: Missing model registry entry

The extension falls back to `guessModelInfoFromId()` which:
- Does NOT set `supportsReasoningBudget: true` → thinking budget disabled in UI
- Does NOT populate `cachableFields` → prompt cache inactive
- Results in "too many tokens" errors during parallel file injection (no cache = tokens accumulate without reuse)

### Layer 2: Breaking API changes in Claude 4.7

Even with the model registered, the Bedrock API rejects requests with errors:
- ❌ `temperature` is deprecated for this model (4.7+ removed sampling parameters entirely)
- ❌ `thinking.type.enabled` is not supported (4.7+ requires `thinking.type.adaptive`)

These cause **400 errors** even after the registry fix.

## Solution

### Commit 1 — Model Registry (`packages/types/src/providers/bedrock.ts`)

Added complete model entry with:
- ✅ `supportsReasoningBudget: true` (enables thinking budget fields in UI)
- ✅ `cachableFields: ["system", "messages", "tools"]` (enables multi-point prompt caching)
- ✅ `supportsPromptCache: true` with `maxCachePoints: 4`
- ✅ `supportsImages: true`
- ✅ 1M context tier pricing (via `tiers[]`)
- ✅ Added to `BEDROCK_1M_CONTEXT_MODEL_IDS`
- ✅ Added to `BEDROCK_GLOBAL_INFERENCE_MODEL_IDS`

### Commit 2 — Provider Logic (`src/api/providers/bedrock.ts`)

Detects Claude 4.7+ models and adapts the request payload:

```typescript
const isGen47Model = baseModelId.includes("opus-4-7") || baseModelId.includes("sonnet-4-7")

// Conditional thinking format:
if (isGen47Model) {
    // Claude 4.7+: adaptive thinking with effort levels
    additionalModelRequestFields = {
        thinking: { type: "adaptive", display: "summarized" },
        output_config: { effort: "xhigh" },
    }
} else {
    // Claude 4.6 and earlier: budget_tokens-based thinking
    additionalModelRequestFields = {
        thinking: { type: "enabled", budget_tokens: ... },
    }
}

// Conditional inferenceConfig (omit temperature for 4.7+):
const inferenceConfig = {
    maxTokens: ...,
    ...(isGen47Model ? {} : { temperature: ... }),
}
```

The `BedrockAdditionalModelFields` interface was expanded to support both thinking formats.

## Effort Levels

The new `output_config.effort` field accepts: `low | medium | high | xhigh | max`

This PR uses `xhigh` as the default, which is recommended by Anthropic for coding and agentic tasks (Zoo Code's primary use case). Future iterations can expose this as a user-configurable setting in the UI.

## Backward Compatibility

✅ **100% backward compatible** with all existing Claude models (4.6, 4.5, 3.7, 3.5, etc.). The conditional logic only activates for `opus-4-7` and `sonnet-4-7` patterns.

## Pricing Note

⚠️ Pricing values for 4.7 are estimated based on `anthropic.claude-opus-4-6-v1` ($5/$25 per million tokens). Please verify against the [AWS Bedrock pricing page](https://aws.amazon.com/bedrock/pricing/) before merging.

## Testing

Tested locally with VSIX install:
- ✅ Model `anthropic.claude-opus-4-7` appears in native dropdown with full configuration
- ✅ Single-message conversations work (no `temperature`/`thinking.type.enabled` errors)
- ✅ Parallel file injection works (8 files read simultaneously without "too many tokens")
- ✅ Adaptive thinking active with `xhigh` effort
- ✅ Backward compatibility verified with `claude-opus-4-6-v1`

## References

- [Anthropic Claude 4.7 release notes](https://docs.anthropic.com/en/release-notes/api-changes) (April 16, 2026)
- Claude 4.7 effort levels: `low | medium | high | xhigh | max`
- `xhigh` is the recommended level for agentic coding tasks per Anthropic guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.7 on Bedrock (1M context, image support, prompt cache, tiered extended-context pricing).
  * Enabled Claude 4.7 “adaptive” thinking mode with effort-level control.
  * Updated inference behavior for Claude 4.7 (omits temperature) and added the model to global/1M-context availability lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->