### PR TITLE
fix(gemini): honor custom model ids instead of falling back to default (#227)

### DIFF
--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -189,6 +189,8 @@ describe("GeminiHandler", () => {
 			// against the default model's rates.
 			expect(modelInfo.info.inputPrice).toBeUndefined()
 			expect(modelInfo.info.outputPrice).toBeUndefined()
+			expect(modelInfo.info.cacheReadsPrice).toBeUndefined()
+			expect(modelInfo.info.cacheWritesPrice).toBeUndefined()
 			expect(modelInfo.info.tiers).toBeUndefined()
 		})
 

--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -174,6 +174,24 @@ describe("GeminiHandler", () => {
 			expect(modelInfo.id).toBe(geminiDefaultModelId) // Default model
 		})
 
+		it("should honor a custom gemini model id not present in geminiModels (#227)", () => {
+			const customHandler = new GeminiHandler({
+				apiModelId: "gemini-3.5-flash",
+				geminiApiKey: "test-key",
+			})
+			const modelInfo = customHandler.getModel()
+			// The configured id must be invoked, not silently swapped for the default.
+			expect(modelInfo.id).toBe("gemini-3.5-flash")
+			expect(modelInfo.id).not.toBe(geminiDefaultModelId)
+			// A baseline ModelInfo is provided so downstream params resolve.
+			expect(modelInfo.info).toBeDefined()
+			// Pricing is unknown for a custom model, so cost should not be reported
+			// against the default model's rates.
+			expect(modelInfo.info.inputPrice).toBeUndefined()
+			expect(modelInfo.info.outputPrice).toBeUndefined()
+			expect(modelInfo.info.tiers).toBeUndefined()
+		})
+
 		it("should exclude apply_diff and include edit in tool preferences", () => {
 			const modelInfo = handler.getModel()
 			expect(modelInfo.info.excludedTools).toContain("apply_diff")

--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -194,6 +194,18 @@ describe("GeminiHandler", () => {
 			expect(modelInfo.info.tiers).toBeUndefined()
 		})
 
+		it("should not treat Object prototype keys as known models", () => {
+			// `"toString" in geminiModels` is true via the prototype chain, which would
+			// otherwise resolve `info` to a function. An own-property check avoids this.
+			const protoHandler = new GeminiHandler({
+				apiModelId: "toString",
+				geminiApiKey: "test-key",
+			})
+			const modelInfo = protoHandler.getModel()
+			expect(modelInfo.id).toBe(geminiDefaultModelId)
+			expect(modelInfo.info).toBeDefined()
+		})
+
 		it("should exclude apply_diff and include edit in tool preferences", () => {
 			const modelInfo = handler.getModel()
 			expect(modelInfo.info.excludedTools).toContain("apply_diff")

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -493,7 +493,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		let id: string
 		let info: ModelInfo
 
-		if (modelId && modelId in geminiModels) {
+		if (modelId && Object.hasOwn(geminiModels, modelId)) {
 			id = modelId
 			info = geminiModels[modelId as GeminiModelId]
 		} else if (modelId && modelId.toLowerCase().startsWith("gemini-")) {

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -490,8 +490,35 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 
 	override getModel() {
 		const modelId = this.options.apiModelId
-		let id = modelId && modelId in geminiModels ? (modelId as GeminiModelId) : geminiDefaultModelId
-		let info: ModelInfo = geminiModels[id]
+		let id: string
+		let info: ModelInfo
+
+		if (modelId && modelId in geminiModels) {
+			id = modelId
+			info = geminiModels[modelId as GeminiModelId]
+		} else if (modelId && modelId.toLowerCase().startsWith("gemini-")) {
+			// Honor a custom/unlisted Gemini model id (e.g. a newly released model
+			// not yet in `geminiModels`) instead of silently falling back to the
+			// default. This mirrors the settings UI's "use custom model" option and
+			// the `useSelectedModel` hook, which both keep the configured id. Ids
+			// that don't look like Gemini models still fall back below.
+			id = modelId
+			// Use the default model's structural info as a baseline, but drop the
+			// pricing fields we can't verify for an unknown model so cost reporting
+			// shows "unknown" (calculateCost returns undefined) instead of charging
+			// the default model's rates against a different model.
+			info = {
+				...geminiModels[geminiDefaultModelId],
+				inputPrice: undefined,
+				outputPrice: undefined,
+				cacheReadsPrice: undefined,
+				cacheWritesPrice: undefined,
+				tiers: undefined,
+			}
+		} else {
+			id = geminiDefaultModelId
+			info = geminiModels[geminiDefaultModelId]
+		}
 
 		const params = getModelParams({
 			format: "gemini",


### PR DESCRIPTION
**Closes #227**

### Problem
Selecting a custom Gemini model id that isn't in the hardcoded `geminiModels` map (e.g. `gemini-3.5-flash`) silently invokes `gemini-3.1-pro-preview` instead. The settings ModelPicker exposes a "use custom model" option and `useSelectedModel` keeps the configured id, but `GeminiHandler.getModel()` discarded any unknown id and fell back to `geminiDefaultModelId` — so the UI and the actual request disagreed.

### Fix
`getModel()` now honors a custom id when it looks like a Gemini model (`gemini-` prefix, case-insensitive), using the default model's structural info as a baseline. Pricing fields (`inputPrice`/`outputPrice`/cache/`tiers`) are dropped for unknown models so cost reporting shows "unknown" rather than charging the default model's rates. Ids that don't look like Gemini models (e.g. `invalid-model`) still fall back to the default, preserving existing behavior.

### Tests
Added a `getModel` case asserting a custom `gemini-3.5-flash` id is honored (not swapped) and that pricing is left undefined. The existing `invalid-model` → default test is unchanged. `tsc`, `eslint`, `prettier`, and the gemini suite (20 tests) pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom Gemini model IDs: configure Gemini identifiers not in the predefined list; these models operate normally but pricing/usage costs are reported as unknown.
* **Tests**
  * Added unit tests ensuring custom Gemini IDs preserve configured IDs and leave pricing fields unset, and that inherited/reserved identifier names fall back to defaults while returning model info.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->