### PR TITLE
feat(zoo-gateway): auth callback and multi-profile token sync

### DIFF
--- a/src/activate/__tests__/handleUri.spec.ts
+++ b/src/activate/__tests__/handleUri.spec.ts
@@ -177,4 +177,24 @@ describe("handleUri", () => {
 
 		expect(order).toEqual(["a:start", "a:end", "b:start", "b:end"])
 	})
+
+	it("continues fan-out when one instance fails to persist the callback token", async () => {
+		mockHandleZooCodeAuthCallback.mockResolvedValue(true)
+
+		const failingProvider = {
+			handleZooCodeCallback: vi.fn(async () => {
+				throw new Error("profile store unavailable")
+			}),
+		} as any
+		const healthyProvider = { handleZooCodeCallback: vi.fn() } as any
+		mockGetAllInstances.mockReturnValue([failingProvider, healthyProvider])
+
+		await handleUri({
+			path: "/auth-callback",
+			query: "token=zoo_ext_test_token",
+		} as any)
+
+		expect(failingProvider.handleZooCodeCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+		expect(healthyProvider.handleZooCodeCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+	})
 })

--- a/src/activate/__tests__/handleUri.spec.ts
+++ b/src/activate/__tests__/handleUri.spec.ts
@@ -6,25 +6,32 @@ vi.mock("vscode", () => ({
 
 import * as vscode from "vscode"
 
-const { mockGetVisibleInstance, mockHandleZooCodeAuthCallback, mockSetZooCodeUserInfo, mockVisibleProvider } =
-	vi.hoisted(() => {
-		const mockVisibleProvider = {
-			handleOpenRouterCallback: vi.fn(),
-			handleRequestyCallback: vi.fn(),
-			handleZooCodeCallback: vi.fn(),
-		} as any
+const {
+	mockGetVisibleInstance,
+	mockGetAllInstances,
+	mockHandleZooCodeAuthCallback,
+	mockSetZooCodeUserInfo,
+	mockVisibleProvider,
+} = vi.hoisted(() => {
+	const mockVisibleProvider = {
+		handleOpenRouterCallback: vi.fn(),
+		handleRequestyCallback: vi.fn(),
+		handleZooCodeCallback: vi.fn(),
+	} as any
 
-		return {
-			mockGetVisibleInstance: vi.fn(() => mockVisibleProvider),
-			mockHandleZooCodeAuthCallback: vi.fn(),
-			mockSetZooCodeUserInfo: vi.fn(),
-			mockVisibleProvider,
-		}
-	})
+	return {
+		mockGetVisibleInstance: vi.fn(() => mockVisibleProvider),
+		mockGetAllInstances: vi.fn(() => [mockVisibleProvider]),
+		mockHandleZooCodeAuthCallback: vi.fn(),
+		mockSetZooCodeUserInfo: vi.fn(),
+		mockVisibleProvider,
+	}
+})
 
 vi.mock("../../core/webview/ClineProvider", () => ({
 	ClineProvider: {
 		getVisibleInstance: mockGetVisibleInstance,
+		getAllInstances: mockGetAllInstances,
 	},
 }))
 
@@ -39,6 +46,7 @@ describe("handleUri", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		mockGetVisibleInstance.mockReturnValue(mockVisibleProvider)
+		mockGetAllInstances.mockReturnValue([mockVisibleProvider])
 	})
 
 	it("ignores legacy cloud auth callback", async () => {
@@ -54,8 +62,9 @@ describe("handleUri", () => {
 		)
 	})
 
-	it("stores callback user info even when no webview is visible", async () => {
+	it("stores callback user info even when no provider instances exist", async () => {
 		mockGetVisibleInstance.mockReturnValue(null)
+		mockGetAllInstances.mockReturnValue([])
 		mockHandleZooCodeAuthCallback.mockResolvedValue(true)
 
 		await handleUri({
@@ -69,6 +78,7 @@ describe("handleUri", () => {
 			email: "jane@example.com",
 			image: "https://example.com/avatar.png",
 		})
+		// No provider instances exist, so handleZooCodeCallback should not be called
 		expect(mockVisibleProvider.handleZooCodeCallback).not.toHaveBeenCalled()
 	})
 
@@ -115,5 +125,56 @@ describe("handleUri", () => {
 
 		expect(mockSetZooCodeUserInfo).not.toHaveBeenCalled()
 		expect(mockVisibleProvider.handleZooCodeCallback).not.toHaveBeenCalled()
+	})
+
+	it("propagates the callback token to every ClineProvider instance, not just the visible one", async () => {
+		// Regression: prior to multi-instance fan-out, hidden providers (sidebar collapsed,
+		// secondary panels) never received the zooSessionToken, so their profile settings
+		// stayed unauthenticated until reload.
+		mockHandleZooCodeAuthCallback.mockResolvedValue(true)
+
+		const hiddenProvider = { handleZooCodeCallback: vi.fn() } as any
+		const secondHidden = { handleZooCodeCallback: vi.fn() } as any
+		mockGetAllInstances.mockReturnValue([mockVisibleProvider, hiddenProvider, secondHidden])
+
+		await handleUri({
+			path: "/auth-callback",
+			query: "token=zoo_ext_test_token",
+		} as any)
+
+		expect(mockHandleZooCodeAuthCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+		expect(mockSetZooCodeUserInfo).toHaveBeenCalled()
+		expect(mockVisibleProvider.handleZooCodeCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+		expect(hiddenProvider.handleZooCodeCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+		expect(secondHidden.handleZooCodeCallback).toHaveBeenCalledWith("zoo_ext_test_token")
+	})
+
+	it("serializes callbacks across instances to avoid concurrent profile-store writes", async () => {
+		// Regression: a previous implementation used Promise.all which fanned out concurrent
+		// read-modify-write operations on the same provider settings store. Verify the
+		// callbacks are invoked sequentially.
+		mockHandleZooCodeAuthCallback.mockResolvedValue(true)
+
+		const order: string[] = []
+		const makeProvider = (name: string) =>
+			({
+				handleZooCodeCallback: vi.fn(async () => {
+					order.push(`${name}:start`)
+					// Yield to the event loop so a concurrent call would interleave.
+					await new Promise((resolve) => setTimeout(resolve, 0))
+					order.push(`${name}:end`)
+				}),
+			}) as any
+
+		const a = makeProvider("a")
+		const b = makeProvider("b")
+		mockGetAllInstances.mockReturnValue([a, b])
+
+		await handleUri({
+			path: "/auth-callback",
+			query: "token=zoo_ext_test_token",
+		} as any)
+
+		expect(order).toEqual(["a:start", "a:end", "b:start", "b:end"])
 	})
 })

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -63,7 +63,14 @@ export const handleUri = async (uri: vscode.Uri) => {
 					// is cheap (at most a handful of instances) and avoids the race.
 					const allInstances = ClineProvider.getAllInstances()
 					for (const instance of allInstances) {
-						await instance.handleZooCodeCallback(token)
+						try {
+							await instance.handleZooCodeCallback(token)
+						} catch (error) {
+							console.error(
+								"Failed to persist Zoo Gateway token for a provider instance:",
+								error instanceof Error ? error.message : error,
+							)
+						}
 					}
 				}
 			}

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -50,9 +50,20 @@ export const handleUri = async (uri: vscode.Uri) => {
 						email,
 						image,
 					})
-					// Refresh webview state if a panel is currently open
-					if (visibleProvider) {
-						await visibleProvider.handleZooCodeCallback(token)
+					// Write the token to all active provider instances regardless of visibility.
+					// The profile settings write (handleZooCodeCallback) must run on any active
+					// instance — not just the visible one — so the zoo-gateway zooSessionToken
+					// is persisted even when the sidebar/panel is hidden at callback time.
+					//
+					// Run sequentially (NOT Promise.all): each ClineProvider's
+					// handleZooCodeCallback does a read-modify-write on the same backing
+					// provider settings store (listConfig → getProfile → saveConfig /
+					// upsertProviderProfile). Fanning out concurrently across N instances
+					// can interleave reads/writes and clobber updates. Serialization here
+					// is cheap (at most a handful of instances) and avoids the race.
+					const allInstances = ClineProvider.getAllInstances()
+					for (const instance of allInstances) {
+						await instance.handleZooCodeCallback(token)
 					}
 				}
 			}

--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -4,6 +4,34 @@ import { getRouterUnavailableSignInMessage } from "../core/config/routerRemoval"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { handleAuthCallback as handleZooCodeAuthCallback, setZooCodeUserInfo } from "../services/zoo-code-auth"
 
+/**
+ * Persist the Zoo Code session token to every active provider instance.
+ *
+ * The profile settings write (handleZooCodeCallback) must run on any active
+ * instance — not just the visible one — so the zoo-gateway zooSessionToken is
+ * persisted even when the sidebar/panel is hidden at callback time.
+ *
+ * Run sequentially (NOT Promise.all): each ClineProvider's handleZooCodeCallback
+ * does a read-modify-write on the same backing provider settings store
+ * (listConfig → getProfile → saveConfig / upsertProviderProfile). Fanning out
+ * concurrently across N instances can interleave reads/writes and clobber
+ * updates. Serialization is cheap (at most a handful of instances) and avoids
+ * the race.
+ */
+async function propagateZooGatewayCallback(token: string): Promise<void> {
+	const allInstances = ClineProvider.getAllInstances()
+	for (const instance of allInstances) {
+		try {
+			await instance.handleZooCodeCallback(token)
+		} catch (error) {
+			console.error(
+				"Failed to persist Zoo Gateway token for a provider instance:",
+				error instanceof Error ? error.message : error,
+			)
+		}
+	}
+}
+
 export const handleUri = async (uri: vscode.Uri) => {
 	const path = uri.path
 	const query = new URLSearchParams(uri.query.replace(/\+/g, "%2B"))
@@ -50,28 +78,7 @@ export const handleUri = async (uri: vscode.Uri) => {
 						email,
 						image,
 					})
-					// Write the token to all active provider instances regardless of visibility.
-					// The profile settings write (handleZooCodeCallback) must run on any active
-					// instance — not just the visible one — so the zoo-gateway zooSessionToken
-					// is persisted even when the sidebar/panel is hidden at callback time.
-					//
-					// Run sequentially (NOT Promise.all): each ClineProvider's
-					// handleZooCodeCallback does a read-modify-write on the same backing
-					// provider settings store (listConfig → getProfile → saveConfig /
-					// upsertProviderProfile). Fanning out concurrently across N instances
-					// can interleave reads/writes and clobber updates. Serialization here
-					// is cheap (at most a handful of instances) and avoids the race.
-					const allInstances = ClineProvider.getAllInstances()
-					for (const instance of allInstances) {
-						try {
-							await instance.handleZooCodeCallback(token)
-						} catch (error) {
-							console.error(
-								"Failed to persist Zoo Gateway token for a provider instance:",
-								error instanceof Error ? error.message : error,
-							)
-						}
-					}
+					await propagateZooGatewayCallback(token)
 				}
 			}
 			break

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -57,11 +57,21 @@ vitest.mock("../fetchers/modelCache", () => ({
 }))
 
 const mockGetCachedZooCodeToken = vitest.hoisted(() => vitest.fn<() => string | undefined>(() => undefined))
+const mockSessionCleared = vitest.hoisted(() => ({ value: false }))
 
 vitest.mock("../../../services/zoo-code-auth", () => ({
 	getZooCodeBaseUrl: vitest.fn(() => "https://www.zoocode.dev"),
-	getCachedZooCodeToken: mockGetCachedZooCodeToken,
-	clearZooCodeToken: vitest.fn(async () => undefined),
+	getCachedZooCodeToken: () => mockGetCachedZooCodeToken() ?? "",
+	resolveZooGatewaySessionToken: (profileToken?: string) => {
+		const cached = mockGetCachedZooCodeToken()
+		if (cached) return cached
+		if (mockSessionCleared.value) return undefined
+		return profileToken
+	},
+	clearZooCodeToken: vitest.fn(async () => {
+		mockSessionCleared.value = true
+		mockGetCachedZooCodeToken.mockReturnValue(undefined)
+	}),
 }))
 
 vitest.mock("../../transform/caching/vercel-ai-gateway", () => ({
@@ -93,6 +103,7 @@ describe("ZooGatewayHandler", () => {
 
 	beforeEach(() => {
 		vitest.clearAllMocks()
+		mockSessionCleared.value = false
 		mockGetCachedZooCodeToken.mockReturnValue(undefined)
 		mockCreate.mockClear()
 		showErrorMessage.mockReset()
@@ -195,6 +206,13 @@ describe("ZooGatewayHandler", () => {
 	})
 
 	describe("createMessage", () => {
+		it("requires authentication at request time when no session token is available", async () => {
+			const handler = new ZooGatewayHandler({})
+			await expect(drainCreateMessage(handler)).rejects.toThrow(
+				"Zoo Gateway requires authentication. Please sign in to Zoo Code first.",
+			)
+		})
+
 		beforeEach(() => {
 			mockCreate.mockImplementation(async () => ({
 				[Symbol.asyncIterator]: async function* () {

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -56,9 +56,11 @@ vitest.mock("../fetchers/modelCache", () => ({
 	getModelsFromCache: vitest.fn().mockReturnValue(undefined),
 }))
 
+const mockGetCachedZooCodeToken = vitest.hoisted(() => vitest.fn<() => string | undefined>(() => undefined))
+
 vitest.mock("../../../services/zoo-code-auth", () => ({
 	getZooCodeBaseUrl: vitest.fn(() => "https://www.zoocode.dev"),
-	getCachedZooCodeToken: vitest.fn(() => undefined),
+	getCachedZooCodeToken: mockGetCachedZooCodeToken,
 	clearZooCodeToken: vitest.fn(async () => undefined),
 }))
 
@@ -91,6 +93,7 @@ describe("ZooGatewayHandler", () => {
 
 	beforeEach(() => {
 		vitest.clearAllMocks()
+		mockGetCachedZooCodeToken.mockReturnValue(undefined)
 		mockCreate.mockClear()
 		showErrorMessage.mockReset()
 		showErrorMessage.mockResolvedValue(undefined)
@@ -124,6 +127,21 @@ describe("ZooGatewayHandler", () => {
 			expect(OpenAI).toHaveBeenCalledWith(
 				expect.objectContaining({
 					apiKey: "not-provided",
+				}),
+			)
+		})
+
+		it("prefers the secret-storage cache over a persisted profile token", () => {
+			mockGetCachedZooCodeToken.mockReturnValue("zoo_ext_cached_token")
+
+			new ZooGatewayHandler({
+				zooSessionToken: "zoo_ext_stale_profile_token",
+				zooGatewayModelId: mockOptions.zooGatewayModelId,
+			})
+
+			expect(OpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiKey: "zoo_ext_cached_token",
 				}),
 			)
 		})

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -1,6 +1,19 @@
 // npx vitest run src/api/providers/__tests__/zoo-gateway.spec.ts
 
-vitest.mock("vscode", () => ({}))
+const { showErrorMessage, openExternal } = vitest.hoisted(() => ({
+	showErrorMessage: vitest.fn(async () => undefined as string | undefined),
+	openExternal: vitest.fn(async () => true),
+}))
+
+vitest.mock("vscode", () => ({
+	window: { showErrorMessage },
+	env: { openExternal, uriScheme: "vscode", appName: "VS Code" },
+	Uri: { parse: (value: string) => ({ toString: () => value }) },
+}))
+
+vitest.mock("../../../i18n", () => ({
+	t: (key: string) => key,
+}))
 
 import OpenAI from "openai"
 
@@ -9,6 +22,7 @@ import { zooGatewayDefaultModelId, ZOO_GATEWAY_DEFAULT_TEMPERATURE } from "@roo-
 import { ZooGatewayHandler } from "../zoo-gateway"
 import { ApiHandlerOptions } from "../../../shared/api"
 import { Package } from "../../../shared/package"
+import { clearZooCodeToken } from "../../../services/zoo-code-auth"
 
 vitest.mock("openai")
 vitest.mock("delay", () => ({ default: vitest.fn(() => Promise.resolve()) }))
@@ -78,8 +92,31 @@ describe("ZooGatewayHandler", () => {
 	beforeEach(() => {
 		vitest.clearAllMocks()
 		mockCreate.mockClear()
+		showErrorMessage.mockReset()
+		showErrorMessage.mockResolvedValue(undefined)
+		openExternal.mockReset()
+		openExternal.mockResolvedValue(true)
 		mockOpenAIClient()
 	})
+
+	function makeApiError(status: number, options: { code?: string; message?: string } = {}) {
+		const err = new Error(options.message ?? `HTTP ${status}`) as Error & {
+			status: number
+			code?: string
+		}
+		err.status = status
+		if (options.code) err.code = options.code
+		return err
+	}
+
+	async function drainCreateMessage(handler: ZooGatewayHandler) {
+		const stream = handler.createMessage("system", [{ role: "user", content: "hi" }])
+		const out: unknown[] = []
+		for await (const chunk of stream) {
+			out.push(chunk)
+		}
+		return out
+	}
 
 	describe("constructor", () => {
 		it("allows construction without a session token (auth is enforced at request time)", () => {
@@ -334,6 +371,114 @@ describe("ZooGatewayHandler", () => {
 			}))
 
 			await expect(handler.completePrompt("Test")).resolves.toBe("")
+		})
+	})
+
+	describe("surfaceGatewayApiError", () => {
+		it("clears the cached token and offers re-sign-in on 401", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(401)
+			})
+			showErrorMessage.mockResolvedValueOnce("common:zooAuth.buttons.sign_in")
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(clearZooCodeToken).toHaveBeenCalledTimes(1)
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				"common:zooAuth.errors.session_expired",
+				"common:zooAuth.buttons.sign_in",
+			)
+			expect(openExternal).toHaveBeenCalledTimes(1)
+		})
+
+		it("does not open a URL on 401 when the user dismisses the prompt", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(401)
+			})
+			showErrorMessage.mockResolvedValueOnce(undefined)
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(clearZooCodeToken).toHaveBeenCalledTimes(1)
+			expect(openExternal).not.toHaveBeenCalled()
+		})
+
+		it("prompts to add credits on 402", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(402)
+			})
+			showErrorMessage.mockResolvedValueOnce("common:zooAuth.buttons.add_credits")
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(clearZooCodeToken).not.toHaveBeenCalled()
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				"common:zooAuth.errors.out_of_credits",
+				"common:zooAuth.buttons.add_credits",
+			)
+			expect(openExternal).toHaveBeenCalledTimes(1)
+		})
+
+		it("shows the budget message on 429 with a budget code", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(429, { code: "monthly_budget_exceeded" })
+			})
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				"common:zooAuth.errors.budget_exceeded",
+				"common:zooAuth.buttons.add_credits",
+			)
+		})
+
+		it("does not surface a notification on 429 without a budget code", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(429, { code: "rate_limited" })
+			})
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(showErrorMessage).not.toHaveBeenCalled()
+		})
+
+		it("offers contact support on 403", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(403)
+			})
+			showErrorMessage.mockResolvedValueOnce("common:zooAuth.buttons.contact_support")
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow()
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				"common:zooAuth.errors.account_unavailable",
+				"common:zooAuth.buttons.contact_support",
+			)
+			expect(openExternal).toHaveBeenCalledTimes(1)
+		})
+
+		it("ignores errors without an HTTP status", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw new Error("network down")
+			})
+
+			await expect(drainCreateMessage(handler)).rejects.toThrow("network down")
+			expect(showErrorMessage).not.toHaveBeenCalled()
+			expect(clearZooCodeToken).not.toHaveBeenCalled()
+		})
+
+		it("surfaces the gateway error then wraps the message in completePrompt", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(() => {
+				throw makeApiError(402, { message: "out of credits" })
+			})
+
+			await expect(handler.completePrompt("ping")).rejects.toThrow("Zoo Gateway completion error: out of credits")
+			expect(showErrorMessage).toHaveBeenCalledWith(
+				"common:zooAuth.errors.out_of_credits",
+				"common:zooAuth.buttons.add_credits",
+			)
 		})
 	})
 })

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -19,7 +19,7 @@ import OpenAI from "openai"
 
 import { zooGatewayDefaultModelId, ZOO_GATEWAY_DEFAULT_TEMPERATURE } from "@roo-code/types"
 
-import { ZooGatewayHandler } from "../zoo-gateway"
+import { ZooGatewayHandler, classifyGatewayApiError } from "../zoo-gateway"
 import { ApiHandlerOptions } from "../../../shared/api"
 import { Package } from "../../../shared/package"
 import { clearZooCodeToken } from "../../../services/zoo-code-auth"
@@ -407,6 +407,39 @@ describe("ZooGatewayHandler", () => {
 			}))
 
 			await expect(handler.completePrompt("Test")).resolves.toBe("")
+		})
+	})
+
+	describe("classifyGatewayApiError", () => {
+		it("returns sign_in on 401", () => {
+			expect(classifyGatewayApiError(makeApiError(401))).toEqual({ kind: "sign_in" })
+		})
+
+		it("returns add_credits (not budget) on 402", () => {
+			expect(classifyGatewayApiError(makeApiError(402))).toEqual({ kind: "add_credits", budgetExceeded: false })
+		})
+
+		it("returns add_credits with budgetExceeded on 429 budget codes", () => {
+			expect(classifyGatewayApiError(makeApiError(429, { code: "monthly_budget_exceeded" }))).toEqual({
+				kind: "add_credits",
+				budgetExceeded: true,
+			})
+			expect(classifyGatewayApiError(makeApiError(429, { code: "daily_budget_exceeded" }))).toEqual({
+				kind: "add_credits",
+				budgetExceeded: true,
+			})
+		})
+
+		it("returns none on 429 without a budget code", () => {
+			expect(classifyGatewayApiError(makeApiError(429, { code: "rate_limited" }))).toEqual({ kind: "none" })
+		})
+
+		it("returns contact_support on 403", () => {
+			expect(classifyGatewayApiError(makeApiError(403))).toEqual({ kind: "contact_support" })
+		})
+
+		it("returns none for errors without an HTTP status", () => {
+			expect(classifyGatewayApiError(new Error("network down"))).toEqual({ kind: "none" })
 		})
 	})
 

--- a/src/api/providers/fetchers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/fetchers/__tests__/zoo-gateway.spec.ts
@@ -8,6 +8,7 @@ vitest.mock("axios")
 vitest.mock("../../../../services/zoo-code-auth", () => ({
 	getCachedZooCodeToken: vitest.fn(() => ""),
 	getZooCodeBaseUrl: vitest.fn(() => "https://example.test"),
+	resolveZooGatewaySessionToken: vitest.fn((profileToken?: string) => profileToken || undefined),
 }))
 const mockedAxios = axios as any
 

--- a/src/api/providers/fetchers/zoo-gateway.ts
+++ b/src/api/providers/fetchers/zoo-gateway.ts
@@ -3,7 +3,7 @@ import axios from "axios"
 import type { ModelInfo } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../../shared/api"
-import { getCachedZooCodeToken, getZooCodeBaseUrl } from "../../../services/zoo-code-auth"
+import { getZooCodeBaseUrl, resolveZooGatewaySessionToken } from "../../../services/zoo-code-auth"
 
 import {
 	type VercelAiGatewayModel,
@@ -24,9 +24,7 @@ export async function getZooGatewayModels(options?: ApiHandlerOptions): Promise<
 	const models: Record<string, ModelInfo> = {}
 	const baseURL = options?.zooGatewayBaseUrl ?? `${getZooCodeBaseUrl()}/api/gateway/v1`
 
-	// Build headers - Zoo Gateway requires authentication via the zoo_ext_ session token.
-	// Fall back to the secret-storage cache when the profile hasn't been seeded yet.
-	const sessionToken = options?.zooSessionToken || getCachedZooCodeToken()
+	const sessionToken = resolveZooGatewaySessionToken(options?.zooSessionToken)
 	const headers: Record<string, string> = {}
 	if (sessionToken) {
 		headers["Authorization"] = `Bearer ${sessionToken}`

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode"
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 
@@ -9,8 +10,9 @@ import {
 } from "@roo-code/types"
 
 import { ApiHandlerOptions } from "../../shared/api"
-import { getCachedZooCodeToken, getZooCodeBaseUrl } from "../../services/zoo-code-auth"
+import { clearZooCodeToken, getCachedZooCodeToken, getZooCodeBaseUrl } from "../../services/zoo-code-auth"
 import { Package } from "../../shared/package"
+import { t } from "../../i18n"
 
 import { ApiStream } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -18,6 +20,74 @@ import { addCacheBreakpoints } from "../transform/caching/vercel-ai-gateway"
 
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { RouterProvider } from "./router-provider"
+
+function getApiErrorStatus(error: unknown): number | undefined {
+	if (typeof error === "object" && error !== null && "status" in error) {
+		const status = (error as { status: unknown }).status
+		if (typeof status === "number") return status
+	}
+	return undefined
+}
+
+function getApiErrorCode(error: unknown): string | undefined {
+	const err = error as { code?: unknown; error?: { code?: unknown } } | null
+	if (!err) return undefined
+	if (typeof err.code === "string") return err.code
+	if (typeof err.error?.code === "string") return err.error.code
+	return undefined
+}
+
+function buildZooCodeSignInUrl(): string {
+	const callbackUri = encodeURIComponent(
+		`${vscode.env.uriScheme}://${Package.publisher}.${Package.name}/auth-callback`,
+	)
+	const device = encodeURIComponent(vscode.env.appName || "VS Code")
+	const editor = encodeURIComponent("VS Code")
+	return `${getZooCodeBaseUrl()}/dashboard/connect?device=${device}&editor=${editor}&version=${Package.version}&callback_uri=${callbackUri}`
+}
+
+// Caller must always rethrow — this only surfaces UX, never swallows.
+async function surfaceGatewayApiError(error: unknown): Promise<void> {
+	const status = getApiErrorStatus(error)
+	if (status === undefined) return
+	const code = getApiErrorCode(error)
+
+	if (status === 401) {
+		// Wipe before sign-in so the callback rebinds against an empty slot.
+		await clearZooCodeToken()
+		const action = await vscode.window.showErrorMessage(
+			t("common:zooAuth.errors.session_expired"),
+			t("common:zooAuth.buttons.sign_in"),
+		)
+		if (action) {
+			void vscode.env.openExternal(vscode.Uri.parse(buildZooCodeSignInUrl()))
+		}
+		return
+	}
+
+	const isBudgetExceeded = status === 429 && (code === "monthly_budget_exceeded" || code === "daily_budget_exceeded")
+	if (status === 402 || isBudgetExceeded) {
+		const message = isBudgetExceeded
+			? t("common:zooAuth.errors.budget_exceeded")
+			: t("common:zooAuth.errors.out_of_credits")
+		const action = await vscode.window.showErrorMessage(message, t("common:zooAuth.buttons.add_credits"))
+		if (action) {
+			void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/dashboard/credits`))
+		}
+		return
+	}
+
+	if (status === 403) {
+		const action = await vscode.window.showErrorMessage(
+			t("common:zooAuth.errors.account_unavailable"),
+			t("common:zooAuth.buttons.contact_support"),
+		)
+		if (action) {
+			void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/support`))
+		}
+		return
+	}
+}
 
 // Extend OpenAI's CompletionUsage to include Zoo Gateway specific fields (same as Vercel AI Gateway)
 interface ZooGatewayUsage extends OpenAI.CompletionUsage {
@@ -107,43 +177,48 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 			parallel_tool_calls: metadata?.parallelToolCalls ?? true,
 		}
 
-		const completion = await this.client.chat.completions.create(body, {
-			headers: requestHeaders,
-		})
+		try {
+			const completion = await this.client.chat.completions.create(body, {
+				headers: requestHeaders,
+			})
 
-		for await (const chunk of completion) {
-			const delta = chunk.choices[0]?.delta
-			if (delta?.content) {
-				yield {
-					type: "text",
-					text: delta.content,
-				}
-			}
-
-			// Emit raw tool call chunks - NativeToolCallParser handles state management
-			if (delta?.tool_calls) {
-				for (const toolCall of delta.tool_calls) {
+			for await (const chunk of completion) {
+				const delta = chunk.choices[0]?.delta
+				if (delta?.content) {
 					yield {
-						type: "tool_call_partial",
-						index: toolCall.index,
-						id: toolCall.id,
-						name: toolCall.function?.name,
-						arguments: toolCall.function?.arguments,
+						type: "text",
+						text: delta.content,
+					}
+				}
+
+				// Emit raw tool call chunks - NativeToolCallParser handles state management
+				if (delta?.tool_calls) {
+					for (const toolCall of delta.tool_calls) {
+						yield {
+							type: "tool_call_partial",
+							index: toolCall.index,
+							id: toolCall.id,
+							name: toolCall.function?.name,
+							arguments: toolCall.function?.arguments,
+						}
+					}
+				}
+
+				if (chunk.usage) {
+					const usage = chunk.usage as ZooGatewayUsage
+					yield {
+						type: "usage",
+						inputTokens: usage.prompt_tokens || 0,
+						outputTokens: usage.completion_tokens || 0,
+						cacheWriteTokens: usage.cache_creation_input_tokens || undefined,
+						cacheReadTokens: usage.prompt_tokens_details?.cached_tokens || undefined,
+						totalCost: usage.cost ?? 0,
 					}
 				}
 			}
-
-			if (chunk.usage) {
-				const usage = chunk.usage as ZooGatewayUsage
-				yield {
-					type: "usage",
-					inputTokens: usage.prompt_tokens || 0,
-					outputTokens: usage.completion_tokens || 0,
-					cacheWriteTokens: usage.cache_creation_input_tokens || undefined,
-					cacheReadTokens: usage.prompt_tokens_details?.cached_tokens || undefined,
-					totalCost: usage.cost ?? 0,
-				}
-			}
+		} catch (error) {
+			void surfaceGatewayApiError(error)
+			throw error
 		}
 	}
 
@@ -168,6 +243,7 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 			const response = await this.client.chat.completions.create(requestOptions)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
+			void surfaceGatewayApiError(error)
 			if (error instanceof Error) {
 				throw new Error(`Zoo Gateway completion error: ${error.message}`)
 			}

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -10,7 +10,7 @@ import {
 } from "@roo-code/types"
 
 import { ApiHandlerOptions } from "../../shared/api"
-import { clearZooCodeToken, getCachedZooCodeToken, getZooCodeBaseUrl } from "../../services/zoo-code-auth"
+import { clearZooCodeToken, getZooCodeBaseUrl, resolveZooGatewaySessionToken } from "../../services/zoo-code-auth"
 import { Package } from "../../shared/package"
 import { t } from "../../i18n"
 
@@ -101,9 +101,7 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 	constructor(options: ApiHandlerOptions) {
 		const baseURL = options.zooGatewayBaseUrl ?? `${getZooCodeBaseUrl()}/api/gateway/v1`
 
-		// Prefer the secret-storage cache so a 401 clear takes effect immediately; fall back
-		// to the profile-persisted token when the user is signed in but seeding hasn't run yet.
-		const sessionToken = getCachedZooCodeToken() || options.zooSessionToken
+		const sessionToken = resolveZooGatewaySessionToken(options.zooSessionToken)
 
 		// Merge Zoo-specific enrichment headers into openAiHeaders so they flow through
 		// the parent's single OpenAI client. We avoid reassigning `this.client` (which
@@ -128,8 +126,7 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 	}
 
 	private ensureAuthenticated(): void {
-		const sessionToken = getCachedZooCodeToken() || this.options.zooSessionToken
-		if (!sessionToken) {
+		if (!resolveZooGatewaySessionToken(this.options.zooSessionToken)) {
 			throw new Error(ZOO_GATEWAY_AUTH_ERROR)
 		}
 	}
@@ -217,12 +214,14 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 				}
 			}
 		} catch (error) {
-			void surfaceGatewayApiError(error).catch((surfaceError) => {
+			try {
+				await surfaceGatewayApiError(error)
+			} catch (surfaceError) {
 				console.error(
 					"Failed to surface Zoo Gateway error:",
 					surfaceError instanceof Error ? surfaceError.message : surfaceError,
 				)
-			})
+			}
 			throw error
 		}
 	}
@@ -248,12 +247,14 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 			const response = await this.client.chat.completions.create(requestOptions)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
-			void surfaceGatewayApiError(error).catch((surfaceError) => {
+			try {
+				await surfaceGatewayApiError(error)
+			} catch (surfaceError) {
 				console.error(
 					"Failed to surface Zoo Gateway error:",
 					surfaceError instanceof Error ? surfaceError.message : surfaceError,
 				)
-			})
+			}
 			if (error instanceof Error) {
 				throw new Error(`Zoo Gateway completion error: ${error.message}`)
 			}

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -217,7 +217,12 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 				}
 			}
 		} catch (error) {
-			void surfaceGatewayApiError(error)
+			void surfaceGatewayApiError(error).catch((surfaceError) => {
+				console.error(
+					"Failed to surface Zoo Gateway error:",
+					surfaceError instanceof Error ? surfaceError.message : surfaceError,
+				)
+			})
 			throw error
 		}
 	}
@@ -243,7 +248,12 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 			const response = await this.client.chat.completions.create(requestOptions)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
-			void surfaceGatewayApiError(error)
+			void surfaceGatewayApiError(error).catch((surfaceError) => {
+				console.error(
+					"Failed to surface Zoo Gateway error:",
+					surfaceError instanceof Error ? surfaceError.message : surfaceError,
+				)
+			})
 			if (error instanceof Error) {
 				throw new Error(`Zoo Gateway completion error: ${error.message}`)
 			}

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -46,46 +46,75 @@ function buildZooCodeSignInUrl(): string {
 	return `${getZooCodeBaseUrl()}/dashboard/connect?device=${device}&editor=${editor}&version=${Package.version}&callback_uri=${callbackUri}`
 }
 
-// Caller must always rethrow — this only surfaces UX, never swallows.
-async function surfaceGatewayApiError(error: unknown): Promise<void> {
+type ZooGatewayApiErrorAction =
+	| { kind: "sign_in" }
+	| { kind: "add_credits"; budgetExceeded: boolean }
+	| { kind: "contact_support" }
+	| { kind: "none" }
+
+// Pure mapping from an API error to the UX action it warrants. No side effects,
+// so this is trivial to unit test independently of the VS Code notification flow.
+// Exported for unit tests.
+export function classifyGatewayApiError(error: unknown): ZooGatewayApiErrorAction {
 	const status = getApiErrorStatus(error)
-	if (status === undefined) return
+	if (status === undefined) return { kind: "none" }
 	const code = getApiErrorCode(error)
 
 	if (status === 401) {
-		// Wipe before sign-in so the callback rebinds against an empty slot.
-		await clearZooCodeToken()
-		const action = await vscode.window.showErrorMessage(
-			t("common:zooAuth.errors.session_expired"),
-			t("common:zooAuth.buttons.sign_in"),
-		)
-		if (action) {
-			void vscode.env.openExternal(vscode.Uri.parse(buildZooCodeSignInUrl()))
-		}
-		return
+		return { kind: "sign_in" }
 	}
 
 	const isBudgetExceeded = status === 429 && (code === "monthly_budget_exceeded" || code === "daily_budget_exceeded")
 	if (status === 402 || isBudgetExceeded) {
-		const message = isBudgetExceeded
-			? t("common:zooAuth.errors.budget_exceeded")
-			: t("common:zooAuth.errors.out_of_credits")
-		const action = await vscode.window.showErrorMessage(message, t("common:zooAuth.buttons.add_credits"))
-		if (action) {
-			void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/dashboard/credits`))
-		}
-		return
+		return { kind: "add_credits", budgetExceeded: isBudgetExceeded }
 	}
 
 	if (status === 403) {
-		const action = await vscode.window.showErrorMessage(
-			t("common:zooAuth.errors.account_unavailable"),
-			t("common:zooAuth.buttons.contact_support"),
-		)
-		if (action) {
-			void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/support`))
+		return { kind: "contact_support" }
+	}
+
+	return { kind: "none" }
+}
+
+// Caller must always rethrow — this only surfaces UX, never swallows.
+async function surfaceGatewayApiError(error: unknown): Promise<void> {
+	const action = classifyGatewayApiError(error)
+
+	switch (action.kind) {
+		case "sign_in": {
+			// Wipe before sign-in so the callback rebinds against an empty slot.
+			await clearZooCodeToken()
+			const clicked = await vscode.window.showErrorMessage(
+				t("common:zooAuth.errors.session_expired"),
+				t("common:zooAuth.buttons.sign_in"),
+			)
+			if (clicked) {
+				void vscode.env.openExternal(vscode.Uri.parse(buildZooCodeSignInUrl()))
+			}
+			return
 		}
-		return
+		case "add_credits": {
+			const message = action.budgetExceeded
+				? t("common:zooAuth.errors.budget_exceeded")
+				: t("common:zooAuth.errors.out_of_credits")
+			const clicked = await vscode.window.showErrorMessage(message, t("common:zooAuth.buttons.add_credits"))
+			if (clicked) {
+				void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/dashboard/credits`))
+			}
+			return
+		}
+		case "contact_support": {
+			const clicked = await vscode.window.showErrorMessage(
+				t("common:zooAuth.errors.account_unavailable"),
+				t("common:zooAuth.buttons.contact_support"),
+			)
+			if (clicked) {
+				void vscode.env.openExternal(vscode.Uri.parse(`${getZooCodeBaseUrl()}/support`))
+			}
+			return
+		}
+		default:
+			return
 	}
 }
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -655,6 +655,10 @@ export class ClineProvider
 		return findLast(Array.from(this.activeInstances), (instance) => instance.view?.visible === true)
 	}
 
+	public static getAllInstances(): ClineProvider[] {
+		return Array.from(this.activeInstances)
+	}
+
 	public static async getInstance(): Promise<ClineProvider | undefined> {
 		let visibleProvider = ClineProvider.getVisibleInstance()
 
@@ -886,6 +890,64 @@ export class ClineProvider
 		if (!currentTask || currentTask.abandoned || currentTask.abort) {
 			await this.removeClineFromStack()
 		}
+
+		// Ensure zoo-gateway profile is seeded for users who signed in before this feature existed.
+		// Without this, users with a valid cached token but no zoo-gateway profile would need to
+		// re-authenticate to use Zoo Gateway. Fire-and-forget to avoid blocking webview init.
+		void this.ensureZooGatewayProfileSeeded().catch((err) => {
+			this.log(`[ensureZooGatewayProfileSeeded] Error: ${err instanceof Error ? err.message : String(err)}`)
+		})
+	}
+
+	/**
+	 * Seeds the zoo-gateway provider profile for users who have a cached auth token
+	 * but no profile (e.g., users who signed in before Zoo Gateway was added), or
+	 * who have an empty/imported profile without a token.
+	 * Called once per webview init; handleZooCodeCallback is idempotent so repeated calls are safe.
+	 */
+	private async ensureZooGatewayProfileSeeded(): Promise<void> {
+		const { getCachedZooCodeToken } = await import("../../services/zoo-code-auth")
+		const token = getCachedZooCodeToken()
+		if (!token) return
+
+		// Check ALL zoo-gateway profiles — only skip seeding if every profile has the current token.
+		// Using .find() would miss stale tokens in duplicate/renamed profiles since handleZooCodeCallback
+		// uses .filter() and updates all of them — the early-return guard must match.
+		const allProfiles = await this.providerSettingsManager.listConfig()
+		const zooGatewayProfiles = allProfiles.filter((p) => p.apiProvider === "zoo-gateway")
+
+		if (zooGatewayProfiles.length === 0) {
+			this.log("[ensureZooGatewayProfileSeeded] No zoo-gateway profile found, creating one")
+		} else {
+			let allUpToDate = true
+
+			for (const entry of zooGatewayProfiles) {
+				try {
+					const fullProfile = await this.providerSettingsManager.getProfile({ name: entry.name })
+					if (fullProfile.zooSessionToken !== token) {
+						allUpToDate = false
+						this.log(
+							fullProfile.zooSessionToken
+								? "[ensureZooGatewayProfileSeeded] Token mismatch (stale session?), updating with current token"
+								: "[ensureZooGatewayProfileSeeded] Existing zoo-gateway profile has no token, updating with cached token",
+						)
+						break
+					}
+				} catch {
+					allUpToDate = false
+					this.log("[ensureZooGatewayProfileSeeded] Failed to read existing profile, will re-seed")
+					break
+				}
+			}
+
+			if (allUpToDate) {
+				// All profiles have the current token — nothing to do
+				return
+			}
+		}
+
+		// User has token but either no profile, some profiles without token, or stale tokens — seed all
+		await this.handleZooCodeCallback(token)
 	}
 
 	public async createTaskWithHistoryItem(
@@ -1676,12 +1738,80 @@ export class ClineProvider
 		await this.upsertProviderProfile(currentApiConfigName, newConfiguration)
 	}
 
-	// Zoo Code Auth (for observability telemetry)
+	// Zoo Code Auth
 
-	async handleZooCodeCallback(_token: string) {
+	async handleZooCodeCallback(token: string) {
 		// Auth mutation (token storage, subscription check, success toast) was already
 		// performed by handleAuthCallback() in handleUri.ts before this method was called.
-		// This method only needs to refresh the webview state to reflect the new auth status.
+		// Save the zoo-gateway provider profile with the session token so that
+		// ZooGatewayHandler can authenticate without any manual user input.
+		//
+		// activate: true ONLY if Zoo Gateway is already the active profile — this pushes
+		// the new token to the in-memory handler so the current task picks it up immediately.
+		// Otherwise activate: false — do NOT switch providers mid-conversation. The user
+		// must explicitly select Zoo Gateway in settings if they want to use it.
+		try {
+			const { apiConfiguration } = await this.getState()
+			const currentSettings = this.contextProxy.getProviderSettings()
+			const currentApiConfigName = this.contextProxy.getValues().currentApiConfigName
+
+			// Derive the gateway base URL from ZOO_CODE_BASE_URL so that non-prod environments
+			// (staging, local dev) route completions to the correct backend instead of always
+			// hard-coding production. An already-set value in the profile is NOT preserved here —
+			// it must always align with the auth server the user just authenticated against.
+			const { getZooCodeBaseUrl } = await import("../../services/zoo-code-auth")
+			const derivedGatewayBaseUrl = `${getZooCodeBaseUrl()}/api/gateway/v1`
+
+			// Check if Zoo Gateway is the currently active profile by apiProvider identity,
+			// not by profile name (profile names are user-renameable).
+			const isZooGatewayActive = currentSettings.apiProvider === "zoo-gateway"
+
+			// Always scan ALL profiles and update every zoo-gateway profile with the new token.
+			// This ensures renamed profiles, duplicate profiles, and inactive profiles all stay
+			// in sync. The model lookup in requestRouterModels uses .find() which returns the
+			// first zoo-gateway profile it finds — if that profile has a stale token, requests fail.
+			const allProfiles = await this.providerSettingsManager.listConfig()
+			const zooProfiles = allProfiles.filter((p) => p.apiProvider === "zoo-gateway")
+
+			if (zooProfiles.length === 0) {
+				// No existing zoo-gateway profile — create the canonical default.
+				const newConfiguration: ProviderSettings = {
+					apiProvider: "zoo-gateway",
+					zooSessionToken: token,
+					zooGatewayModelId: apiConfiguration.zooGatewayModelId,
+					zooGatewayBaseUrl: derivedGatewayBaseUrl,
+				}
+				// Activate only if zoo-gateway was the active provider (shouldn't happen if
+				// no profiles exist, but defensive).
+				await this.upsertProviderProfile("Zoo Gateway", newConfiguration, isZooGatewayActive)
+			} else {
+				// Update every existing zoo-gateway profile with the new token and the
+				// derived base URL so that environment-specific routing stays consistent.
+				for (const entry of zooProfiles) {
+					const isActiveProfile = isZooGatewayActive && entry.name === currentApiConfigName
+					const existing = await this.providerSettingsManager.getProfile({ name: entry.name })
+					const updated: ProviderSettings = {
+						...existing,
+						zooSessionToken: token,
+						zooGatewayBaseUrl: derivedGatewayBaseUrl,
+					}
+					if (isActiveProfile) {
+						// Use upsertProviderProfile with activate: true so the in-memory handler
+						// picks up the new token immediately for the current task.
+						await this.upsertProviderProfile(entry.name, updated, true)
+					} else {
+						// Non-active profiles just need the token saved to disk.
+						await this.providerSettingsManager.saveConfig(entry.name, updated)
+					}
+				}
+			}
+		} catch (error) {
+			this.log(
+				`[handleZooCodeCallback] Failed to save zoo-gateway profile: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			)
+		}
 		await this.postStateToWebview()
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -906,9 +906,10 @@ export class ClineProvider
 	 * Called once per webview init; handleZooCodeCallback is idempotent so repeated calls are safe.
 	 */
 	private async ensureZooGatewayProfileSeeded(): Promise<void> {
-		const { getCachedZooCodeToken } = await import("../../services/zoo-code-auth")
+		const { getCachedZooCodeToken, getZooCodeBaseUrl } = await import("../../services/zoo-code-auth")
 		const token = getCachedZooCodeToken()
 		if (!token) return
+		const expectedGatewayBaseUrl = `${getZooCodeBaseUrl()}/api/gateway/v1`
 
 		// Check ALL zoo-gateway profiles — only skip seeding if every profile has the current token.
 		// Using .find() would miss stale tokens in duplicate/renamed profiles since handleZooCodeCallback
@@ -924,13 +925,12 @@ export class ClineProvider
 			for (const entry of zooGatewayProfiles) {
 				try {
 					const fullProfile = await this.providerSettingsManager.getProfile({ name: entry.name })
-					if (fullProfile.zooSessionToken !== token) {
+					if (
+						fullProfile.zooSessionToken !== token ||
+						fullProfile.zooGatewayBaseUrl !== expectedGatewayBaseUrl
+					) {
 						allUpToDate = false
-						this.log(
-							fullProfile.zooSessionToken
-								? "[ensureZooGatewayProfileSeeded] Token mismatch (stale session?), updating with current token"
-								: "[ensureZooGatewayProfileSeeded] Existing zoo-gateway profile has no token, updating with cached token",
-						)
+						this.log("[ensureZooGatewayProfileSeeded] Existing zoo-gateway profile is stale, updating")
 						break
 					}
 				} catch {

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -230,6 +230,14 @@ vi.mock("../../../api/providers/fetchers/modelCache", () => ({
 	getModelsFromCache: vi.fn().mockReturnValue(undefined),
 }))
 
+vi.mock("../../../services/zoo-code-auth", () => ({
+	getZooCodeBaseUrl: vi.fn(() => "https://www.zoocode.dev"),
+	getCachedZooCodeToken: vi.fn(),
+	handleAuthCallback: vi.fn(),
+	setZooCodeUserInfo: vi.fn(),
+	disconnectZooCode: vi.fn(),
+}))
+
 vi.mock("../../../shared/modes", () => ({
 	modes: [
 		{
@@ -3662,6 +3670,153 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 
 			// Restore the spy
 			vi.mocked(fsUtils.fileExistsAtPath).mockRestore()
+		})
+	})
+
+	describe("Zoo Code auth profile sync", () => {
+		beforeEach(async () => {
+			const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
+			vi.mocked(getCachedZooCodeToken).mockReturnValue("")
+		})
+
+		describe("handleZooCodeCallback", () => {
+			it("creates a Zoo Gateway profile when none exists", async () => {
+				vi.spyOn(provider, "getState").mockResolvedValue({
+					apiConfiguration: { zooGatewayModelId: "anthropic/claude-sonnet-4" },
+				} as any)
+				vi.spyOn(provider.contextProxy, "getProviderSettings").mockReturnValue({
+					apiProvider: "anthropic",
+				} as any)
+				vi.spyOn(provider.contextProxy, "getValues").mockReturnValue({
+					currentApiConfigName: "Anthropic",
+				} as any)
+				const upsertSpy = vi.spyOn(provider, "upsertProviderProfile").mockResolvedValue("profile-id")
+				vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([]),
+				}
+
+				await provider.handleZooCodeCallback("zoo_ext_token")
+
+				expect(upsertSpy).toHaveBeenCalledWith(
+					"Zoo Gateway",
+					expect.objectContaining({
+						apiProvider: "zoo-gateway",
+						zooSessionToken: "zoo_ext_token",
+						zooGatewayBaseUrl: "https://www.zoocode.dev/api/gateway/v1",
+					}),
+					false,
+				)
+			})
+
+			it("updates every zoo-gateway profile and activates only the active one", async () => {
+				vi.spyOn(provider, "getState").mockResolvedValue({
+					apiConfiguration: { zooGatewayModelId: "anthropic/claude-sonnet-4" },
+				} as any)
+				vi.spyOn(provider.contextProxy, "getProviderSettings").mockReturnValue({
+					apiProvider: "zoo-gateway",
+				} as any)
+				vi.spyOn(provider.contextProxy, "getValues").mockReturnValue({
+					currentApiConfigName: "Zoo Gateway",
+				} as any)
+				const upsertSpy = vi.spyOn(provider, "upsertProviderProfile").mockResolvedValue("profile-id")
+				const saveConfig = vi.fn().mockResolvedValue(undefined)
+				vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([
+						{ name: "Zoo Gateway", apiProvider: "zoo-gateway" },
+						{ name: "Backup Zoo", apiProvider: "zoo-gateway" },
+					]),
+					getProfile: vi
+						.fn()
+						.mockResolvedValueOnce({
+							apiProvider: "zoo-gateway",
+							zooSessionToken: "old-token",
+							zooGatewayBaseUrl: "https://old.example/api/gateway/v1",
+						})
+						.mockResolvedValueOnce({
+							apiProvider: "zoo-gateway",
+							zooSessionToken: "old-token",
+						}),
+					saveConfig,
+				}
+
+				await provider.handleZooCodeCallback("new-token")
+
+				expect(upsertSpy).toHaveBeenCalledWith(
+					"Zoo Gateway",
+					expect.objectContaining({
+						zooSessionToken: "new-token",
+						zooGatewayBaseUrl: "https://www.zoocode.dev/api/gateway/v1",
+					}),
+					true,
+				)
+				expect(saveConfig).toHaveBeenCalledWith(
+					"Backup Zoo",
+					expect.objectContaining({
+						zooSessionToken: "new-token",
+						zooGatewayBaseUrl: "https://www.zoocode.dev/api/gateway/v1",
+					}),
+				)
+			})
+
+			it("logs and posts state when profile persistence fails", async () => {
+				vi.spyOn(provider, "getState").mockRejectedValue(new Error("state unavailable"))
+				vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([]),
+				}
+
+				await provider.handleZooCodeCallback("zoo_ext_token")
+
+				expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+					expect.stringContaining("[handleZooCodeCallback] Failed to save zoo-gateway profile"),
+				)
+			})
+		})
+
+		describe("ensureZooGatewayProfileSeeded", () => {
+			it("does nothing when no cached auth token exists", async () => {
+				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
+
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn(),
+				}
+
+				await (provider as any).ensureZooGatewayProfileSeeded()
+
+				expect(handleSpy).not.toHaveBeenCalled()
+			})
+
+			it("skips seeding when every zoo-gateway profile already has the current token", async () => {
+				const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
+				vi.mocked(getCachedZooCodeToken).mockReturnValue("current-token")
+				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
+
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
+					getProfile: vi.fn().mockResolvedValue({ zooSessionToken: "current-token" }),
+				}
+
+				await (provider as any).ensureZooGatewayProfileSeeded()
+
+				expect(handleSpy).not.toHaveBeenCalled()
+			})
+
+			it("re-seeds when any zoo-gateway profile has a stale or missing token", async () => {
+				const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
+				vi.mocked(getCachedZooCodeToken).mockReturnValue("fresh-token")
+				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
+
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
+					getProfile: vi.fn().mockResolvedValue({ zooSessionToken: "stale-token" }),
+				}
+
+				await (provider as any).ensureZooGatewayProfileSeeded()
+
+				expect(handleSpy).toHaveBeenCalledWith("fresh-token")
+			})
 		})
 	})
 })

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -3788,14 +3788,17 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 				expect(handleSpy).not.toHaveBeenCalled()
 			})
 
-			it("skips seeding when every zoo-gateway profile already has the current token", async () => {
+			it("skips seeding when every zoo-gateway profile already has the current token and base URL", async () => {
 				const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
 				vi.mocked(getCachedZooCodeToken).mockReturnValue("current-token")
 				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
 
 				;(provider as any).providerSettingsManager = {
 					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
-					getProfile: vi.fn().mockResolvedValue({ zooSessionToken: "current-token" }),
+					getProfile: vi.fn().mockResolvedValue({
+						zooSessionToken: "current-token",
+						zooGatewayBaseUrl: "https://www.zoocode.dev/api/gateway/v1",
+					}),
 				}
 
 				await (provider as any).ensureZooGatewayProfileSeeded()
@@ -3810,12 +3813,33 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 
 				;(provider as any).providerSettingsManager = {
 					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
-					getProfile: vi.fn().mockResolvedValue({ zooSessionToken: "stale-token" }),
+					getProfile: vi.fn().mockResolvedValue({
+						zooSessionToken: "stale-token",
+						zooGatewayBaseUrl: "https://www.zoocode.dev/api/gateway/v1",
+					}),
 				}
 
 				await (provider as any).ensureZooGatewayProfileSeeded()
 
 				expect(handleSpy).toHaveBeenCalledWith("fresh-token")
+			})
+
+			it("re-seeds when any zoo-gateway profile has a stale base URL", async () => {
+				const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
+				vi.mocked(getCachedZooCodeToken).mockReturnValue("current-token")
+				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
+
+				;(provider as any).providerSettingsManager = {
+					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
+					getProfile: vi.fn().mockResolvedValue({
+						zooSessionToken: "current-token",
+						zooGatewayBaseUrl: "https://staging.zoocode.dev/api/gateway/v1",
+					}),
+				}
+
+				await (provider as any).ensureZooGatewayProfileSeeded()
+
+				expect(handleSpy).toHaveBeenCalledWith("current-token")
 			})
 		})
 	})

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -2473,11 +2473,11 @@ describe("ClineProvider - Router Models", () => {
 				openrouter: mockModels,
 				requesty: mockModels,
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				litellm: mockModels,
 				ollama: {},
 				lmstudio: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},
@@ -2510,6 +2510,7 @@ describe("ClineProvider - Router Models", () => {
 			.mockRejectedValueOnce(new Error("Requesty API error")) // requesty fail
 			.mockResolvedValueOnce(mockModels) // unbound success
 			.mockResolvedValueOnce(mockModels) // vercel-ai-gateway success
+			.mockResolvedValueOnce(mockModels) // zoo-gateway success
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm fail
 
 		await messageHandler({ type: "requestRouterModels" })
@@ -2521,11 +2522,11 @@ describe("ClineProvider - Router Models", () => {
 				openrouter: mockModels,
 				requesty: {},
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				ollama: {},
 				lmstudio: {},
 				litellm: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},
@@ -2618,11 +2619,11 @@ describe("ClineProvider - Router Models", () => {
 				openrouter: mockModels,
 				requesty: mockModels,
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				litellm: {},
 				ollama: {},
 				lmstudio: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -3772,6 +3772,8 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 				expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
 					expect.stringContaining("[handleZooCodeCallback] Failed to save zoo-gateway profile"),
 				)
+				// State must still be refreshed even when profile persistence fails.
+				expect(provider.postStateToWebview).toHaveBeenCalled()
 			})
 		})
 

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -381,58 +381,6 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 		})
 	})
 
-	it("recovers zoo-gateway credentials from a separate profile when not the active provider", async () => {
-		// Regression: when zoo-gateway is NOT the active provider, the active apiConfiguration
-		// will not contain zooSessionToken / zooGatewayBaseUrl. The aggregate model fetcher must
-		// fall back to scanning providerSettingsManager profiles for a zoo-gateway entry so the
-		// model picker still populates.
-		mockClineProvider.getState = vi.fn().mockResolvedValue({
-			apiConfiguration: {
-				// Active provider is anthropic (or anything other than zoo-gateway).
-				apiProvider: "anthropic",
-				openRouterApiKey: "openrouter-key",
-				requestyApiKey: "requesty-key",
-				// No zooSessionToken / zooGatewayBaseUrl on the active config.
-			},
-		})
-		;(mockClineProvider as any).providerSettingsManager = {
-			listConfig: vi.fn().mockResolvedValue([
-				{ name: "Anthropic", apiProvider: "anthropic" },
-				{ name: "My Zoo Gateway Profile", apiProvider: "zoo-gateway" },
-			]),
-			getProfile: vi.fn().mockResolvedValue({
-				apiProvider: "zoo-gateway",
-				zooSessionToken: "recovered-zoo-token",
-				zooGatewayBaseUrl: "https://zoo.example.com/api/gateway/v1",
-			}),
-		}
-
-		const mockModels: ModelRecord = {
-			"model-1": {
-				maxTokens: 4096,
-				contextWindow: 8192,
-				supportsPromptCache: false,
-				description: "Test model 1",
-			},
-		}
-		mockGetModels.mockResolvedValue(mockModels)
-
-		await webviewMessageHandler(mockClineProvider, { type: "requestRouterModels" })
-
-		expect((mockClineProvider as any).providerSettingsManager.listConfig).toHaveBeenCalled()
-		expect((mockClineProvider as any).providerSettingsManager.getProfile).toHaveBeenCalledWith({
-			name: "My Zoo Gateway Profile",
-		})
-		expect(mockGetModels).toHaveBeenCalledWith({
-			provider: "zoo-gateway",
-			apiKey: "recovered-zoo-token",
-			baseUrl: "https://zoo.example.com/api/gateway/v1",
-		})
-
-		// Reset to avoid bleeding into other tests
-		delete (mockClineProvider as any).providerSettingsManager
-	})
-
 	it("handles LiteLLM models with values from message when config is missing", async () => {
 		mockClineProvider.getState = vi.fn().mockResolvedValue({
 			apiConfiguration: {

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -4,6 +4,9 @@ import type { Mock } from "vitest"
 
 // Mock dependencies - must come before imports
 vi.mock("../../../api/providers/fetchers/modelCache")
+vi.mock("../../../services/zoo-code-auth", () => ({
+	disconnectZooCode: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock("../../../api/providers/fetchers/lmstudio", () => ({
 	getLMStudioModels: vi.fn(),
 }))
@@ -1147,5 +1150,83 @@ describe("webviewMessageHandler - downloadErrorDiagnostics", () => {
 
 		expect(vscode.window.showErrorMessage).toHaveBeenCalledWith("No active task to generate diagnostics for")
 		expect(generateErrorDiagnostics).not.toHaveBeenCalled()
+	})
+})
+
+describe("zooCodeSignOut", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("disconnects Zoo Code and clears tokens from all zoo-gateway profiles", async () => {
+		const { disconnectZooCode } = await import("../../../services/zoo-code-auth")
+		const upsertProviderProfile = vi.fn().mockResolvedValue(undefined)
+		const saveConfig = vi.fn().mockResolvedValue(undefined)
+
+		;(mockClineProvider as any).contextProxy = {
+			...mockClineProvider.contextProxy,
+			getProviderSettings: vi.fn().mockReturnValue({ apiProvider: "zoo-gateway" }),
+			getValues: vi.fn().mockReturnValue({ currentApiConfigName: "Zoo Gateway" }),
+		}
+		;(mockClineProvider as any).providerSettingsManager = {
+			listConfig: vi.fn().mockResolvedValue([
+				{ name: "Zoo Gateway", apiProvider: "zoo-gateway" },
+				{ name: "Backup Zoo", apiProvider: "zoo-gateway" },
+			]),
+			getProfile: vi
+				.fn()
+				.mockResolvedValueOnce({
+					apiProvider: "zoo-gateway",
+					zooSessionToken: "token-active",
+					zooGatewayModelId: "anthropic/claude-sonnet-4",
+				})
+				.mockResolvedValueOnce({
+					apiProvider: "zoo-gateway",
+					zooSessionToken: "token-backup",
+				}),
+			saveConfig,
+		}
+		;(mockClineProvider as any).upsertProviderProfile = upsertProviderProfile
+
+		await webviewMessageHandler(mockClineProvider, { type: "zooCodeSignOut" })
+
+		expect(disconnectZooCode).toHaveBeenCalled()
+		expect(upsertProviderProfile).toHaveBeenCalledWith(
+			"Zoo Gateway",
+			expect.not.objectContaining({ zooSessionToken: expect.anything() }),
+			true,
+		)
+		expect(saveConfig).toHaveBeenCalledWith(
+			"Backup Zoo",
+			expect.not.objectContaining({ zooSessionToken: expect.anything() }),
+		)
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalled()
+	})
+
+	it("still clears the in-memory handler when the active profile token is already empty on disk", async () => {
+		const upsertProviderProfile = vi.fn().mockResolvedValue(undefined)
+
+		;(mockClineProvider as any).contextProxy = {
+			...mockClineProvider.contextProxy,
+			getProviderSettings: vi.fn().mockReturnValue({ apiProvider: "zoo-gateway" }),
+			getValues: vi.fn().mockReturnValue({ currentApiConfigName: "Zoo Gateway" }),
+		}
+		;(mockClineProvider as any).providerSettingsManager = {
+			listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
+			getProfile: vi.fn().mockResolvedValue({
+				apiProvider: "zoo-gateway",
+				zooGatewayModelId: "anthropic/claude-sonnet-4",
+			}),
+			saveConfig: vi.fn(),
+		}
+		;(mockClineProvider as any).upsertProviderProfile = upsertProviderProfile
+
+		await webviewMessageHandler(mockClineProvider, { type: "zooCodeSignOut" })
+
+		expect(upsertProviderProfile).toHaveBeenCalledWith(
+			"Zoo Gateway",
+			expect.not.objectContaining({ zooSessionToken: expect.anything() }),
+			true,
+		)
 	})
 })

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -365,17 +365,69 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				openrouter: mockModels,
 				requesty: mockModels,
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				litellm: mockModels,
 				ollama: {},
 				lmstudio: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},
 			},
 			values: undefined,
 		})
+	})
+
+	it("recovers zoo-gateway credentials from a separate profile when not the active provider", async () => {
+		// Regression: when zoo-gateway is NOT the active provider, the active apiConfiguration
+		// will not contain zooSessionToken / zooGatewayBaseUrl. The aggregate model fetcher must
+		// fall back to scanning providerSettingsManager profiles for a zoo-gateway entry so the
+		// model picker still populates.
+		mockClineProvider.getState = vi.fn().mockResolvedValue({
+			apiConfiguration: {
+				// Active provider is anthropic (or anything other than zoo-gateway).
+				apiProvider: "anthropic",
+				openRouterApiKey: "openrouter-key",
+				requestyApiKey: "requesty-key",
+				// No zooSessionToken / zooGatewayBaseUrl on the active config.
+			},
+		})
+		;(mockClineProvider as any).providerSettingsManager = {
+			listConfig: vi.fn().mockResolvedValue([
+				{ name: "Anthropic", apiProvider: "anthropic" },
+				{ name: "My Zoo Gateway Profile", apiProvider: "zoo-gateway" },
+			]),
+			getProfile: vi.fn().mockResolvedValue({
+				apiProvider: "zoo-gateway",
+				zooSessionToken: "recovered-zoo-token",
+				zooGatewayBaseUrl: "https://zoo.example.com/api/gateway/v1",
+			}),
+		}
+
+		const mockModels: ModelRecord = {
+			"model-1": {
+				maxTokens: 4096,
+				contextWindow: 8192,
+				supportsPromptCache: false,
+				description: "Test model 1",
+			},
+		}
+		mockGetModels.mockResolvedValue(mockModels)
+
+		await webviewMessageHandler(mockClineProvider, { type: "requestRouterModels" })
+
+		expect((mockClineProvider as any).providerSettingsManager.listConfig).toHaveBeenCalled()
+		expect((mockClineProvider as any).providerSettingsManager.getProfile).toHaveBeenCalledWith({
+			name: "My Zoo Gateway Profile",
+		})
+		expect(mockGetModels).toHaveBeenCalledWith({
+			provider: "zoo-gateway",
+			apiKey: "recovered-zoo-token",
+			baseUrl: "https://zoo.example.com/api/gateway/v1",
+		})
+
+		// Reset to avoid bleeding into other tests
+		delete (mockClineProvider as any).providerSettingsManager
 	})
 
 	it("handles LiteLLM models with values from message when config is missing", async () => {
@@ -453,11 +505,11 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				openrouter: mockModels,
 				requesty: mockModels,
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				litellm: {},
 				ollama: {},
 				lmstudio: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},
@@ -482,6 +534,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			.mockRejectedValueOnce(new Error("Requesty API error")) // requesty
 			.mockResolvedValueOnce(mockModels) // unbound
 			.mockResolvedValueOnce(mockModels) // vercel-ai-gateway
+			.mockResolvedValueOnce(mockModels) // zoo-gateway
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm
 
 		await webviewMessageHandler(mockClineProvider, {
@@ -510,11 +563,11 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 				openrouter: mockModels,
 				requesty: {},
 				unbound: mockModels,
+				"vercel-ai-gateway": mockModels,
+				"zoo-gateway": mockModels,
 				litellm: {},
 				ollama: {},
 				lmstudio: {},
-				"vercel-ai-gateway": mockModels,
-				"zoo-gateway": {},
 				poe: {},
 				deepseek: {},
 				"opencode-go": {},
@@ -530,6 +583,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 			.mockRejectedValueOnce(new Error("Requesty API error")) // requesty
 			.mockRejectedValueOnce(new Error("Unbound error")) // unbound
 			.mockRejectedValueOnce(new Error("Vercel AI Gateway error")) // vercel-ai-gateway
+			.mockRejectedValueOnce(new Error("Zoo Gateway error")) // zoo-gateway
 			.mockRejectedValueOnce(new Error("LiteLLM connection failed")) // litellm
 
 		await webviewMessageHandler(mockClineProvider, {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -946,31 +946,6 @@ export const webviewMessageHandler = async (
 				}
 			}
 
-			// For zoo-gateway, the token may be stored in a separate zoo-gateway profile
-			// (not the currently active profile). Look it up so the model list populates
-			// even when zoo-gateway isn't the active provider.
-			let zooGatewayToken = apiConfiguration.zooSessionToken
-			let zooGatewayBaseUrl = apiConfiguration.zooGatewayBaseUrl
-
-			if (!zooGatewayToken) {
-				try {
-					const allProfiles = await provider.providerSettingsManager.listConfig()
-					const zooGatewayProfiles = allProfiles.filter((p) => p.apiProvider === "zoo-gateway")
-					for (const profileMeta of zooGatewayProfiles) {
-						const fullProfile = await provider.providerSettingsManager.getProfile({
-							name: profileMeta.name,
-						})
-						if (fullProfile.zooSessionToken) {
-							zooGatewayToken = fullProfile.zooSessionToken
-							zooGatewayBaseUrl = fullProfile.zooGatewayBaseUrl ?? zooGatewayBaseUrl
-							break
-						}
-					}
-				} catch (error) {
-					console.debug("Failed to look up zoo-gateway profile for model fetch:", error)
-				}
-			}
-
 			// Base candidates (only those handled by this aggregate fetcher)
 			const candidates: { key: RouterName; options: GetModelsOptions }[] = [
 				{ key: "openrouter", options: { provider: "openrouter" } },
@@ -994,8 +969,7 @@ export const webviewMessageHandler = async (
 					key: "zoo-gateway",
 					options: {
 						provider: "zoo-gateway",
-						apiKey: zooGatewayToken,
-						baseUrl: zooGatewayBaseUrl,
+						baseUrl: apiConfiguration.zooGatewayBaseUrl,
 					},
 				},
 			]

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -955,13 +955,16 @@ export const webviewMessageHandler = async (
 			if (!zooGatewayToken) {
 				try {
 					const allProfiles = await provider.providerSettingsManager.listConfig()
-					const zooGatewayProfile = allProfiles.find((p) => p.apiProvider === "zoo-gateway")
-					if (zooGatewayProfile) {
+					const zooGatewayProfiles = allProfiles.filter((p) => p.apiProvider === "zoo-gateway")
+					for (const profileMeta of zooGatewayProfiles) {
 						const fullProfile = await provider.providerSettingsManager.getProfile({
-							name: zooGatewayProfile.name,
+							name: profileMeta.name,
 						})
-						zooGatewayToken = fullProfile.zooSessionToken
-						zooGatewayBaseUrl = fullProfile.zooGatewayBaseUrl ?? zooGatewayBaseUrl
+						if (fullProfile.zooSessionToken) {
+							zooGatewayToken = fullProfile.zooSessionToken
+							zooGatewayBaseUrl = fullProfile.zooGatewayBaseUrl ?? zooGatewayBaseUrl
+							break
+						}
 					}
 				} catch (error) {
 					console.debug("Failed to look up zoo-gateway profile for model fetch:", error)

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -946,6 +946,28 @@ export const webviewMessageHandler = async (
 				}
 			}
 
+			// For zoo-gateway, the token may be stored in a separate zoo-gateway profile
+			// (not the currently active profile). Look it up so the model list populates
+			// even when zoo-gateway isn't the active provider.
+			let zooGatewayToken = apiConfiguration.zooSessionToken
+			let zooGatewayBaseUrl = apiConfiguration.zooGatewayBaseUrl
+
+			if (!zooGatewayToken) {
+				try {
+					const allProfiles = await provider.providerSettingsManager.listConfig()
+					const zooGatewayProfile = allProfiles.find((p) => p.apiProvider === "zoo-gateway")
+					if (zooGatewayProfile) {
+						const fullProfile = await provider.providerSettingsManager.getProfile({
+							name: zooGatewayProfile.name,
+						})
+						zooGatewayToken = fullProfile.zooSessionToken
+						zooGatewayBaseUrl = fullProfile.zooGatewayBaseUrl ?? zooGatewayBaseUrl
+					}
+				} catch (error) {
+					console.debug("Failed to look up zoo-gateway profile for model fetch:", error)
+				}
+			}
+
 			// Base candidates (only those handled by this aggregate fetcher)
 			const candidates: { key: RouterName; options: GetModelsOptions }[] = [
 				{ key: "openrouter", options: { provider: "openrouter" } },
@@ -965,6 +987,14 @@ export const webviewMessageHandler = async (
 					},
 				},
 				{ key: "vercel-ai-gateway", options: { provider: "vercel-ai-gateway" } },
+				{
+					key: "zoo-gateway",
+					options: {
+						provider: "zoo-gateway",
+						apiKey: zooGatewayToken,
+						baseUrl: zooGatewayBaseUrl,
+					},
+				},
 			]
 
 			// LiteLLM is conditional on baseUrl+apiKey
@@ -2438,6 +2468,47 @@ export const webviewMessageHandler = async (
 			try {
 				const { disconnectZooCode } = await import("../../services/zoo-code-auth")
 				await disconnectZooCode()
+
+				// Clear zooSessionToken from ALL provider profiles with apiProvider === "zoo-gateway".
+				// Profiles are user-renameable, so we cannot rely on a hardcoded name like "Zoo Gateway".
+				// We must scan all profiles and clear tokens from any that use the zoo-gateway provider.
+				try {
+					const allProfiles = await provider.providerSettingsManager.listConfig()
+					// Check if Zoo Gateway is the currently active profile by apiProvider identity
+					const currentSettings = provider.contextProxy.getProviderSettings()
+					const isZooGatewayActive = currentSettings.apiProvider === "zoo-gateway"
+					const currentApiConfigName = provider.contextProxy.getValues().currentApiConfigName
+
+					for (const entry of allProfiles) {
+						if (entry.apiProvider === "zoo-gateway") {
+							const profile = await provider.providerSettingsManager.getProfile({ name: entry.name })
+							const { zooSessionToken: _removed, ...cleanedProfile } = profile
+
+							// If this is the currently active profile, ALWAYS push to the in-memory
+							// handler — even when the persisted profile has already been cleared —
+							// because currentSettings (and therefore the live API handler) may still
+							// carry a stale token from before sign-out. Persisted-only profiles get
+							// rewritten only when they previously had a token to avoid no-op disk writes.
+							const isThisProfileActive = isZooGatewayActive && currentApiConfigName === entry.name
+
+							if (isThisProfileActive) {
+								await provider.upsertProviderProfile(entry.name, cleanedProfile, true)
+								provider.log(
+									`[zooCodeSignOut] Cleared zooSessionToken from "${entry.name}" profile and updated in-memory handler`,
+								)
+							} else if (profile.zooSessionToken) {
+								await provider.providerSettingsManager.saveConfig(entry.name, cleanedProfile)
+								provider.log(`[zooCodeSignOut] Cleared zooSessionToken from "${entry.name}" profile`)
+							}
+						}
+					}
+				} catch (profileError) {
+					// Log but don't fail the sign-out if profile cleanup fails
+					provider.log(
+						`[zooCodeSignOut] Failed to clear profile token: ${profileError instanceof Error ? profileError.message : String(profileError)}`,
+					)
+				}
+
 				await provider.postStateToWebview()
 			} catch (error) {
 				provider.log(

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -2457,7 +2457,14 @@ export const webviewMessageHandler = async (
 					const currentApiConfigName = provider.contextProxy.getValues().currentApiConfigName
 
 					for (const entry of allProfiles) {
-						if (entry.apiProvider === "zoo-gateway") {
+						if (entry.apiProvider !== "zoo-gateway") {
+							continue
+						}
+
+						// Isolate per-profile failures: a corrupted profile or a failed write
+						// for one entry must not abort cleanup of the remaining profiles,
+						// otherwise sign-out would leave later profiles with a stale token.
+						try {
 							const profile = await provider.providerSettingsManager.getProfile({ name: entry.name })
 							const { zooSessionToken: _removed, ...cleanedProfile } = profile
 
@@ -2477,12 +2484,18 @@ export const webviewMessageHandler = async (
 								await provider.providerSettingsManager.saveConfig(entry.name, cleanedProfile)
 								provider.log(`[zooCodeSignOut] Cleared zooSessionToken from "${entry.name}" profile`)
 							}
+						} catch (profileError) {
+							// Log but continue to the next profile so one failure doesn't
+							// leave other profiles holding a stale token.
+							provider.log(
+								`[zooCodeSignOut] Failed to clear profile token for "${entry.name}": ${profileError instanceof Error ? profileError.message : String(profileError)}`,
+							)
 						}
 					}
 				} catch (profileError) {
-					// Log but don't fail the sign-out if profile cleanup fails
+					// listConfig itself failed — nothing to iterate.
 					provider.log(
-						`[zooCodeSignOut] Failed to clear profile token: ${profileError instanceof Error ? profileError.message : String(profileError)}`,
+						`[zooCodeSignOut] Failed to list profiles for token cleanup: ${profileError instanceof Error ? profileError.message : String(profileError)}`,
 					)
 				}
 

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: S'ha rebut un token d'autenticació no vàlid.",
 			"token_verification_failed": "Zoo Code: Ha fallat la verificació del token.",
 			"invalid_token": "Zoo Code: Token no vàlid.",
-			"could_not_verify_token": "Zoo Code: No s'ha pogut verificar el token."
+			"could_not_verify_token": "Zoo Code: No s'ha pogut verificar el token.",
+			"session_expired": "Sessió de Zoo Code caducada. Torna a iniciar sessió per continuar utilitzant Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: crèdits insuficients. Afegeix crèdits per continuar.",
+			"account_unavailable": "Zoo Gateway: el teu compte no està disponible. Contacta amb el suport.",
+			"budget_exceeded": "Zoo Gateway: pressupost d'ús assolit. Espera que es restableixi o afegeix crèdits."
 		},
 		"info": {
 			"connected": "Zoo Code: Connectat correctament! Ara podeu utilitzar Zoo Code com a proveïdor d'IA.",
 			"disconnected": "Zoo Code: Desconnectat correctament."
+		},
+		"buttons": {
+			"sign_in": "Inicia sessió",
+			"add_credits": "Afegeix crèdits",
+			"contact_support": "Contacta amb el suport"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -256,11 +256,20 @@
 			"invalid_token_received": "Zoo Code: Ungültiger Authentifizierungstoken empfangen.",
 			"token_verification_failed": "Zoo Code: Token-Überprüfung fehlgeschlagen.",
 			"invalid_token": "Zoo Code: Ungültiger Token.",
-			"could_not_verify_token": "Zoo Code: Token konnte nicht verifiziert werden."
+			"could_not_verify_token": "Zoo Code: Token konnte nicht verifiziert werden.",
+			"session_expired": "Zoo Code-Sitzung abgelaufen. Bitte melde dich erneut an, um Zoo Gateway weiter zu nutzen.",
+			"out_of_credits": "Zoo Gateway: Unzureichendes Guthaben. Füge Guthaben hinzu, um fortzufahren.",
+			"account_unavailable": "Zoo Gateway: Dein Konto ist derzeit nicht verfügbar. Bitte kontaktiere den Support.",
+			"budget_exceeded": "Zoo Gateway: Nutzungsbudget erreicht. Warte auf das Zurücksetzen oder lade auf."
 		},
 		"info": {
 			"connected": "Zoo Code: Erfolgreich verbunden! Du kannst Zoo Code jetzt als KI-Anbieter verwenden.",
 			"disconnected": "Zoo Code: Erfolgreich getrennt."
+		},
+		"buttons": {
+			"sign_in": "Anmelden",
+			"add_credits": "Guthaben hinzufügen",
+			"contact_support": "Support kontaktieren"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -253,11 +253,20 @@
 			"invalid_token_received": "Zoo Code: Invalid authentication token received.",
 			"token_verification_failed": "Zoo Code: Token verification failed.",
 			"invalid_token": "Zoo Code: Invalid token.",
-			"could_not_verify_token": "Zoo Code: Could not verify token."
+			"could_not_verify_token": "Zoo Code: Could not verify token.",
+			"session_expired": "Zoo Code session expired. Please sign in again to continue using Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: insufficient credits. Add credits to continue.",
+			"account_unavailable": "Zoo Gateway: your account is currently unavailable. Please contact support.",
+			"budget_exceeded": "Zoo Gateway: usage budget reached. Wait for the budget to reset or top up."
 		},
 		"info": {
 			"connected": "Zoo Code: Successfully connected! You can now use Zoo Code as your AI provider.",
 			"disconnected": "Zoo Code: Disconnected successfully."
+		},
+		"buttons": {
+			"sign_in": "Sign In",
+			"add_credits": "Add Credits",
+			"contact_support": "Contact Support"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -256,11 +256,20 @@
 			"invalid_token_received": "Zoo Code: Se recibió un token de autenticación inválido.",
 			"token_verification_failed": "Zoo Code: Error al verificar el token.",
 			"invalid_token": "Zoo Code: Token inválido.",
-			"could_not_verify_token": "Zoo Code: No se pudo verificar el token."
+			"could_not_verify_token": "Zoo Code: No se pudo verificar el token.",
+			"session_expired": "Sesión de Zoo Code caducada. Inicia sesión de nuevo para seguir usando Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: créditos insuficientes. Añade créditos para continuar.",
+			"account_unavailable": "Zoo Gateway: tu cuenta no está disponible. Contacta con soporte.",
+			"budget_exceeded": "Zoo Gateway: presupuesto de uso alcanzado. Espera al restablecimiento o recarga."
 		},
 		"info": {
 			"connected": "Zoo Code: ¡Conectado correctamente! Ahora puedes usar Zoo Code como proveedor de IA.",
 			"disconnected": "Zoo Code: Desconectado correctamente."
+		},
+		"buttons": {
+			"sign_in": "Iniciar sesión",
+			"add_credits": "Añadir créditos",
+			"contact_support": "Contactar con soporte"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Jeton d'authentification invalide reçu.",
 			"token_verification_failed": "Zoo Code: La vérification du jeton a échoué.",
 			"invalid_token": "Zoo Code: Jeton invalide.",
-			"could_not_verify_token": "Zoo Code: Impossible de vérifier le jeton."
+			"could_not_verify_token": "Zoo Code: Impossible de vérifier le jeton.",
+			"session_expired": "Session Zoo Code expirée. Reconnectez-vous pour continuer à utiliser Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway : crédits insuffisants. Ajoutez des crédits pour continuer.",
+			"account_unavailable": "Zoo Gateway : votre compte n'est pas disponible actuellement. Contactez le support.",
+			"budget_exceeded": "Zoo Gateway : budget d'utilisation atteint. Attendez la réinitialisation ou rechargez."
 		},
 		"info": {
 			"connected": "Zoo Code: Connecté avec succès ! Vous pouvez maintenant utiliser Zoo Code comme fournisseur d'IA.",
 			"disconnected": "Zoo Code: Déconnecté avec succès."
+		},
+		"buttons": {
+			"sign_in": "Se connecter",
+			"add_credits": "Ajouter des crédits",
+			"contact_support": "Contacter le support"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: अमान्य प्रमाणीकरण token प्राप्त हुआ।",
 			"token_verification_failed": "Zoo Code: Token सत्यापन विफल रहा।",
 			"invalid_token": "Zoo Code: अमान्य token।",
-			"could_not_verify_token": "Zoo Code: Token सत्यापित नहीं किया जा सका।"
+			"could_not_verify_token": "Zoo Code: Token सत्यापित नहीं किया जा सका।",
+			"session_expired": "Zoo Code सत्र समाप्त हो गया है। Zoo Gateway का उपयोग जारी रखने के लिए कृपया फिर से साइन इन करें।",
+			"out_of_credits": "Zoo Gateway: अपर्याप्त क्रेडिट। जारी रखने के लिए क्रेडिट जोड़ें।",
+			"account_unavailable": "Zoo Gateway: आपका खाता वर्तमान में उपलब्ध नहीं है। कृपया सहायता से संपर्क करें।",
+			"budget_exceeded": "Zoo Gateway: उपयोग बजट पूरा हो गया है। बजट रीसेट होने की प्रतीक्षा करें या रिचार्ज करें।"
 		},
 		"info": {
 			"connected": "Zoo Code: सफलतापूर्वक कनेक्ट हो गया! अब तुम Zoo Code को अपने AI प्रदाता के रूप में उपयोग कर सकते हो।",
 			"disconnected": "Zoo Code: सफलतापूर्वक डिस्कनेक्ट हो गया।"
+		},
+		"buttons": {
+			"sign_in": "साइन इन करें",
+			"add_credits": "क्रेडिट जोड़ें",
+			"contact_support": "सहायता से संपर्क करें"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/id/common.json
+++ b/src/i18n/locales/id/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Token autentikasi yang diterima tidak valid.",
 			"token_verification_failed": "Zoo Code: Verifikasi token gagal.",
 			"invalid_token": "Zoo Code: Token tidak valid.",
-			"could_not_verify_token": "Zoo Code: Tidak dapat memverifikasi token."
+			"could_not_verify_token": "Zoo Code: Tidak dapat memverifikasi token.",
+			"session_expired": "Sesi Zoo Code kedaluwarsa. Silakan masuk lagi untuk melanjutkan menggunakan Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: kredit tidak cukup. Tambahkan kredit untuk melanjutkan.",
+			"account_unavailable": "Zoo Gateway: akun Anda sedang tidak tersedia. Silakan hubungi dukungan.",
+			"budget_exceeded": "Zoo Gateway: anggaran penggunaan tercapai. Tunggu reset anggaran atau isi ulang."
 		},
 		"info": {
 			"connected": "Zoo Code: Berhasil terhubung! Kamu sekarang bisa menggunakan Zoo Code sebagai penyedia AI.",
 			"disconnected": "Zoo Code: Berhasil terputus."
+		},
+		"buttons": {
+			"sign_in": "Masuk",
+			"add_credits": "Tambah Kredit",
+			"contact_support": "Hubungi Dukungan"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Ricevuto un token di autenticazione non valido.",
 			"token_verification_failed": "Zoo Code: Verifica del token non riuscita.",
 			"invalid_token": "Zoo Code: Token non valido.",
-			"could_not_verify_token": "Zoo Code: Impossibile verificare il token."
+			"could_not_verify_token": "Zoo Code: Impossibile verificare il token.",
+			"session_expired": "Sessione Zoo Code scaduta. Accedi di nuovo per continuare a usare Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: crediti insufficienti. Aggiungi crediti per continuare.",
+			"account_unavailable": "Zoo Gateway: il tuo account non è attualmente disponibile. Contatta l'assistenza.",
+			"budget_exceeded": "Zoo Gateway: budget di utilizzo raggiunto. Attendi il reset o ricarica."
 		},
 		"info": {
 			"connected": "Zoo Code: Connesso con successo! Ora puoi usare Zoo Code come fornitore AI.",
 			"disconnected": "Zoo Code: Disconnesso con successo."
+		},
+		"buttons": {
+			"sign_in": "Accedi",
+			"add_credits": "Aggiungi crediti",
+			"contact_support": "Contatta l'assistenza"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: 無効な認証 token を受信しました。",
 			"token_verification_failed": "Zoo Code: Token の検証に失敗しました。",
 			"invalid_token": "Zoo Code: 無効な token です。",
-			"could_not_verify_token": "Zoo Code: Token を検証できませんでした。"
+			"could_not_verify_token": "Zoo Code: Token を検証できませんでした。",
+			"session_expired": "Zoo Codeのセッションの有効期限が切れました。Zoo Gatewayを引き続き使用するには、再度サインインしてください。",
+			"out_of_credits": "Zoo Gateway: クレジットが不足しています。続行するにはクレジットを追加してください。",
+			"account_unavailable": "Zoo Gateway: 現在アカウントを利用できません。サポートまでお問い合わせください。",
+			"budget_exceeded": "Zoo Gateway: 利用予算に達しました。リセットを待つかチャージしてください。"
 		},
 		"info": {
 			"connected": "Zoo Code: 接続に成功しました！Zoo Code を AI プロバイダーとして使用できます。",
 			"disconnected": "Zoo Code: 正常に切断されました。"
+		},
+		"buttons": {
+			"sign_in": "サインイン",
+			"add_credits": "クレジットを追加",
+			"contact_support": "サポートに連絡"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: 잘못된 인증 token을 수신했습니다.",
 			"token_verification_failed": "Zoo Code: Token 검증에 실패했습니다.",
 			"invalid_token": "Zoo Code: 잘못된 token입니다.",
-			"could_not_verify_token": "Zoo Code: Token을 검증할 수 없습니다."
+			"could_not_verify_token": "Zoo Code: Token을 검증할 수 없습니다.",
+			"session_expired": "Zoo Code 세션이 만료되었습니다. Zoo Gateway를 계속 사용하려면 다시 로그인해 주세요.",
+			"out_of_credits": "Zoo Gateway: 크레딧이 부족합니다. 계속하려면 크레딧을 추가하세요.",
+			"account_unavailable": "Zoo Gateway: 현재 계정을 사용할 수 없습니다. 지원팀에 문의하세요.",
+			"budget_exceeded": "Zoo Gateway: 사용 한도에 도달했습니다. 한도가 재설정되기를 기다리거나 충전하세요."
 		},
 		"info": {
 			"connected": "Zoo Code: 연결에 성공했습니다! 이제 Zoo Code를 AI 제공자로 사용할 수 있습니다.",
 			"disconnected": "Zoo Code: 연결이 해제되었습니다."
+		},
+		"buttons": {
+			"sign_in": "로그인",
+			"add_credits": "크레딧 추가",
+			"contact_support": "지원팀 문의"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Ongeldig authenticatietoken ontvangen.",
 			"token_verification_failed": "Zoo Code: Tokenverificatie mislukt.",
 			"invalid_token": "Zoo Code: Ongeldig token.",
-			"could_not_verify_token": "Zoo Code: Token kon niet worden geverifieerd."
+			"could_not_verify_token": "Zoo Code: Token kon niet worden geverifieerd.",
+			"session_expired": "Zoo Code-sessie verlopen. Meld je opnieuw aan om Zoo Gateway te blijven gebruiken.",
+			"out_of_credits": "Zoo Gateway: onvoldoende tegoed. Voeg tegoed toe om door te gaan.",
+			"account_unavailable": "Zoo Gateway: je account is momenteel niet beschikbaar. Neem contact op met support.",
+			"budget_exceeded": "Zoo Gateway: gebruiksbudget bereikt. Wacht op de reset of laad bij."
 		},
 		"info": {
 			"connected": "Zoo Code: Succesvol verbonden! Je kunt Zoo Code nu gebruiken als AI-provider.",
 			"disconnected": "Zoo Code: Succesvol losgekoppeld."
+		},
+		"buttons": {
+			"sign_in": "Aanmelden",
+			"add_credits": "Tegoed toevoegen",
+			"contact_support": "Contact opnemen"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Otrzymano nieprawidłowy token uwierzytelniania.",
 			"token_verification_failed": "Zoo Code: Weryfikacja tokenu nie powiodła się.",
 			"invalid_token": "Zoo Code: Nieprawidłowy token.",
-			"could_not_verify_token": "Zoo Code: Nie udało się zweryfikować tokenu."
+			"could_not_verify_token": "Zoo Code: Nie udało się zweryfikować tokenu.",
+			"session_expired": "Sesja Zoo Code wygasła. Zaloguj się ponownie, aby kontynuować korzystanie z Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: niewystarczające środki. Doładuj, aby kontynuować.",
+			"account_unavailable": "Zoo Gateway: Twoje konto jest obecnie niedostępne. Skontaktuj się z pomocą techniczną.",
+			"budget_exceeded": "Zoo Gateway: osiągnięto budżet użycia. Poczekaj na reset lub doładuj."
 		},
 		"info": {
 			"connected": "Zoo Code: Połączono pomyślnie! Możesz teraz używać Zoo Code jako dostawcy AI.",
 			"disconnected": "Zoo Code: Rozłączono pomyślnie."
+		},
+		"buttons": {
+			"sign_in": "Zaloguj się",
+			"add_credits": "Doładuj",
+			"contact_support": "Kontakt z pomocą"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Token de autenticação inválido recebido.",
 			"token_verification_failed": "Zoo Code: Falha na verificação do token.",
 			"invalid_token": "Zoo Code: Token inválido.",
-			"could_not_verify_token": "Zoo Code: Não foi possível verificar o token."
+			"could_not_verify_token": "Zoo Code: Não foi possível verificar o token.",
+			"session_expired": "Sessão do Zoo Code expirada. Entre novamente para continuar usando o Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: créditos insuficientes. Adicione créditos para continuar.",
+			"account_unavailable": "Zoo Gateway: sua conta está indisponível no momento. Entre em contato com o suporte.",
+			"budget_exceeded": "Zoo Gateway: orçamento de uso atingido. Aguarde o reset ou recarregue."
 		},
 		"info": {
 			"connected": "Zoo Code: Conectado com sucesso! Agora você pode usar o Zoo Code como provedor de IA.",
 			"disconnected": "Zoo Code: Desconectado com sucesso."
+		},
+		"buttons": {
+			"sign_in": "Entrar",
+			"add_credits": "Adicionar créditos",
+			"contact_support": "Contatar suporte"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Получен недействительный token аутентификации.",
 			"token_verification_failed": "Zoo Code: Не удалось проверить token.",
 			"invalid_token": "Zoo Code: Недействительный token.",
-			"could_not_verify_token": "Zoo Code: Не удалось проверить token."
+			"could_not_verify_token": "Zoo Code: Не удалось проверить token.",
+			"session_expired": "Сессия Zoo Code истекла. Войдите снова, чтобы продолжить использовать Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: недостаточно кредитов. Добавьте кредиты, чтобы продолжить.",
+			"account_unavailable": "Zoo Gateway: ваша учётная запись сейчас недоступна. Обратитесь в поддержку.",
+			"budget_exceeded": "Zoo Gateway: лимит использования достигнут. Дождитесь сброса или пополните счёт."
 		},
 		"info": {
 			"connected": "Zoo Code: Успешно подключено! Теперь ты можешь использовать Zoo Code в качестве AI-провайдера.",
 			"disconnected": "Zoo Code: Успешно отключено."
+		},
+		"buttons": {
+			"sign_in": "Войти",
+			"add_credits": "Добавить кредиты",
+			"contact_support": "Связаться с поддержкой"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: Geçersiz kimlik doğrulama token'ı alındı.",
 			"token_verification_failed": "Zoo Code: Token doğrulaması başarısız oldu.",
 			"invalid_token": "Zoo Code: Geçersiz token.",
-			"could_not_verify_token": "Zoo Code: Token doğrulanamadı."
+			"could_not_verify_token": "Zoo Code: Token doğrulanamadı.",
+			"session_expired": "Zoo Code oturumunun süresi doldu. Zoo Gateway'i kullanmaya devam etmek için lütfen tekrar giriş yapın.",
+			"out_of_credits": "Zoo Gateway: yetersiz kredi. Devam etmek için kredi ekleyin.",
+			"account_unavailable": "Zoo Gateway: hesabınız şu anda kullanılamıyor. Lütfen destek ile iletişime geçin.",
+			"budget_exceeded": "Zoo Gateway: kullanım bütçesine ulaşıldı. Sıfırlanmasını bekleyin veya kredi ekleyin."
 		},
 		"info": {
 			"connected": "Zoo Code: Başarıyla bağlandı! Artık Zoo Code'u AI sağlayıcısı olarak kullanabilirsin.",
 			"disconnected": "Zoo Code: Başarıyla bağlantı kesildi."
+		},
+		"buttons": {
+			"sign_in": "Giriş Yap",
+			"add_credits": "Kredi Ekle",
+			"contact_support": "Destek ile İletişim"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -268,11 +268,20 @@
 			"invalid_token_received": "Zoo Code: Nhận được token xác thực không hợp lệ.",
 			"token_verification_failed": "Zoo Code: Xác minh token thất bại.",
 			"invalid_token": "Zoo Code: Token không hợp lệ.",
-			"could_not_verify_token": "Zoo Code: Không thể xác minh token."
+			"could_not_verify_token": "Zoo Code: Không thể xác minh token.",
+			"session_expired": "Phiên Zoo Code đã hết hạn. Vui lòng đăng nhập lại để tiếp tục sử dụng Zoo Gateway.",
+			"out_of_credits": "Zoo Gateway: không đủ tín dụng. Thêm tín dụng để tiếp tục.",
+			"account_unavailable": "Zoo Gateway: tài khoản của bạn hiện không khả dụng. Vui lòng liên hệ hỗ trợ.",
+			"budget_exceeded": "Zoo Gateway: đã đạt ngân sách sử dụng. Chờ đặt lại ngân sách hoặc nạp thêm."
 		},
 		"info": {
 			"connected": "Zoo Code: Kết nối thành công! Bạn có thể sử dụng Zoo Code làm nhà cung cấp AI.",
 			"disconnected": "Zoo Code: Đã ngắt kết nối thành công."
+		},
+		"buttons": {
+			"sign_in": "Đăng nhập",
+			"add_credits": "Thêm tín dụng",
+			"contact_support": "Liên hệ hỗ trợ"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -266,11 +266,20 @@
 			"invalid_token_received": "Zoo Code: 收到无效的认证 token。",
 			"token_verification_failed": "Zoo Code: Token 验证失败。",
 			"invalid_token": "Zoo Code: 无效的 token。",
-			"could_not_verify_token": "Zoo Code: 无法验证 token。"
+			"could_not_verify_token": "Zoo Code: 无法验证 token。",
+			"session_expired": "Zoo Code 会话已过期。请重新登录以继续使用 Zoo Gateway。",
+			"out_of_credits": "Zoo Gateway：积分不足。请添加积分以继续。",
+			"account_unavailable": "Zoo Gateway：你的账户当前不可用。请联系支持。",
+			"budget_exceeded": "Zoo Gateway：已达到使用预算。请等待预算重置或充值。"
 		},
 		"info": {
 			"connected": "Zoo Code: 连接成功！你现在可以使用 Zoo Code 作为 AI 提供商。",
 			"disconnected": "Zoo Code: 已成功断开连接。"
+		},
+		"buttons": {
+			"sign_in": "登录",
+			"add_credits": "添加积分",
+			"contact_support": "联系支持"
 		}
 	},
 	"codeActions": {

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -261,11 +261,20 @@
 			"invalid_token_received": "Zoo Code: 收到無效的認證 token。",
 			"token_verification_failed": "Zoo Code: Token 驗證失敗。",
 			"invalid_token": "Zoo Code: 無效的 token。",
-			"could_not_verify_token": "Zoo Code: 無法驗證 token。"
+			"could_not_verify_token": "Zoo Code: 無法驗證 token。",
+			"session_expired": "Zoo Code 工作階段已過期。請重新登入以繼續使用 Zoo Gateway。",
+			"out_of_credits": "Zoo Gateway：點數不足。請新增點數以繼續。",
+			"account_unavailable": "Zoo Gateway：您的帳戶目前無法使用。請聯絡支援。",
+			"budget_exceeded": "Zoo Gateway：已達使用預算。請等待預算重置或加值。"
 		},
 		"info": {
 			"connected": "Zoo Code: 連線成功！你現在可以使用 Zoo Code 作為 AI 提供商。",
 			"disconnected": "Zoo Code: 已成功中斷連線。"
+		},
+		"buttons": {
+			"sign_in": "登入",
+			"add_credits": "新增點數",
+			"contact_support": "聯絡支援"
 		}
 	},
 	"codeActions": {

--- a/src/services/__tests__/zoo-code-auth.test.ts
+++ b/src/services/__tests__/zoo-code-auth.test.ts
@@ -12,6 +12,7 @@ import {
 	getZooCodeBaseUrl,
 	handleAuthCallback,
 	initZooCodeAuth,
+	resolveZooGatewaySessionToken,
 	setZooCodeToken,
 	setZooCodeUserInfo,
 	verifyZooCodeToken,
@@ -429,6 +430,29 @@ describe("zoo-code-auth", () => {
 			const info = getCachedZooCodeUserInfo()
 			expect(info.email).toBe("jane@example.com")
 			expect(info.name).toBe("John Doe")
+		})
+	})
+
+	describe("resolveZooGatewaySessionToken", () => {
+		it("prefers the cached token over a profile token", async () => {
+			await initZooCodeAuth(mockContext)
+			await setZooCodeToken("zoo_ext_cached")
+
+			expect(resolveZooGatewaySessionToken("zoo_ext_profile")).toBe("zoo_ext_cached")
+		})
+
+		it("ignores profile tokens after an explicit sign-out clear", async () => {
+			await initZooCodeAuth(mockContext)
+			await setZooCodeToken("zoo_ext_cached")
+			await clearZooCodeToken()
+
+			expect(resolveZooGatewaySessionToken("zoo_ext_stale_profile")).toBeUndefined()
+		})
+
+		it("falls back to the profile token when the cache is empty and not cleared", async () => {
+			await initZooCodeAuth(mockContext)
+
+			expect(resolveZooGatewaySessionToken("zoo_ext_profile")).toBe("zoo_ext_profile")
 		})
 	})
 

--- a/src/services/__tests__/zoo-code-auth.test.ts
+++ b/src/services/__tests__/zoo-code-auth.test.ts
@@ -242,6 +242,23 @@ describe("zoo-code-auth", () => {
 			expect(getCachedZooCodeUserInfo().name).toBe("Jane Doe")
 			expect(getCachedSubscriptionStatus()).toBe("unknown")
 		})
+
+		it("preserves token and user info when verify returns 5xx (transient backend error)", async () => {
+			await mockSecrets.store("zoo-code-session-token", "zoo_ext_valid_token")
+			await mockSecrets.store("zoo-code-user-name", "Jane Doe")
+			await mockSecrets.store("zoo-code-user-email", "jane@example.com")
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 503,
+				statusText: "Service Unavailable",
+			})
+
+			await initZooCodeAuth(mockContext)
+
+			expect(getCachedZooCodeToken()).toBe("zoo_ext_valid_token")
+			expect(getCachedZooCodeUserInfo().name).toBe("Jane Doe")
+			expect(getCachedSubscriptionStatus()).toBe("unknown")
+		})
 	})
 
 	describe("setZooCodeToken", () => {
@@ -365,7 +382,7 @@ describe("zoo-code-auth", () => {
 			expect(getCachedZooCodeToken()).toBe("zoo_ext_invalid_token")
 		})
 
-		it("returns 'invalid' when the backend returns HTTP error", async () => {
+		it("returns 'invalid' when the backend returns 4xx", async () => {
 			await initZooCodeAuth(mockContext)
 			await setZooCodeToken("zoo_ext_invalid_token")
 			mockFetch.mockResolvedValueOnce({
@@ -375,6 +392,19 @@ describe("zoo-code-auth", () => {
 			})
 
 			expect(await verifyZooCodeToken()).toBe("invalid")
+		})
+
+		it("returns 'unreachable' when the backend returns 5xx (transient)", async () => {
+			await initZooCodeAuth(mockContext)
+			await setZooCodeToken("zoo_ext_token")
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 503,
+				statusText: "Service Unavailable",
+			})
+
+			expect(await verifyZooCodeToken()).toBe("unreachable")
+			expect(getCachedZooCodeToken()).toBe("zoo_ext_token")
 		})
 
 		it("returns 'unreachable' when a network error occurs", async () => {

--- a/src/services/zoo-code-auth.ts
+++ b/src/services/zoo-code-auth.ts
@@ -11,6 +11,7 @@ let secretStorage: vscode.SecretStorage | undefined
 
 // In-memory cache for synchronous access in ZooCodeHandler hot path
 let _cachedToken: string | undefined = undefined
+let _sessionCleared = false
 let _cachedUserName: string | undefined = undefined
 let _cachedUserEmail: string | undefined = undefined
 let _cachedUserImage: string | undefined = undefined
@@ -28,6 +29,7 @@ export async function initZooCodeAuth(context: vscode.ExtensionContext): Promise
 
 	// Pre-load the token and user info into memory on init so ZooCodeHandler can access them synchronously
 	_cachedToken = await secretStorage.get(ZOO_CODE_TOKEN_KEY)
+	_sessionCleared = false
 	_cachedUserName = await secretStorage.get(ZOO_CODE_USER_NAME_KEY)
 	_cachedUserEmail = await secretStorage.get(ZOO_CODE_USER_EMAIL_KEY)
 	_cachedUserImage = await secretStorage.get(ZOO_CODE_USER_IMAGE_KEY)
@@ -83,6 +85,21 @@ export async function initZooCodeAuth(context: vscode.ExtensionContext): Promise
 // Synchronous getter for use in ZooCodeHandler (called in hot path during API requests)
 export function getCachedZooCodeToken(): string {
 	return _cachedToken ?? ""
+}
+
+/**
+ * Resolves the Zoo Gateway session token for API calls.
+ * Secret-storage cache wins over profile-persisted tokens; after an explicit sign-out
+ * or 401 clear, profile tokens are ignored so stale credentials cannot be reused.
+ */
+export function resolveZooGatewaySessionToken(profileToken?: string): string | undefined {
+	if (_cachedToken) {
+		return _cachedToken
+	}
+	if (_sessionCleared) {
+		return undefined
+	}
+	return profileToken || undefined
 }
 
 export function getCachedZooCodeUserInfo(): { name?: string; email?: string; image?: string } {
@@ -153,6 +170,7 @@ export async function setZooCodeToken(token: string): Promise<void> {
 	if (!secretStorage) return
 	await secretStorage.store(ZOO_CODE_TOKEN_KEY, token)
 	_cachedToken = token
+	_sessionCleared = false
 	// Reset subscription status when token is set
 	_cachedSubscriptionStatus = "unknown"
 	_lastSubscriptionCheck = 0
@@ -204,6 +222,7 @@ export async function clearZooCodeToken(): Promise<void> {
 	if (!secretStorage) return
 	await secretStorage.delete(ZOO_CODE_TOKEN_KEY)
 	_cachedToken = undefined
+	_sessionCleared = true
 	_cachedSubscriptionStatus = "unknown"
 	_lastSubscriptionCheck = 0
 }

--- a/src/services/zoo-code-auth.ts
+++ b/src/services/zoo-code-auth.ts
@@ -245,7 +245,13 @@ export async function handleAuthCallback(token: string): Promise<boolean> {
 			signal: AbortSignal.timeout(10_000),
 		})
 		if (!response.ok) {
-			vscode.window.showErrorMessage(t("common:zooAuth.errors.token_verification_failed"))
+			// Treat 5xx as a transient backend issue (e.g. DB unreachable) so the
+			// user can retry sign-in instead of being told the token is bad.
+			if (response.status >= 500) {
+				vscode.window.showErrorMessage(t("common:zooAuth.errors.could_not_verify_token"))
+			} else {
+				vscode.window.showErrorMessage(t("common:zooAuth.errors.token_verification_failed"))
+			}
 			return false
 		}
 		const data = (await response.json()) as { valid?: boolean }
@@ -271,8 +277,12 @@ export async function handleAuthCallback(token: string): Promise<boolean> {
  * Verify the stored token against the backend.
  * Returns:
  *   - "valid"       — backend confirmed the token is good
- *   - "invalid"     — backend explicitly rejected the token (HTTP error or valid: false)
- *   - "unreachable" — network error / timeout; token state is unknown
+ *   - "invalid"     — backend explicitly rejected the token (4xx or valid: false)
+ *   - "unreachable" — network error / timeout / 5xx backend error; token state is unknown
+ *
+ * 5xx responses are treated as transient: the website returns 503 when the
+ * database is unreachable, and clearing a real session on a backend hiccup
+ * forces users to sign in again every time the API blips.
  *
  * This function has no side-effects; callers are responsible for acting on the result.
  */
@@ -289,6 +299,9 @@ export async function verifyZooCodeToken(): Promise<"valid" | "invalid" | "unrea
 		})
 
 		if (!response.ok) {
+			if (response.status >= 500) {
+				return "unreachable"
+			}
 			return "invalid"
 		}
 

--- a/webview-ui/src/components/welcome/WelcomeViewProvider.tsx
+++ b/webview-ui/src/components/welcome/WelcomeViewProvider.tsx
@@ -20,14 +20,17 @@ const DEFAULT_WELCOME_API_CONFIGURATION: ProviderSettings = {
 	openRouterModelId: openRouterDefaultModelId,
 }
 
-const getWelcomeApiConfiguration = (apiConfiguration?: ProviderSettings): ProviderSettings => {
+const getWelcomeApiConfiguration = (
+	apiConfiguration?: ProviderSettings,
+	zooCodeIsAuthenticated?: boolean,
+): ProviderSettings => {
 	// validateApiConfiguration treats a missing apiProvider as valid (no switch case matches),
 	// so we explicitly fall back here before delegating to it for incomplete-but-set configs.
 	if (!apiConfiguration?.apiProvider) {
 		return DEFAULT_WELCOME_API_CONFIGURATION
 	}
 
-	const validationError = validateApiConfiguration(apiConfiguration)
+	const validationError = validateApiConfiguration(apiConfiguration, undefined, undefined, zooCodeIsAuthenticated)
 	if (validationError) {
 		return DEFAULT_WELCOME_API_CONFIGURATION
 	}
@@ -42,7 +45,8 @@ const WelcomeViewProvider = () => {
 	const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined)
 	const [showProviderSetup, setShowProviderSetup] = useState(false)
 	const [welcomeApiConfiguration, setWelcomeApiConfiguration] = useState<ProviderSettings>()
-	const effectiveApiConfiguration = welcomeApiConfiguration ?? getWelcomeApiConfiguration(apiConfiguration)
+	const effectiveApiConfiguration =
+		welcomeApiConfiguration ?? getWelcomeApiConfiguration(apiConfiguration, zooCodeIsAuthenticated)
 
 	const setApiConfigurationFieldForApiOptions = useCallback(
 		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
@@ -57,7 +61,7 @@ const WelcomeViewProvider = () => {
 
 	const handleGetStarted = useCallback(() => {
 		if (!showProviderSetup) {
-			const initialApiConfiguration = getWelcomeApiConfiguration(apiConfiguration)
+			const initialApiConfiguration = getWelcomeApiConfiguration(apiConfiguration, zooCodeIsAuthenticated)
 			setWelcomeApiConfiguration(initialApiConfiguration)
 
 			setApiConfiguration(initialApiConfiguration)


### PR DESCRIPTION
## Summary
- Propagates OAuth callback token to all ClineProvider instances (sequential writes to avoid profile-store races)
- Seeds/syncs zoo-gateway profiles, including non-active profiles for model fetch
- Clears in-memory active profile on sign-out even when disk is already clean

Part 3 of the Zoo Gateway stack. **Depends on PR2 (stacked on #344).**

## Test plan
- [ ] handleUri multi-instance + serialization tests
- [ ] webviewMessageHandler separate-profile lookup test
- [ ] Manual: sign in/out across multiple profiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zoo Code auth callbacks now propagate sequentially to all active provider instances.
  * Zoo Gateway profiles are auto-seeded/updated when cached auth tokens exist but profiles are missing or stale.
  * Sign-out now clears Zoo session tokens across all Zoo Gateway profiles.

* **Error Handling**
  * Centralized Zoo Gateway error classification and user-facing surfaces for auth, session, credit, and account issues.

* **Internationalization**
  * Added localized error messages and action buttons across 16 locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->