### PR TITLE
fix(ThinkingBudget): extract maxOutputTokensControl to resolve undefined reference in binary reasoning path

### DIFF
--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -164,6 +164,27 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 		return null
 	}
 
+	// Max output tokens control used by both binary reasoning and budget reasoning paths.
+	const maxOutputTokensControl = (
+		<div className="flex flex-col gap-1">
+			<div className="font-medium">{t("settings:thinkingBudget.maxTokens")}</div>
+			<div className="flex items-center gap-1">
+				<Slider
+					min={8192}
+					max={Math.max(
+						modelInfo.maxTokens || 8192,
+						customMaxOutputTokens,
+						DEFAULT_HYBRID_REASONING_MODEL_MAX_TOKENS,
+					)}
+					step={1024}
+					value={[customMaxOutputTokens]}
+					onValueChange={([value]) => setApiConfigurationField("modelMaxTokens", value)}
+				/>
+				<div className="w-12 text-sm text-center">{customMaxOutputTokens}</div>
+			</div>
+		</div>
+	)
+
 	// Models with supportsReasoningBinary (binary reasoning) show a simple on/off toggle
 	if (isReasoningSupported) {
 		return (
@@ -175,6 +196,7 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 					}>
 					{t("settings:providers.useReasoning")}
 				</Checkbox>
+				{maxOutputTokensControl}
 			</div>
 		)
 	}

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -196,7 +196,10 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 					}>
 					{t("settings:providers.useReasoning")}
 				</Checkbox>
-				{maxOutputTokensControl}
+				{/* Only show the max-output-tokens slider when reasoning is enabled: with it off,
+				    getModelMaxOutputTokens returns the model default regardless of the slider, so an
+				    interactive-but-ignored control would mislead. Matches the budget path's guard. */}
+				{enableReasoningEffort && maxOutputTokensControl}
 			</div>
 		)
 	}

--- a/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ThinkingBudget.spec.tsx
@@ -111,6 +111,45 @@ describe("ThinkingBudget", () => {
 		expect(screen.queryByTestId("reasoning-effort")).not.toBeInTheDocument()
 	})
 
+	const binaryReasoningModel: ModelInfo = {
+		...mockModelInfo,
+		supportsReasoningBinary: true,
+		supportsReasoningBudget: false,
+		supportsReasoningEffort: false,
+	}
+
+	it("should hide the max-output-tokens slider in binary reasoning when reasoning is off", () => {
+		// With reasoning disabled, getModelMaxOutputTokens ignores the slider value, so an
+		// interactive control would be misleading — it must not render (PR #332 review).
+		render(
+			<ThinkingBudget
+				{...defaultProps}
+				apiConfiguration={{ enableReasoningEffort: false }}
+				modelInfo={binaryReasoningModel}
+			/>,
+		)
+
+		expect(screen.getByText("settings:providers.useReasoning")).toBeInTheDocument()
+		expect(screen.queryByTestId("slider")).not.toBeInTheDocument()
+	})
+
+	it("should show and wire the max-output-tokens slider in binary reasoning when reasoning is on", () => {
+		const setApiConfigurationField = vi.fn()
+		render(
+			<ThinkingBudget
+				{...defaultProps}
+				apiConfiguration={{ enableReasoningEffort: true }}
+				setApiConfigurationField={setApiConfigurationField}
+				modelInfo={binaryReasoningModel}
+			/>,
+		)
+
+		const slider = screen.getByTestId("slider")
+		expect(slider).toBeInTheDocument()
+		fireEvent.change(slider, { target: { value: "12288" } })
+		expect(setApiConfigurationField).toHaveBeenCalledWith("modelMaxTokens", 12288)
+	})
+
 	it("should render sliders when model supports thinking", () => {
 		render(<ThinkingBudget {...defaultProps} />)
 


### PR DESCRIPTION
## Summary

Extracts the `maxOutputTokensControl` JSX fragment as a named variable declared **before** both the binary reasoning and budget reasoning conditional branches in `ThinkingBudget.tsx`.

This fixes a scoping issue where the max output tokens slider was only defined inside the budget reasoning block, making it unavailable (and would crash at runtime) for models using `supportsReasoningBinary` (binary reasoning toggle).

## Changes

- **Extracted `maxOutputTokensControl`** as a standalone JSX variable at line 167, before the binary/budget conditional branches
- **Added `{maxOutputTokensControl}`** inside the binary reasoning `<div>` so the slider appears for both reasoning modes

## Motivation

This fix addresses a bug reported in PR #274 by @edelauna: models using binary reasoning mode (e.g., Zhipu GLM via `supportsReasoningBinary`) could not configure `modelMaxTokens` because the slider control was scoped only within the budget reasoning conditional path.

## Related

- Fixes issue described in [PR #274](https://github.com/Zoo-Code-Org/Zoo-Code/pull/274)
- Addresses @edelauna's code review comment about `modelMaxTokens` bug


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thinking budget settings now show the max output‑tokens control in the binary reasoning option when reasoning effort is enabled.
* **Tests**
  * Added tests covering binary reasoning: verifies the reasoning toggle shows the slider only when enabled and that adjusting the slider updates the model output‑token setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->