### PR TITLE
chore: prepare v3.56.0 release

### DIFF
--- a/.changeset/terminate-process-on-cancel.md
+++ b/.changeset/terminate-process-on-cancel.md
@@ -1,5 +1,0 @@
----
-"zoo-code": patch
----
-
-Terminate the running command when a task is cancelled or torn down (#245). Pressing cancel (✕) now aborts the underlying terminal process instead of leaving it running while the terminal stays stuck "busy" until a manual kill.

--- a/.changeset/vertex-credentials-field-validation.md
+++ b/.changeset/vertex-credentials-field-validation.md
@@ -1,5 +1,0 @@
----
-"zoo-code": patch
----
-
-Detect when the "Google Cloud Credentials" Vertex field has been given a filesystem path instead of the raw JSON contents of a service-account key file. The runtime now skips JSON.parse for path-shaped input, logs a single specific console warning naming the sibling "Google Cloud Key File Path" field and `GOOGLE_APPLICATION_CREDENTIALS` env var, and the settings UI shows an inline warning under the field while the input still looks like a path. Auth behavior is unchanged for correctly-configured users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Zoo Code Changelog
 
+## 3.56.0
+
+### Minor Changes
+
+- Add Claude Opus 4.8 support across Anthropic, Bedrock, and Vertex providers (PR #386 by @vandre-sales)
+- Add Opencode Go as a first-class provider (#172 by @vijay-0001, PR #319 by @proyectoauraorg)
+- Add glm-5.1, kimi-k2.6, and deepseek-v4-pro models to the Fireworks provider (#198 by @DeCodeTheWeb, PR #231 by @proyectoauraorg)
+- Show Zoo Code identity in outbound provider activity logs (#203 by @yfdyh000, PR #219 by @app/roomote)
+- Fix API requests hanging indefinitely on VS Code 1.122.0+ (#381 by @greatgradz-svg, #382 by @abcxlab, PR #383 by @app/roomote)
+- Fix terminal task cancellation so the running process is terminated when a task is cancelled (#245 by @proyectoauraorg, PR #261 by @proyectoauraorg)
+- Fix terminal Ctrl+C retry so processes that need multiple SIGINT signals are properly stopped (#266 by @edelauna, PR #272 by @proyectoauraorg)
+- Fix Gemini provider to honor custom model IDs instead of falling back to the default (#227 by @notoccupy2023-design, PR #317 by @proyectoauraorg)
+- Fix truncated Grok diffs caused by missing diff markers (#186 by @jcalfee, PR #230 by @proyectoauraorg)
+- Fix PowerShell detection on Windows when no shell profile is configured (#82 by @rossdonald, PR #239 by @proyectoauraorg)
+- Fix Vertex AI warning when the Google Cloud Credentials field receives a file path instead of JSON (PR #294 by @0xMink)
+- Rename Zoo Code in VS Code code actions (#328 by @rrewll, PR #329 by @rrewll)
+- Localize VS Code code action commands (#334 by @edelauna, PR #339 by @rrewll)
+- Migrate webview build to Vite 8 (PR #214 by @maxdewald)
+- Add comprehensive unit tests for AskFollowupQuestionTool and ListFilesTool (#206 by @app/roomote, PR #212, #213 by @proyectoauraorg)
+- Update `diff` to v5.2.2 for a security fix (PR #173 by @app/renovate)
+- Update `i18next-http-backend` to v3.0.5 for a security fix (PR #174 by @app/renovate)
+- Update `fast-xml-parser` to v5.7.0 for a security fix (PR #179 by @app/renovate)
+- Update `simple-git` to v3.36.0 for a security fix (PR #182 by @app/renovate)
+- Update `uuid` and pin esbuild/rollup/vite for a security fix (PR #205 by @app/renovate)
+- Update `turbo` to v2.9.14 for a security fix (PR #236 by @app/renovate)
+
 ## 3.55.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@
 You can find a quick guide for migrating from Roo Code to Zoo Code in the [Roo→Zoo migration guide](https://docs.zoocode.dev/roo-to-zoo-migration). We plan to try and help users as they transition over, we have our [Reddit](https://www.reddit.com/r/ZooCode) and [Discord](https://discord.gg/VxfP4Vx3gX)
 for this exact support, so if you are having problems or if you have question, jump on and ask.
 
-## What's New in v3.55.1
+## What's New in v3.56.0
 
-**This hotfix release** restores prompt execution on newer VS Code builds that
-ship ripgrep under `@vscode/ripgrep-universal`.
-
-- Fix API requests hanging indefinitely on VS Code 1.122.0+ after the ripgrep
-  package rename
+- **Claude Opus 4.8** support across Anthropic, Bedrock, and Vertex providers
+- **Opencode Go** added as a new first-class API provider
+- **Reliable task cancellation** — cancelling a task now terminates the running process, with automatic Ctrl+C retry for stubborn processes
+- Fix Gemini custom model IDs being ignored and falling back to the default
+- Fix truncated Grok diffs caused by missing diff markers
+- Fix PowerShell detection on Windows when no shell profile is configured
+- Fix VS Code code actions still showing Roo Code branding; localized into all supported languages
+- Fix Vertex AI warning when the Google Cloud Credentials field receives a file path
+- Six security dependency updates (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 <details>
   <summary>🌐 Available languages</summary>
@@ -83,7 +87,7 @@ ship ripgrep under `@vscode/ripgrep-universal`.
 - [简体中文](locales/zh-CN/README.md)
 - [繁體中文](locales/zh-TW/README.md)
 - ...
-  </details>
+    </details>
 
 ---
 

--- a/locales/ca/README.md
+++ b/locales/ca/README.md
@@ -30,35 +30,17 @@
 
 Pots trobar una guia ràpida per passar de Roo Code a Zoo Code a la [guia de migració Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Volem ajudar tant com puguem durant la transició, i per això tens el nostre [Reddit](https://www.reddit.com/r/ZooCode) i [Discord](https://discord.gg/VxfP4Vx3gX) per a aquest suport. Si tens problemes o alguna pregunta, entra i pregunta.
 
-## Novetats a la v3.55.1
+## Novetats a la v3.56.0
 
-**Aquesta versió hotfix** restaura l'execució dels prompts a les versions noves de VS Code que inclouen ripgrep sota `@vscode/ripgrep-universal`.
-
-- S'ha corregit el bloqueig indefinit de les sol·licituds d'API a VS Code 1.122.0+ després del canvi de paquet de ripgrep.
-
-<details>
-  <summary>🌐 Idiomes disponibles</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Suport per a **Claude Opus 4.8** als proveïdors Anthropic, Bedrock i Vertex
+- **Opencode Go** afegit com a nou proveïdor d'API de primera classe
+- **Cancel·lació de tasques fiable** — cancel·lar una tasca ara finalitza el procés en execució, amb reintent automàtic de Ctrl+C per als processos que no responen
+- S'han corregit els ID de model personalitzats de Gemini que s'ignoraven i tornaven al valor predeterminat
+- S'han corregit els diffs de Grok truncats per marcadors faltants
+- S'ha corregit la detecció de PowerShell a Windows quan no hi ha cap perfil de shell configurat
+- S'han corregit les accions de codi del VS Code que encara mostraven la marca Roo Code; localitzades en tots els idiomes suportats
+- S'ha corregit l'avís de Vertex AI quan el camp de credencials de Google Cloud rep una ruta de fitxer
+- Sis actualitzacions de seguretat de dependències (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/de/README.md
+++ b/locales/de/README.md
@@ -30,35 +30,17 @@
 
 Eine kurze Anleitung für den Wechsel von Roo Code zu Zoo Code findest du im [Roo→Zoo-Migrationsleitfaden](https://docs.zoocode.dev/roo-to-zoo-migration). Wir wollen Nutzer beim Umstieg so gut wie möglich unterstützen, und genau dafür sind unser [Reddit](https://www.reddit.com/r/ZooCode) und [Discord](https://discord.gg/VxfP4Vx3gX) da. Wenn du Probleme hast oder Fragen auftauchen, komm vorbei und frag nach.
 
-## Neu in v3.55.1
+## Neu in v3.56.0
 
-**Dieses Hotfix-Release** stellt die Ausführung von Prompts auf neueren VS Code-Versionen wieder her, die ripgrep unter `@vscode/ripgrep-universal` ausliefern.
-
-- Behebt API-Anfragen, die sich unter VS Code 1.122.0+ nach der Umbenennung des ripgrep-Pakets endlos aufhängen.
-
-<details>
-  <summary>🌐 Verfügbare Sprachen</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- **Claude Opus 4.8**-Unterstützung für Anthropic, Bedrock und Vertex
+- **Opencode Go** als neuer vollwertiger API-Provider hinzugefügt
+- **Zuverlässiger Task-Abbruch** — das Abbrechen einer Aufgabe beendet jetzt den laufenden Prozess, mit automatischem Ctrl+C-Retry für hartnäckige Prozesse
+- Benutzerdefinierte Gemini-Modell-IDs werden nicht mehr ignoriert und auf den Standard zurückgesetzt
+- Abgeschnittene Grok-Diffs durch fehlende Markierungen behoben
+- PowerShell-Erkennung unter Windows ohne konfiguriertes Shell-Profil korrigiert
+- VS Code-Code-Actions zeigen nicht mehr Roo Code-Branding; in alle unterstützten Sprachen lokalisiert
+- Vertex AI-Warnung bei Dateipfad im Google Cloud Credentials-Feld behoben
+- Sechs Sicherheitsupdates für Abhängigkeiten (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/es/README.md
+++ b/locales/es/README.md
@@ -30,35 +30,17 @@
 
 Puedes encontrar una guía rápida para pasar de Roo Code a Zoo Code en la [guía de migración Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Queremos ayudar a los usuarios durante la transición, y para eso tenemos nuestro [Reddit](https://www.reddit.com/r/ZooCode) y [Discord](https://discord.gg/VxfP4Vx3gX). Si tienes problemas o alguna pregunta, entra y pregúntanos.
 
-## Novedades de la v3.55.1
+## Novedades de la v3.56.0
 
-**Esta versión hotfix** restablece la ejecución de prompts en las versiones nuevas de VS Code que distribuyen ripgrep bajo `@vscode/ripgrep-universal`.
-
-- Corrige las solicitudes de API que quedaban cargando indefinidamente en VS Code 1.122.0+ tras el cambio de paquete de ripgrep.
-
-<details>
-  <summary>🌐 Idiomas disponibles</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Soporte para **Claude Opus 4.8** en los proveedores Anthropic, Bedrock y Vertex
+- **Opencode Go** añadido como nuevo proveedor de API de primera clase
+- **Cancelación de tareas fiable** — cancelar una tarea ahora termina el proceso en ejecución, con reintento automático de Ctrl+C para procesos que no responden
+- Se corrigieron los IDs de modelo personalizados de Gemini que se ignoraban y volvían al valor predeterminado
+- Se corrigieron los diffs de Grok truncados por marcadores faltantes
+- Se corrigió la detección de PowerShell en Windows cuando no hay perfil de shell configurado
+- Se corrigieron las acciones de código de VS Code que aún mostraban la marca Roo Code; localizadas en todos los idiomas soportados
+- Se corrigió la advertencia de Vertex AI cuando el campo de credenciales de Google Cloud recibe una ruta de archivo
+- Seis actualizaciones de seguridad de dependencias (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/fr/README.md
+++ b/locales/fr/README.md
@@ -30,35 +30,17 @@
 
 Tu peux trouver un guide rapide pour passer de Roo Code à Zoo Code dans le [guide de migration Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). On veut aider au maximum pendant la transition, et notre [Reddit](https://www.reddit.com/r/ZooCode) et notre [Discord](https://discord.gg/VxfP4Vx3gX) sont là pour ça. Si tu rencontres un problème ou si tu as une question, viens demander.
 
-## Nouveautés de la v3.55.1
+## Nouveautés de la v3.56.0
 
-**Cette version corrective** rétablit l'exécution des prompts sur les versions récentes de VS Code qui distribuent ripgrep sous `@vscode/ripgrep-universal`.
-
-- Corrige les requêtes API qui restaient bloquées indéfiniment sur VS Code 1.122.0+ après le renommage du package ripgrep.
-
-<details>
-  <summary>🌐 Langues disponibles</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Support de **Claude Opus 4.8** pour les fournisseurs Anthropic, Bedrock et Vertex
+- **Opencode Go** ajouté comme nouveau fournisseur d'API de premier plan
+- **Annulation de tâches fiable** — annuler une tâche arrête désormais le processus en cours, avec une relance automatique de Ctrl+C pour les processus récalcitrants
+- Correction des ID de modèles personnalisés Gemini qui étaient ignorés et revenaient à la valeur par défaut
+- Correction des diffs Grok tronqués par des marqueurs manquants
+- Correction de la détection de PowerShell sous Windows sans profil de shell configuré
+- Correction des code actions VS Code qui affichaient encore le nom Roo Code ; localisées dans toutes les langues supportées
+- Correction de l'avertissement Vertex AI quand le champ des identifiants Google Cloud reçoit un chemin de fichier
+- Six mises à jour de sécurité de dépendances (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/hi/README.md
+++ b/locales/hi/README.md
@@ -30,35 +30,17 @@
 
 Roo Code से Zoo Code में आने के लिए एक quick guide तुम्हें [Roo→Zoo migration guide](https://docs.zoocode.dev/roo-to-zoo-migration) में मिल जाएगी। We plan to help users as much as possible during the transition, और उसी support के लिए हमारा [Reddit](https://www.reddit.com/r/ZooCode) और [Discord](https://discord.gg/VxfP4Vx3gX) है। अगर तुम्हें कोई problem हो या कोई question हो, आकर पूछो।
 
-## v3.55.1 में नया क्या है
+## v3.56.0 में नया क्या है
 
-**यह hotfix release** उन नए VS Code versions पर prompt execution वापस लाता है जो ripgrep को `@vscode/ripgrep-universal` के तहत ship करते हैं।
-
-- VS Code 1.122.0+ में ripgrep package rename के बाद API requests के अनिश्चित समय तक spinner पर अटकने की समस्या ठीक की गई।
-
-<details>
-  <summary>🌐 उपलब्ध भाषाएँ</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Anthropic, Bedrock और Vertex providers पर **Claude Opus 4.8** का समर्थन
+- **Opencode Go** को नए first-class API provider के रूप में जोड़ा गया
+- **भरोसेमंद task cancellation** — किसी task को cancel करने पर अब चल रहा process सही तरीके से बंद होता है, जिद्दी processes के लिए automatic Ctrl+C retry भी
+- Gemini के custom model IDs को अनदेखा करके default पर fallback होने की समस्या ठीक की गई
+- Missing diff markers के कारण truncated Grok diffs ठीक किए गए
+- Windows पर कोई shell profile न होने पर PowerShell detection ठीक की गई
+- VS Code code actions में अभी भी Roo Code branding दिखने की समस्या ठीक की गई; सभी supported languages में localized
+- Google Cloud Credentials field में file path मिलने पर Vertex AI की गलत warning ठीक की गई
+- छह security dependency updates (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/id/README.md
+++ b/locales/id/README.md
@@ -30,35 +30,17 @@
 
 Kamu bisa menemukan panduan singkat untuk berpindah dari Roo Code ke Zoo Code di [panduan migrasi Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Kami ingin membantu pengguna semaksimal mungkin selama masa transisi, dan itulah gunanya [Reddit](https://www.reddit.com/r/ZooCode) dan [Discord](https://discord.gg/VxfP4Vx3gX) kami. Kalau kamu mengalami masalah atau punya pertanyaan, langsung mampir dan tanya.
 
-## Yang Baru di v3.55.1
+## Yang Baru di v3.56.0
 
-**Rilis hotfix ini** memulihkan eksekusi prompt di versi VS Code baru yang mengemas ripgrep di bawah `@vscode/ripgrep-universal`.
-
-- Memperbaiki request API yang terus menggantung di VS Code 1.122.0+ setelah rename package ripgrep.
-
-<details>
-  <summary>🌐 Bahasa yang tersedia</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Dukungan **Claude Opus 4.8** untuk provider Anthropic, Bedrock, dan Vertex
+- **Opencode Go** ditambahkan sebagai provider API baru kelas utama
+- **Pembatalan tugas yang andal** — membatalkan tugas kini benar-benar menghentikan proses yang berjalan, dengan percobaan ulang Ctrl+C otomatis untuk proses yang sulit dihentikan
+- Memperbaiki ID model kustom Gemini yang diabaikan dan kembali ke default
+- Memperbaiki diff Grok yang terpotong karena marker yang hilang
+- Memperbaiki deteksi PowerShell di Windows tanpa profil shell yang dikonfigurasi
+- Memperbaiki code action VS Code yang masih menampilkan branding Roo Code; dilokalisasi ke semua bahasa yang didukung
+- Memperbaiki peringatan Vertex AI saat field Google Cloud Credentials menerima path file
+- Enam pembaruan keamanan dependensi (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/it/README.md
+++ b/locales/it/README.md
@@ -30,35 +30,17 @@
 
 Puoi trovare una guida rapida per passare da Roo Code a Zoo Code nella [guida alla migrazione Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Vogliamo aiutare gli utenti il più possibile durante la transizione, e per questo abbiamo il nostro [Reddit](https://www.reddit.com/r/ZooCode) e il nostro [Discord](https://discord.gg/VxfP4Vx3gX). Se hai problemi o domande, passa pure e chiedi.
 
-## Novità in v3.55.1
+## Novità in v3.56.0
 
-**Questa hotfix release** ripristina l'esecuzione dei prompt nelle versioni più recenti di VS Code che distribuiscono ripgrep come `@vscode/ripgrep-universal`.
-
-- Risolve le richieste API che rimanevano bloccate indefinitamente su VS Code 1.122.0+ dopo la rinomina del pacchetto ripgrep.
-
-<details>
-  <summary>🌐 Lingue disponibili</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Supporto per **Claude Opus 4.8** sui provider Anthropic, Bedrock e Vertex
+- **Opencode Go** aggiunto come nuovo provider API di primo livello
+- **Cancellazione delle task affidabile** — annullare una task ora termina correttamente il processo in esecuzione, con retry automatico di Ctrl+C per i processi ostinati
+- Corretti gli ID modello personalizzati di Gemini che venivano ignorati e tornavano al valore predefinito
+- Corretti i diff di Grok troncati per marcatori mancanti
+- Corretta la rilevazione di PowerShell su Windows senza profilo di shell configurato
+- Corrette le code action di VS Code che mostravano ancora il nome Roo Code; localizzate in tutte le lingue supportate
+- Corretta la notifica di Vertex AI quando il campo delle credenziali Google Cloud riceve un percorso file
+- Sei aggiornamenti di sicurezza delle dipendenze (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/ja/README.md
+++ b/locales/ja/README.md
@@ -30,35 +30,17 @@
 
 Roo Code から Zoo Code へ移行するためのクイックガイドは、[Roo→Zoo 移行ガイド](https://docs.zoocode.dev/roo-to-zoo-migration) で確認できます。移行中のユーザーをできるだけ支援したいと考えていて、そのために [Reddit](https://www.reddit.com/r/ZooCode) と [Discord](https://discord.gg/VxfP4Vx3gX) を用意しています。困ったことや質問があれば、気軽に参加して聞いてください。
 
-## v3.55.1 の新機能
+## v3.56.0 の新機能
 
-**このホットフィックス リリース** は、ripgrep を `@vscode/ripgrep-universal` として同梱する新しい VS Code でのプロンプト実行を復旧します。
-
-- ripgrep パッケージ名の変更後、VS Code 1.122.0 以降で API リクエストが無限に待機し続ける問題を修正。
-
-<details>
-  <summary>🌐 利用可能な言語</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Anthropic・Bedrock・Vertex で **Claude Opus 4.8** をサポート
+- **Opencode Go** を新たな正式 API プロバイダーとして追加
+- **タスクキャンセルの改善** — タスクをキャンセルすると実行中のプロセスが正しく終了。応答しないプロセスには Ctrl+C の自動リトライも実施
+- Gemini のカスタムモデル ID が無視されてデフォルトにフォールバックする問題を修正
+- マーカー欠落による Grok diff の切り捨てを修正
+- シェルプロファイルが未設定の Windows での PowerShell 検出を修正
+- VS Code コードアクションが Roo Code のブランド名を表示していた問題を修正。全サポート言語にローカライズ済み
+- Google Cloud 認証情報フィールドにファイルパスを受け取った際の Vertex AI の誤警告を修正
+- 6 件のセキュリティ依存関係更新 (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/ko/README.md
+++ b/locales/ko/README.md
@@ -30,35 +30,17 @@
 
 Roo Code에서 Zoo Code로 옮겨오는 빠른 가이드는 [Roo→Zoo 마이그레이션 가이드](https://docs.zoocode.dev/roo-to-zoo-migration)에서 확인할 수 있어. 전환하는 동안 사용자들을 최대한 돕고 싶고, 바로 그 지원을 위해 [Reddit](https://www.reddit.com/r/ZooCode)와 [Discord](https://discord.gg/VxfP4Vx3gX)를 운영하고 있어. 문제가 있거나 궁금한 점이 있으면 들어와서 편하게 물어봐.
 
-## v3.55.1의 새로운 기능
+## v3.56.0의 새로운 기능
 
-**이번 핫픽스 릴리스는** ripgrep를 `@vscode/ripgrep-universal`로 제공하는 최신 VS Code에서 프롬프트 실행을 복구합니다.
-
-- ripgrep 패키지 이름 변경 이후 VS Code 1.122.0+에서 API 요청이 무한 로딩에 빠지는 문제를 수정했어요.
-
-<details>
-  <summary>🌐 사용 가능한 언어</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Anthropic, Bedrock, Vertex provider에서 **Claude Opus 4.8** 지원
+- **Opencode Go**를 새로운 first-class API provider로 추가
+- **안정적인 task 취소** — task를 취소하면 실행 중인 프로세스가 제대로 종료돼요. 잘 안 꺼지는 프로세스에는 자동으로 Ctrl+C를 재시도해요
+- Gemini 커스텀 모델 ID가 무시되고 기본값으로 폴백되던 문제 수정
+- 마커 누락으로 인한 Grok diff 잘림 문제 수정
+- 쉘 프로파일이 없는 Windows에서 PowerShell 감지 문제 수정
+- VS Code code action에 여전히 Roo Code 브랜딩이 표시되던 문제 수정; 모든 지원 언어로 로컬라이즈
+- Google Cloud Credentials 필드에 파일 경로를 입력했을 때 Vertex AI 경고가 잘못 표시되던 문제 수정
+- 보안 의존성 업데이트 6건 (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/nl/README.md
+++ b/locales/nl/README.md
@@ -30,35 +30,17 @@
 
 Je vindt een korte handleiding voor de overstap van Roo Code naar Zoo Code in de [Roo→Zoo-migratiegids](https://docs.zoocode.dev/roo-to-zoo-migration). We willen gebruikers zo goed mogelijk helpen tijdens de overgang, en precies daarvoor zijn onze [Reddit](https://www.reddit.com/r/ZooCode) en [Discord](https://discord.gg/VxfP4Vx3gX) er. Als je ergens tegenaan loopt of vragen hebt, kom langs en vraag het.
 
-## Nieuw in v3.55.1
+## Nieuw in v3.56.0
 
-**Deze hotfix-release** herstelt het uitvoeren van prompts op nieuwere VS Code-versies die ripgrep onder `@vscode/ripgrep-universal` leveren.
-
-- Verhelpt API-aanvragen die op VS Code 1.122.0+ oneindig bleven hangen na de hernoeming van het ripgrep-pakket.
-
-<details>
-  <summary>🌐 Beschikbare talen</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- **Claude Opus 4.8**-ondersteuning voor Anthropic, Bedrock en Vertex
+- **Opencode Go** toegevoegd als nieuwe eersteklas API-provider
+- **Betrouwbare taakafsluiting** — een taak annuleren beëindigt nu correct het lopende proces, met automatische Ctrl+C-herpoging voor hardnekkige processen
+- Aangepaste Gemini-model-ID's die werden genegeerd en terugvielen op de standaard zijn gecorrigeerd
+- Afgeknipte Grok-diffs door ontbrekende markeerders zijn opgelost
+- PowerShell-detectie op Windows zonder geconfigureerd shell-profiel is gecorrigeerd
+- VS Code-code-acties die nog de Roo Code-naam toonden zijn gecorrigeerd; gelokaliseerd in alle ondersteunde talen
+- Vertex AI-waarschuwing bij een bestandspad in het Google Cloud Credentials-veld is opgelost
+- Zes beveiligingsupdates voor afhankelijkheden (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/pl/README.md
+++ b/locales/pl/README.md
@@ -30,35 +30,17 @@
 
 Szybki przewodnik po przejściu z Roo Code do Zoo Code znajdziesz w [przewodniku migracji Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Chcemy jak najlepiej pomagać użytkownikom w czasie przejścia i właśnie do tego służą nasze [Reddit](https://www.reddit.com/r/ZooCode) oraz [Discord](https://discord.gg/VxfP4Vx3gX). Jeśli masz problem albo pytanie, wpadaj i pytaj.
 
-## Nowości w v3.55.1
+## Nowości w v3.56.0
 
-**Ta poprawka hotfix** przywraca wykonywanie promptów w nowszych wersjach VS Code, które dostarczają ripgrep jako `@vscode/ripgrep-universal`.
-
-- Naprawia żądania API, które po zmianie nazwy pakietu ripgrep zawieszały się bez końca w VS Code 1.122.0+.
-
-<details>
-  <summary>🌐 Dostępne języki</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Wsparcie dla **Claude Opus 4.8** u dostawców Anthropic, Bedrock i Vertex
+- **Opencode Go** dodany jako nowy dostawca API pierwszej klasy
+- **Niezawodne anulowanie zadań** — anulowanie zadania teraz poprawnie kończy uruchomiony proces, z automatycznym ponowieniem Ctrl+C dla opornych procesów
+- Naprawiono niestandardowe ID modeli Gemini, które były ignorowane i wracały do domyślnego
+- Naprawiono obcinanie diffów Grok przez brakujące znaczniki
+- Naprawiono wykrywanie PowerShell na Windows bez skonfigurowanego profilu powłoki
+- Naprawiono akcje kodu VS Code wyświetlające nazwę Roo Code; zlokalizowane we wszystkich obsługiwanych językach
+- Naprawiono ostrzeżenie Vertex AI przy ścieżce pliku w polu poświadczeń Google Cloud
+- Sześć aktualizacji bezpieczeństwa zależności (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/pt-BR/README.md
+++ b/locales/pt-BR/README.md
@@ -30,35 +30,17 @@
 
 Você encontra um guia rápido para migrar do Roo Code para o Zoo Code no [guia de migração Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Queremos ajudar os usuários durante essa transição da melhor forma possível, e é exatamente para isso que temos nosso [Reddit](https://www.reddit.com/r/ZooCode) e nosso [Discord](https://discord.gg/VxfP4Vx3gX). Se você tiver algum problema ou dúvida, apareça por lá e pergunte.
 
-## Novidades na v3.55.1
+## Novidades na v3.56.0
 
-**Este hotfix** restaura a execução de prompts nas novas versões do VS Code que distribuem o ripgrep como `@vscode/ripgrep-universal`.
-
-- Corrige as requisições de API que ficavam carregando indefinidamente no VS Code 1.122.0+ após a renomeação do pacote ripgrep.
-
-<details>
-  <summary>🌐 Idiomas disponíveis</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Suporte ao **Claude Opus 4.8** nos provedores Anthropic, Bedrock e Vertex
+- **Opencode Go** adicionado como novo provedor de API de primeira classe
+- **Cancelamento de tarefas confiável** — cancelar uma tarefa agora encerra corretamente o processo em execução, com retry automático de Ctrl+C para processos resistentes
+- Corrigidos IDs de modelo personalizado do Gemini que eram ignorados e voltavam ao padrão
+- Corrigido o truncamento de diffs do Grok por marcadores ausentes
+- Corrigida a detecção do PowerShell no Windows sem perfil de shell configurado
+- Corrigidas as code actions do VS Code que ainda exibiam o nome Roo Code; localizadas em todos os idiomas suportados
+- Corrigido o aviso do Vertex AI quando o campo de credenciais do Google Cloud recebe um caminho de arquivo
+- Seis atualizações de segurança de dependências (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/ru/README.md
+++ b/locales/ru/README.md
@@ -30,35 +30,17 @@
 
 Короткое руководство по переходу с Roo Code на Zoo Code можно найти в [гайде по миграции Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Мы хотим как можно лучше помочь пользователям во время перехода, и именно для этого у нас есть [Reddit](https://www.reddit.com/r/ZooCode) и [Discord](https://discord.gg/VxfP4Vx3gX). Если у тебя возникнут проблемы или вопросы, заходи и спрашивай.
 
-## Что нового в v3.55.1
+## Что нового в v3.56.0
 
-**Этот хотфикс-релиз** восстанавливает выполнение промптов в новых версиях VS Code, которые поставляют ripgrep как `@vscode/ripgrep-universal`.
-
-- Исправляет API-запросы, которые бесконечно зависали в VS Code 1.122.0+ после переименования пакета ripgrep.
-
-<details>
-  <summary>🌐 Доступные языки</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Поддержка **Claude Opus 4.8** у провайдеров Anthropic, Bedrock и Vertex
+- **Opencode Go** добавлен как новый полноценный API-провайдер
+- **Надёжная отмена задач** — отмена задачи теперь корректно завершает запущенный процесс, с автоматическим повтором Ctrl+C для упорных процессов
+- Исправлены пользовательские ID моделей Gemini, которые игнорировались и сбрасывались на стандартные
+- Исправлена обрезка диффов Grok из-за отсутствующих маркеров
+- Исправлено определение PowerShell в Windows без настроенного профиля оболочки
+- Исправлены code action в VS Code, которые всё ещё отображали название Roo Code; локализованы на все поддерживаемые языки
+- Исправлено предупреждение Vertex AI при получении пути к файлу в поле учётных данных Google Cloud
+- Шесть обновлений безопасности зависимостей (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/tr/README.md
+++ b/locales/tr/README.md
@@ -30,35 +30,17 @@
 
 Roo Code'dan Zoo Code'a geçmek için hızlı bir rehberi [Roo→Zoo geçiş rehberinde](https://docs.zoocode.dev/roo-to-zoo-migration) bulabilirsin. Geçiş sürecinde kullanıcılara elimizden geldiğince yardımcı olmak istiyoruz ve bunun için [Reddit](https://www.reddit.com/r/ZooCode) ile [Discord](https://discord.gg/VxfP4Vx3gX) topluluklarımız var. Bir sorun yaşarsan ya da sorunun olursa gel ve sor.
 
-## v3.55.1'daki Yenilikler
+## v3.56.0'daki Yenilikler
 
-**Bu hotfix sürümü** ripgrep'i `@vscode/ripgrep-universal` altında dağıtan yeni VS Code sürümlerinde prompt çalıştırmayı yeniden düzeltir.
-
-- ripgrep paketinin yeniden adlandırılmasından sonra VS Code 1.122.0+ üzerinde sonsuza kadar bekleyen API isteklerini düzeltir.
-
-<details>
-  <summary>🌐 Mevcut diller</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Anthropic, Bedrock ve Vertex sağlayıcılarında **Claude Opus 4.8** desteği
+- **Opencode Go** yeni birinci sınıf API sağlayıcısı olarak eklendi
+- **Güvenilir görev iptali** — bir görevi iptal etmek artık çalışan işlemi doğru şekilde sonlandırıyor; inatçı işlemler için otomatik Ctrl+C yeniden denemesi
+- Gemini özel model ID'lerinin yok sayılarak varsayılana geri dönmesi düzeltildi
+- Eksik işaretçilerden kaynaklanan Grok diff kesintileri düzeltildi
+- Yapılandırılmış shell profili olmayan Windows'ta PowerShell algılama düzeltildi
+- VS Code code action'larının hâlâ Roo Code markasını göstermesi düzeltildi; tüm desteklenen dillere yerelleştirildi
+- Google Cloud Credentials alanına dosya yolu girildiğinde Vertex AI uyarısı düzeltildi
+- Altı güvenlik bağımlılık güncellemesi (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/vi/README.md
+++ b/locales/vi/README.md
@@ -30,35 +30,17 @@
 
 Bạn có thể xem hướng dẫn nhanh để chuyển từ Roo Code sang Zoo Code trong [hướng dẫn chuyển đổi Roo→Zoo](https://docs.zoocode.dev/roo-to-zoo-migration). Chúng tôi muốn hỗ trợ người dùng nhiều nhất có thể trong quá trình chuyển đổi, và đó chính là lý do chúng tôi có [Reddit](https://www.reddit.com/r/ZooCode) và [Discord](https://discord.gg/VxfP4Vx3gX). Nếu bạn gặp vấn đề hoặc có câu hỏi, cứ vào hỏi nhé.
 
-## Điểm mới trong v3.55.1
+## Điểm mới trong v3.56.0
 
-**Bản hotfix này** khôi phục việc chạy prompt trên các phiên bản VS Code mới đóng gói ripgrep dưới tên `@vscode/ripgrep-universal`.
-
-- Sửa lỗi request API bị treo vô thời hạn trên VS Code 1.122.0+ sau khi gói ripgrep được đổi tên.
-
-<details>
-  <summary>🌐 Các ngôn ngữ có sẵn</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- Hỗ trợ **Claude Opus 4.8** trên các provider Anthropic, Bedrock và Vertex
+- **Opencode Go** được thêm làm provider API hạng nhất mới
+- **Hủy tác vụ đáng tin cậy** — hủy tác vụ giờ sẽ kết thúc đúng tiến trình đang chạy, với tính năng tự động thử lại Ctrl+C cho các tiến trình khó dừng
+- Sửa lỗi ID model tùy chỉnh của Gemini bị bỏ qua và rơi về mặc định
+- Sửa lỗi diff Grok bị cắt ngắn do thiếu marker
+- Sửa lỗi phát hiện PowerShell trên Windows khi không có shell profile
+- Sửa lỗi code action của VS Code vẫn hiển thị thương hiệu Roo Code; đã bản địa hóa sang tất cả ngôn ngữ được hỗ trợ
+- Sửa cảnh báo Vertex AI khi trường Google Cloud Credentials nhận đường dẫn file
+- Sáu bản cập nhật bảo mật phụ thuộc (diff, i18next-http-backend, fast-xml-parser, simple-git, uuid, turbo)
 
 ---
 

--- a/locales/zh-CN/README.md
+++ b/locales/zh-CN/README.md
@@ -30,35 +30,17 @@
 
 你可以在 [Roo→Zoo 迁移指南](https://docs.zoocode.dev/roo-to-zoo-migration) 中找到从 Roo Code 迁移到 Zoo Code 的快速说明。我们希望在大家迁移过程中尽可能提供帮助，这也是我们设立 [Reddit](https://www.reddit.com/r/ZooCode) 和 [Discord](https://discord.gg/VxfP4Vx3gX) 社区的原因。如果你遇到问题或有任何疑问，欢迎加入后直接提问。
 
-## v3.55.1 新增内容
+## v3.56.0 新增内容
 
-**这个热修复版本** 恢复了在使用 `@vscode/ripgrep-universal` 打包 ripgrep 的新版本 VS Code 上的提示执行。
-
-- 修复 ripgrep 包重命名后，VS Code 1.122.0+ 中 API 请求无限转圈的问题。
-
-<details>
-  <summary>🌐 可用语言</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- 为 Anthropic、Bedrock 和 Vertex 提供商添加 **Claude Opus 4.8** 支持
+- 新增 **Opencode Go** 作为一等 API 提供商
+- **可靠的任务取消** — 取消任务现在会正确终止正在运行的进程，对于顽固进程还会自动重试 Ctrl+C
+- 修复 Gemini 自定义模型 ID 被忽略并回退到默认值的问题
+- 修复因缺少标记导致的 Grok diff 截断问题
+- 修复 Windows 上未配置 shell 配置文件时 PowerShell 检测失败的问题
+- 修复 VS Code 代码操作仍显示 Roo Code 品牌名称的问题；已本地化为所有支持的语言
+- 修复 Google Cloud 凭据字段收到文件路径时 Vertex AI 的错误警告
+- 六项安全依赖更新（diff、i18next-http-backend、fast-xml-parser、simple-git、uuid、turbo）
 
 ---
 

--- a/locales/zh-TW/README.md
+++ b/locales/zh-TW/README.md
@@ -30,35 +30,17 @@
 
 你可以在 [Roo→Zoo 遷移指南](https://docs.zoocode.dev/roo-to-zoo-migration) 中找到從 Roo Code 遷移到 Zoo Code 的快速說明。我們希望在大家轉移過程中盡可能提供協助，這也是我們設立 [Reddit](https://www.reddit.com/r/ZooCode) 和 [Discord](https://discord.gg/VxfP4Vx3gX) 社群的原因。如果你遇到問題或有任何疑問，歡迎加入後直接提問。
 
-## v3.55.1 新功能
+## v3.56.0 新功能
 
-**這個 hotfix 版本** 恢復了在以 `@vscode/ripgrep-universal` 打包 ripgrep 的新版 VS Code 上的提示執行。
-
-- 修正 ripgrep 套件重新命名後，VS Code 1.122.0+ 中 API 請求無限轉圈的問題。
-
-<details>
-  <summary>🌐 支援語言</summary>
-
-- [English](../../README.md)
-- [Català](../ca/README.md)
-- [Deutsch](../de/README.md)
-- [Español](../es/README.md)
-- [Français](../fr/README.md)
-- [हिंदी](../hi/README.md)
-- [Bahasa Indonesia](../id/README.md)
-- [Italiano](../it/README.md)
-- [日本語](../ja/README.md)
-- [한국어](../ko/README.md)
-- [Nederlands](../nl/README.md)
-- [Polski](../pl/README.md)
-- [Português (BR)](../pt-BR/README.md)
-- [Русский](../ru/README.md)
-- [Türkçe](../tr/README.md)
-- [Tiếng Việt](../vi/README.md)
-- [简体中文](../zh-CN/README.md)
-- [繁體中文](../zh-TW/README.md)
-- ...
-  </details>
+- 為 Anthropic、Bedrock 和 Vertex 供應商新增 **Claude Opus 4.8** 支援
+- 新增 **Opencode Go** 作為一等 API 供應商
+- **可靠的任務取消** — 取消任務現在會正確終止正在執行的程序，對於頑固程序還會自動重試 Ctrl+C
+- 修正 Gemini 自訂模型 ID 被忽略並退回預設值的問題
+- 修正因缺少標記導致的 Grok diff 截斷問題
+- 修正 Windows 上未設定 shell 設定檔時 PowerShell 偵測失敗的問題
+- 修正 VS Code 程式碼動作仍顯示 Roo Code 品牌名稱的問題；已本地化為所有支援的語言
+- 修正 Google Cloud 憑證欄位收到檔案路徑時 Vertex AI 的錯誤警告
+- 六項安全性相依套件更新（diff、i18next-http-backend、fast-xml-parser、simple-git、uuid、turbo）
 
 ---
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -160,7 +160,7 @@ export class ClineProvider
 
 	public isViewLaunched = false
 	public settingsImportedAt?: number
-	public readonly latestAnnouncementId = "may-2026-v3.55.0-mimo-handoff-stability" // v3.55.0 Xiaomi MiMo, upstream handoff updates, stability fixes
+	public readonly latestAnnouncementId = "may-2026-v3.56.0-opus48-opencodego-cancellation" // v3.56.0 Claude Opus 4.8, Opencode Go provider, task cancellation fixes
 	public readonly providerSettingsManager: ProviderSettingsManager
 	public readonly customModesManager: CustomModesManager
 

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%extension.displayName%",
 	"description": "%extension.description%",
 	"publisher": "ZooCodeOrganization",
-	"version": "3.55.1",
+	"version": "3.56.0",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Novetats:",
-			"highlight1": "Proveïdor Xiaomi MiMo: S'ha afegit Xiaomi MiMo com a proveïdor d'API de primer nivell perquè puguis configurar els models MiMo directament a Zoo Code.",
-			"highlight2": "Traspàs upstream de Zoo Code: S'ha incorporat l'última fusió upstream del sunset i les actualitzacions relacionades de la plataforma per mantenir Zoo Code alineat amb el treball de traspàs de la comunitat.",
-			"highlight3": "Correccions d'estabilitat al xat i als proveïdors: S'han corregit els textos de l'inici de sessió d'MCP, les sol·licituds completes d'eines de Gemini, la gestió de la temperatura d'OpenAI i el renderitzat del text amb una sola titlla a Markdown."
+			"highlight1": "Claude Opus 4.8 i Opencode Go: S'ha afegit Claude Opus 4.8 a Anthropic, Bedrock i Vertex, més Opencode Go com a nou proveïdor de primera classe.",
+			"highlight2": "Cancel·lació de tasques fiable: Cancel·lar una tasca ara finalitza correctament el procés en execució, amb reintent automàtic de Ctrl+C per als processos que no responen.",
+			"highlight3": "Correccions de proveïdors i editor: S'han corregit els ID de model personalitzats de Gemini, el truncament de diffs de Grok, la detecció de PowerShell a Windows i la marca de les accions de codi del VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Novetats al núvol:",

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Was ist neu:",
-			"highlight1": "Xiaomi MiMo-Provider: Xiaomi MiMo als vollwertigen API-Provider hinzugefügt, damit du MiMo-Modelle direkt in Zoo Code konfigurieren kannst.",
-			"highlight2": "Upstream-Zoo-Code-Handoff: Den neuesten Upstream-Sunset-Merge und zugehörige Plattform-Updates übernommen, damit Zoo Code mit der Community-Handoff-Arbeit abgestimmt bleibt.",
-			"highlight3": "Stabilitätsfixes für Chat und Provider: Texte auf der MCP-Anmeldeseite, Gemini-Anfragen mit vollem Tool-Set, die OpenAI-Temperaturbehandlung und die Markdown-Darstellung einzelner Tilden korrigiert."
+			"highlight1": "Claude Opus 4.8 und Opencode Go: Claude Opus 4.8 wurde für Anthropic, Bedrock und Vertex hinzugefügt, plus Opencode Go als neuer vollwertiger Provider.",
+			"highlight2": "Zuverlässiger Task-Abbruch: Das Abbrechen einer Aufgabe beendet jetzt korrekt den laufenden Prozess, mit automatischem Ctrl+C-Retry für hartnäckige Prozesse.",
+			"highlight3": "Provider- und Editor-Fixes: Behoben wurden benutzerdefinierte Gemini-Modell-IDs, abgeschnittene Grok-Diffs, PowerShell-Erkennung unter Windows und die VS Code-Code-Action-Benennung."
 		},
 		"cloudAgents": {
 			"heading": "Neu in der Cloud:",

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -356,9 +356,9 @@
 		},
 		"release": {
 			"heading": "What's New:",
-			"highlight1": "Xiaomi MiMo provider: Added Xiaomi MiMo as a first-class API provider so you can configure MiMo models directly in Zoo Code.",
-			"highlight2": "Upstream Zoo Code handoff: Pulled in the latest upstream sunset merge and related platform updates to keep Zoo Code aligned with the community handoff work.",
-			"highlight3": "Stability fixes across chat and providers: Fixed MCP sign-in copy, Gemini full-tool requests, OpenAI temperature handling, and Markdown single-tilde rendering."
+			"highlight1": "Claude Opus 4.8 and Opencode Go: Added Claude Opus 4.8 across Anthropic, Bedrock, and Vertex, plus Opencode Go as a new first-class provider.",
+			"highlight2": "Reliable task cancellation: Cancelling a task now properly terminates the running process, with automatic Ctrl+C retry for stubborn processes.",
+			"highlight3": "Provider and editor fixes: Fixed Gemini custom model IDs, Grok diff truncation, PowerShell detection on Windows, and VS Code code action branding."
 		},
 		"cloudAgents": {
 			"heading": "New in the Cloud:",

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Novedades:",
-			"highlight1": "Proveedor Xiaomi MiMo: Se añadió Xiaomi MiMo como proveedor de API de primera clase para que puedas configurar modelos MiMo directamente en Zoo Code.",
-			"highlight2": "Traspaso upstream de Zoo Code: Se incorporaron el merge upstream del sunset y las actualizaciones relacionadas de la plataforma para mantener Zoo Code alineado con el trabajo de traspaso de la comunidad.",
-			"highlight3": "Correcciones de estabilidad en chat y proveedores: Se corrigieron los textos del inicio de sesión de MCP, las solicitudes de Gemini con todo el conjunto de herramientas, el manejo de la temperatura de OpenAI y el renderizado de Markdown con una sola tilde."
+			"highlight1": "Claude Opus 4.8 y Opencode Go: Se añadió Claude Opus 4.8 en Anthropic, Bedrock y Vertex, más Opencode Go como nuevo proveedor de primera clase.",
+			"highlight2": "Cancelación de tareas fiable: Cancelar una tarea ahora termina correctamente el proceso en ejecución, con reintento automático de Ctrl+C para procesos que no responden.",
+			"highlight3": "Correcciones de proveedores y editor: Se corrigieron los IDs de modelo personalizados de Gemini, el truncamiento de diffs de Grok, la detección de PowerShell en Windows y el nombre de las acciones de código de VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Novedades en la Nube:",

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Nouveautés :",
-			"highlight1": "Fournisseur Xiaomi MiMo : Xiaomi MiMo a été ajouté comme fournisseur d'API de premier plan pour que tu puisses configurer les modèles MiMo directement dans Zoo Code.",
-			"highlight2": "Handoff upstream de Zoo Code : Nous avons intégré la dernière fusion upstream du sunset et les mises à jour de plateforme associées pour garder Zoo Code aligné avec le travail de relais de la communauté.",
-			"highlight3": "Correctifs de stabilité dans le chat et les fournisseurs : Le texte de connexion MCP, les requêtes Gemini avec tout l'ensemble d'outils, la gestion de la température OpenAI et le rendu Markdown avec un tilde unique ont été corrigés."
+			"highlight1": "Claude Opus 4.8 et Opencode Go : Claude Opus 4.8 a été ajouté sur Anthropic, Bedrock et Vertex, plus Opencode Go comme nouveau fournisseur de premier plan.",
+			"highlight2": "Annulation de tâches fiable : Annuler une tâche termine désormais correctement le processus en cours, avec une relance automatique de Ctrl+C pour les processus récalcitrants.",
+			"highlight3": "Correctifs fournisseurs et éditeur : Correction des ID de modèles personnalisés Gemini, du truncage des diffs Grok, de la détection de PowerShell sous Windows et du nom des actions de code VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Nouveautés dans le Cloud :",

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "नया क्या है:",
-			"highlight1": "Xiaomi MiMo provider: Xiaomi MiMo को first-class API provider के रूप में जोड़ा गया है, ताकि आप MiMo models को सीधे Zoo Code में configure कर सकें।",
-			"highlight2": "Zoo Code upstream handoff: Community handoff work के साथ Zoo Code को aligned रखने के लिए latest upstream sunset merge और जुड़े platform updates को शामिल किया गया है।",
-			"highlight3": "Chat और providers में stability fixes: MCP sign-in copy, Gemini की full-tool requests, OpenAI temperature handling, और Markdown single-tilde rendering को ठीक किया गया है।"
+			"highlight1": "Claude Opus 4.8 और Opencode Go: Anthropic, Bedrock और Vertex पर Claude Opus 4.8 जोड़ा गया, साथ ही Opencode Go को नए first-class provider के रूप में शामिल किया गया।",
+			"highlight2": "भरोसेमंद task cancellation: किसी task को cancel करने पर अब चल रहा process सही तरीके से बंद हो जाता है, और जिद्दी processes के लिए automatic Ctrl+C retry भी होता है।",
+			"highlight3": "Provider और editor fixes: Gemini के custom model IDs, Grok diff truncation, Windows पर PowerShell detection, और VS Code code action branding को ठीक किया गया।"
 		},
 		"cloudAgents": {
 			"heading": "क्लाउड में नया:",

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -366,9 +366,9 @@
 		},
 		"release": {
 			"heading": "Yang Baru:",
-			"highlight1": "Provider Xiaomi MiMo: Xiaomi MiMo ditambahkan sebagai provider API kelas utama agar kamu bisa mengatur model MiMo langsung di Zoo Code.",
-			"highlight2": "Handoff upstream Zoo Code: Merge upstream sunset terbaru dan pembaruan platform terkait diambil agar Zoo Code tetap selaras dengan kerja handoff komunitas.",
-			"highlight3": "Perbaikan stabilitas di chat dan provider: Memperbaiki teks sign-in MCP, request Gemini dengan tool set penuh, penanganan temperature OpenAI, dan render Markdown untuk single tilde."
+			"highlight1": "Claude Opus 4.8 dan Opencode Go: Claude Opus 4.8 ditambahkan ke Anthropic, Bedrock, dan Vertex, ditambah Opencode Go sebagai provider baru kelas utama.",
+			"highlight2": "Pembatalan tugas yang andal: Membatalkan tugas kini benar-benar menghentikan proses yang berjalan, dengan percobaan ulang Ctrl+C otomatis untuk proses yang sulit dihentikan.",
+			"highlight3": "Perbaikan provider dan editor: Memperbaiki ID model kustom Gemini, pemotongan diff Grok, deteksi PowerShell di Windows, dan branding code action VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Baru di Cloud:",

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Novità:",
-			"highlight1": "Provider Xiaomi MiMo: Xiaomi MiMo è stato aggiunto come provider API di primo livello così puoi configurare i modelli MiMo direttamente in Zoo Code.",
-			"highlight2": "Handoff upstream di Zoo Code: È stata integrata l'ultima fusione upstream del sunset e i relativi aggiornamenti di piattaforma per mantenere Zoo Code allineato al lavoro di handoff della community.",
-			"highlight3": "Correzioni di stabilità per chat e provider: Sono stati corretti il testo del sign-in MCP, le richieste Gemini con il set completo di strumenti, la gestione della temperatura OpenAI e il rendering Markdown con tilde singola."
+			"highlight1": "Claude Opus 4.8 e Opencode Go: Claude Opus 4.8 aggiunto su Anthropic, Bedrock e Vertex, più Opencode Go come nuovo provider di primo livello.",
+			"highlight2": "Cancellazione delle task affidabile: Annullare una task ora termina correttamente il processo in esecuzione, con un retry automatico di Ctrl+C per i processi ostinati.",
+			"highlight3": "Fix per provider ed editor: Corretti gli ID modello personalizzati di Gemini, il troncamento dei diff di Grok, il rilevamento di PowerShell su Windows e il nome delle code action di VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Novità nel Cloud:",

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "新機能:",
-			"highlight1": "Xiaomi MiMo プロバイダー: Xiaomi MiMo を正式な API プロバイダーとして追加し、MiMo モデルを Zoo Code で直接設定できるようにしました。",
-			"highlight2": "Zoo Code の upstream handoff: 最新の upstream sunset merge と関連するプラットフォーム更新を取り込み、Zoo Code をコミュニティ移管作業と揃えました。",
-			"highlight3": "チャットとプロバイダーの安定性修正: MCP サインイン文言、Gemini のフルツールリクエスト、OpenAI temperature 処理、Markdown の単一チルダ描画を修正しました。"
+			"highlight1": "Claude Opus 4.8 と Opencode Go: Anthropic・Bedrock・Vertex に Claude Opus 4.8 を追加し、Opencode Go を新たな正式プロバイダーとして追加しました。",
+			"highlight2": "タスクキャンセルの改善: タスクをキャンセルすると実行中のプロセスが正しく終了するようになりました。応答しないプロセスには Ctrl+C の自動リトライも行います。",
+			"highlight3": "プロバイダーとエディターの修正: Gemini のカスタムモデル ID、Grok の差分切り捨て、Windows での PowerShell 検出、VS Code コードアクションのブランド名を修正しました。"
 		},
 		"cloudAgents": {
 			"heading": "クラウドの新機能:",

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "새로운 기능:",
-			"highlight1": "Xiaomi MiMo provider: Xiaomi MiMo를 first-class API provider로 추가해 MiMo 모델을 Zoo Code에서 직접 설정할 수 있게 했어요.",
-			"highlight2": "Zoo Code upstream handoff: 최신 upstream sunset merge와 관련 platform 업데이트를 반영해 Zoo Code가 커뮤니티 handoff 작업과 계속 맞춰지도록 했어요.",
-			"highlight3": "채팅과 provider 안정성 수정: MCP sign-in 문구, Gemini의 full-tool 요청, OpenAI temperature 처리, Markdown single-tilde 렌더링을 수정했어요."
+			"highlight1": "Claude Opus 4.8과 Opencode Go: Anthropic, Bedrock, Vertex에 Claude Opus 4.8을 추가했고, Opencode Go를 새로운 first-class provider로 추가했어요.",
+			"highlight2": "안정적인 task 취소: task를 취소하면 이제 실행 중인 프로세스가 제대로 종료돼요. 잘 안 꺼지는 프로세스에는 자동으로 Ctrl+C를 재시도해요.",
+			"highlight3": "Provider와 에디터 수정: Gemini 커스텀 모델 ID, Grok diff 잘림 현상, Windows PowerShell 감지, VS Code code action 브랜딩을 수정했어요."
 		},
 		"cloudAgents": {
 			"heading": "클라우드의 새로운 기능:",

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -310,9 +310,9 @@
 		},
 		"release": {
 			"heading": "Wat is nieuw:",
-			"highlight1": "Xiaomi MiMo-provider: Xiaomi MiMo toegevoegd als eersteklas API-provider, zodat je MiMo-modellen direct in Zoo Code kunt configureren.",
-			"highlight2": "Upstream-handoff van Zoo Code: De nieuwste upstream sunset-merge en bijbehorende platformupdates zijn overgenomen om Zoo Code afgestemd te houden op het community-handoffwerk.",
-			"highlight3": "Stabiliteitsfixes voor chat en providers: De MCP-aanmeldtekst, Gemini-verzoeken met de volledige toolset, de OpenAI-temperatuurafhandeling en Markdown met één tilde zijn gecorrigeerd."
+			"highlight1": "Claude Opus 4.8 en Opencode Go: Claude Opus 4.8 toegevoegd voor Anthropic, Bedrock en Vertex, plus Opencode Go als nieuwe eersteklas provider.",
+			"highlight2": "Betrouwbare taakafsluiting: Een taak annuleren beëindigt nu correct het lopende proces, met automatische Ctrl+C-herpoging voor hardnekkige processen.",
+			"highlight3": "Provider- en editorfixes: Aangepaste Gemini-model-ID's, afgeknipte Grok-diffs, PowerShell-detectie op Windows en de VS Code-code-actienaam zijn gecorrigeerd."
 		},
 		"cloudAgents": {
 			"heading": "Nieuw in de Cloud:",

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Co nowego:",
-			"highlight1": "Dostawca Xiaomi MiMo: Dodano Xiaomi MiMo jako pełnoprawnego dostawcę API, żebyś mógł konfigurować modele MiMo bezpośrednio w Zoo Code.",
-			"highlight2": "Upstreamowy handoff Zoo Code: Włączono najnowszy upstreamowy sunset merge i powiązane aktualizacje platformy, aby Zoo Code pozostał zgodny z pracą społeczności nad handoffem.",
-			"highlight3": "Poprawki stabilności w czacie i u dostawców: Naprawiono teksty logowania MCP, żądania Gemini z pełnym zestawem narzędzi, obsługę temperatury OpenAI i renderowanie Markdown z pojedynczą tyldą."
+			"highlight1": "Claude Opus 4.8 i Opencode Go: Claude Opus 4.8 dodano dla Anthropic, Bedrock i Vertex, a Opencode Go dołączono jako nowego dostawcę pierwszej klasy.",
+			"highlight2": "Niezawodne anulowanie zadań: Anulowanie zadania teraz poprawnie kończy działający proces, z automatycznym ponowieniem Ctrl+C dla opornych procesów.",
+			"highlight3": "Poprawki dostawców i edytora: Naprawiono niestandardowe ID modeli Gemini, obcinanie diffów Grok, wykrywanie PowerShell w Windows i nazwy akcji kodu VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Nowości w chmurze:",

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -337,9 +337,9 @@
 		},
 		"release": {
 			"heading": "Novidades:",
-			"highlight1": "Provedor Xiaomi MiMo: O Xiaomi MiMo foi adicionado como provedor de API de primeira classe para você configurar modelos MiMo diretamente no Zoo Code.",
-			"highlight2": "Handoff upstream do Zoo Code: Incorporamos o merge upstream mais recente do sunset e as atualizações relacionadas de plataforma para manter o Zoo Code alinhado ao trabalho de handoff da comunidade.",
-			"highlight3": "Correções de estabilidade em chat e provedores: Corrigimos os textos de sign-in do MCP, as requisições do Gemini com o conjunto completo de tools, o tratamento de temperatura da OpenAI e a renderização de til única em Markdown."
+			"highlight1": "Claude Opus 4.8 e Opencode Go: Claude Opus 4.8 adicionado para Anthropic, Bedrock e Vertex, mais Opencode Go como novo provedor de primeira classe.",
+			"highlight2": "Cancelamento de tarefas confiável: Cancelar uma tarefa agora encerra corretamente o processo em execução, com retry automático de Ctrl+C para processos resistentes.",
+			"highlight3": "Correções de provedores e editor: Corrigidos os IDs de modelo personalizado do Gemini, o truncamento de diffs do Grok, a detecção do PowerShell no Windows e o nome das code actions do VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Novidades na Nuvem:",

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -311,9 +311,9 @@
 		},
 		"release": {
 			"heading": "Что нового:",
-			"highlight1": "Провайдер Xiaomi MiMo: Xiaomi MiMo добавлен как полноценный API-провайдер, чтобы ты мог настраивать модели MiMo прямо в Zoo Code.",
-			"highlight2": "Upstream-handoff Zoo Code: Мы подтянули последний upstream sunset merge и связанные обновления платформы, чтобы Zoo Code оставался синхронизирован с работой сообщества по handoff.",
-			"highlight3": "Исправления стабильности в чате и у провайдеров: Исправлены текст входа MCP, запросы Gemini с полным набором инструментов, обработка температуры OpenAI и рендеринг Markdown с одиночной тильдой."
+			"highlight1": "Claude Opus 4.8 и Opencode Go: Claude Opus 4.8 добавлен для Anthropic, Bedrock и Vertex, плюс Opencode Go как новый полноценный провайдер.",
+			"highlight2": "Надёжная отмена задач: Отмена задачи теперь корректно завершает запущенный процесс, с автоматическим повтором Ctrl+C для упорных процессов.",
+			"highlight3": "Исправления провайдеров и редактора: Исправлены пользовательские ID моделей Gemini, обрезка диффов Grok, определение PowerShell в Windows и название code action в VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Новое в облаке:",

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -338,9 +338,9 @@
 		},
 		"release": {
 			"heading": "Yenilikler:",
-			"highlight1": "Xiaomi MiMo sağlayıcısı: Xiaomi MiMo, MiMo modellerini doğrudan Zoo Code içinde yapılandırabilmen için birinci sınıf bir API sağlayıcısı olarak eklendi.",
-			"highlight2": "Zoo Code upstream handoff'u: Zoo Code'u topluluk handoff çalışmasıyla uyumlu tutmak için en son upstream sunset merge'i ve ilgili platform güncellemeleri alındı.",
-			"highlight3": "Sohbet ve sağlayıcılarda kararlılık düzeltmeleri: MCP oturum açma metni, Gemini tam araç seti istekleri, OpenAI temperature işleme ve Markdown single-tilde renderingi düzeltildi."
+			"highlight1": "Claude Opus 4.8 ve Opencode Go: Anthropic, Bedrock ve Vertex'e Claude Opus 4.8 eklendi; Opencode Go ise yeni bir birinci sınıf sağlayıcı olarak katıldı.",
+			"highlight2": "Güvenilir görev iptali: Bir görevi iptal etmek artık çalışan işlemi doğru şekilde sonlandırıyor; inatçı işlemler için otomatik Ctrl+C yeniden denemesi de yapılıyor.",
+			"highlight3": "Sağlayıcı ve editör düzeltmeleri: Gemini özel model ID'leri, Grok diff kesintisi, Windows'ta PowerShell algılama ve VS Code code action isimlendirmesi düzeltildi."
 		},
 		"cloudAgents": {
 			"heading": "Cloud'daki yenilikler:",

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -338,9 +338,9 @@
 		},
 		"release": {
 			"heading": "Có gì mới:",
-			"highlight1": "Provider Xiaomi MiMo: Đã thêm Xiaomi MiMo như một provider API hạng nhất để bạn có thể cấu hình model MiMo trực tiếp trong Zoo Code.",
-			"highlight2": "Handoff upstream của Zoo Code: Đã lấy merge upstream sunset mới nhất cùng các cập nhật nền tảng liên quan để giữ Zoo Code đồng bộ với công việc handoff của cộng đồng.",
-			"highlight3": "Các bản sửa ổn định cho chat và provider: Đã sửa nội dung sign-in của MCP, các request Gemini với đầy đủ tool, cách xử lý temperature của OpenAI và render Markdown với single tilde."
+			"highlight1": "Claude Opus 4.8 và Opencode Go: Đã thêm Claude Opus 4.8 cho Anthropic, Bedrock và Vertex, cùng với Opencode Go là provider hạng nhất mới.",
+			"highlight2": "Hủy tác vụ đáng tin cậy: Hủy tác vụ giờ sẽ kết thúc đúng tiến trình đang chạy, với tính năng tự động thử lại Ctrl+C cho các tiến trình khó dừng.",
+			"highlight3": "Sửa lỗi provider và editor: Đã sửa ID model tùy chỉnh của Gemini, lỗi cắt ngắn diff của Grok, phát hiện PowerShell trên Windows và tên code action của VS Code."
 		},
 		"cloudAgents": {
 			"heading": "Mới trên Cloud:",

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -338,9 +338,9 @@
 		},
 		"release": {
 			"heading": "新增功能：",
-			"highlight1": "Xiaomi MiMo 提供商：已将 Xiaomi MiMo 添加为一等 API 提供商，让你可以直接在 Zoo Code 中配置 MiMo 模型。",
-			"highlight2": "Zoo Code 上游交接：已合入最新的上游 sunset merge 及相关平台更新，让 Zoo Code 持续与社区交接工作保持一致。",
-			"highlight3": "聊天与提供商稳定性修复：已修复 MCP 登录文案、Gemini 全工具集请求、OpenAI temperature 处理，以及 Markdown 单波浪线渲染。"
+			"highlight1": "Claude Opus 4.8 与 Opencode Go：已为 Anthropic、Bedrock 和 Vertex 添加 Claude Opus 4.8，并新增 Opencode Go 作为一等提供商。",
+			"highlight2": "可靠的任务取消：取消任务现在会正确终止正在运行的进程，对于顽固进程还会自动重试 Ctrl+C。",
+			"highlight3": "提供商与编辑器修复：修复了 Gemini 自定义模型 ID、Grok diff 截断、Windows 上的 PowerShell 检测以及 VS Code 代码操作的品牌名称。"
 		},
 		"cloudAgents": {
 			"heading": "云端新功能：",

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -359,9 +359,9 @@
 		},
 		"release": {
 			"heading": "新增功能：",
-			"highlight1": "Xiaomi MiMo 供應商：已將 Xiaomi MiMo 新增為一級 API 供應商，讓你可以直接在 Zoo Code 中設定 MiMo 模型。",
-			"highlight2": "Zoo Code 上游交接：已合入最新的上游 sunset merge 與相關平台更新，讓 Zoo Code 持續與社群交接工作保持一致。",
-			"highlight3": "聊天與供應商穩定性修正：已修正 MCP 登入文案、Gemini 全工具組請求、OpenAI temperature 處理，以及 Markdown 單波浪號渲染。"
+			"highlight1": "Claude Opus 4.8 與 Opencode Go：已為 Anthropic、Bedrock 和 Vertex 新增 Claude Opus 4.8，並新增 Opencode Go 作為一等供應商。",
+			"highlight2": "可靠的任務取消：取消任務現在會正確終止正在執行的程序，對於頑固程序還會自動重試 Ctrl+C。",
+			"highlight3": "供應商與編輯器修正：修正了 Gemini 自訂模型 ID、Grok diff 截斷、Windows 上的 PowerShell 偵測以及 VS Code 程式碼動作的品牌名稱。"
 		},
 		"cloudAgents": {
 			"heading": "雲端的新功能：",


### PR DESCRIPTION
## Summary

- Bump version to 3.56.0 in `src/package.json`
- Generate `CHANGELOG.md` with all 22 PRs merged since v3.54.1 (excluding what shipped in 3.55.0 and 3.55.1)
- Update root `README.md` and all 17 localized `locales/*/README.md` files with v3.56.0 What's New section
- Update in-app announcement highlights in `webview-ui/src/i18n/locales/*/chat.json` (all 18 locales)
- Update `latestAnnouncementId` in `src/core/webview/ClineProvider.ts`

## Highlights

- **Claude Opus 4.8** support across Anthropic, Bedrock, and Vertex providers (PR #386)
- **Opencode Go** added as a new first-class API provider (PR #319)
- **Reliable task cancellation** — cancelling a task now terminates the running process, with automatic Ctrl+C retry for stubborn processes (PRs #261, #272)

## Test plan

- [ ] Confirm `src/package.json` version is `3.56.0`
- [ ] Confirm `CHANGELOG.md` 3.56.0 section lists all expected PRs with no duplicates
- [ ] Confirm announcement shows on first launch after install (new `latestAnnouncementId`)
- [ ] Spot-check one or two localized READMEs for correct v3.56.0 What's New content
- [ ] Let release validation workflow and normal PR checks pass before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4.8 support across Anthropic, Bedrock, and Vertex providers.
  * Introduced Opencode Go as a first-class API provider.
  * Improved task cancellation—terminal processes now properly terminate when cancelled instead of hanging.

* **Bug Fixes**
  * Fixed Gemini custom model ID handling.
  * Corrected Grok diff truncation issues.
  * Fixed Windows PowerShell detection when no profile exists.
  * Improved Vertex AI credential field validation warnings.
  * Enhanced VS Code code action localization and naming.

* **Documentation**
  * Updated release notes and localization across 15+ languages.
  * Multiple security dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->