### PR TITLE
Fix Codex OAuth refresh token rotation races

### DIFF
--- a/packages/vscode-shim/src/__tests__/storage.test.ts
+++ b/packages/vscode-shim/src/__tests__/storage.test.ts
@@ -132,6 +132,17 @@ describe("FileSecretStorage", () => {
 		expect(value).toBe("persistent-value")
 	})
 
+	it("should reload secrets changed by an existing peer instance", async () => {
+		const storage1 = new FileSecretStorage(tempDir)
+		const storage2 = new FileSecretStorage(tempDir)
+
+		await storage1.store("token", "first-value")
+		expect(await storage2.get("token")).toBe("first-value")
+
+		await storage1.store("token", "second-value")
+		expect(await storage2.get("token")).toBe("second-value")
+	})
+
 	it("should fire onDidChange event when secret changes", async () => {
 		const storage = new FileSecretStorage(tempDir)
 		const events: string[] = []

--- a/packages/vscode-shim/src/storage/SecretStorage.ts
+++ b/packages/vscode-shim/src/storage/SecretStorage.ts
@@ -56,6 +56,8 @@ export class FileSecretStorage implements SecretStorage {
 			if (fs.existsSync(this.filePath)) {
 				const content = fs.readFileSync(this.filePath, "utf-8")
 				this.secrets = JSON.parse(content)
+			} else {
+				this.secrets = {}
 			}
 		} catch (error) {
 			console.warn(`Failed to load secrets from ${this.filePath}:`, error)
@@ -95,6 +97,7 @@ export class FileSecretStorage implements SecretStorage {
 	 * @returns The secret value or undefined if not found
 	 */
 	async get(key: string): Promise<string | undefined> {
+		this.loadFromFile()
 		return this.secrets[key]
 	}
 

--- a/src/integrations/openai-codex/__tests__/oauth.spec.ts
+++ b/src/integrations/openai-codex/__tests__/oauth.spec.ts
@@ -1,0 +1,312 @@
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import type { ExtensionContext } from "vscode"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+	exchangeCodeForTokens,
+	OpenAiCodexOAuthManager,
+	refreshAccessToken,
+	type OpenAiCodexCredentials,
+} from "../oauth"
+
+const CREDENTIALS_KEY = "openai-codex-oauth-credentials"
+
+class SharedSecretStorage {
+	private readonly values = new Map<string, string>()
+	storeGate: Promise<void> | null = null
+	storeError: Error | null = null
+	storeAttempts = 0
+	deleteAttempts = 0
+
+	async get(key: string): Promise<string | undefined> {
+		return this.values.get(key)
+	}
+
+	async store(key: string, value: string): Promise<void> {
+		this.storeAttempts++
+		await this.storeGate
+		if (this.storeError) {
+			throw this.storeError
+		}
+		this.values.set(key, value)
+	}
+
+	async delete(key: string): Promise<void> {
+		this.deleteAttempts++
+		this.values.delete(key)
+	}
+
+	setCredentials(credentials: OpenAiCodexCredentials): void {
+		this.values.set(CREDENTIALS_KEY, JSON.stringify(credentials))
+	}
+
+	getCredentials(): OpenAiCodexCredentials | null {
+		const credentials = this.values.get(CREDENTIALS_KEY)
+		return credentials ? (JSON.parse(credentials) as OpenAiCodexCredentials) : null
+	}
+}
+
+function createCredentials({
+	accessToken = "at0",
+	refreshToken = "rt0",
+	expires = Date.now() - 1,
+}: {
+	accessToken?: string
+	refreshToken?: string
+	expires?: number
+} = {}): OpenAiCodexCredentials {
+	return {
+		type: "openai-codex",
+		access_token: accessToken,
+		refresh_token: refreshToken,
+		expires,
+	}
+}
+
+function createContext(globalStoragePath: string, secrets: SharedSecretStorage): ExtensionContext {
+	return {
+		globalStorageUri: { fsPath: globalStoragePath },
+		secrets,
+	} as unknown as ExtensionContext
+}
+
+function createTokenResponse(accessToken: string, refreshToken: string): Response {
+	return new Response(
+		JSON.stringify({
+			access_token: accessToken,
+			refresh_token: refreshToken,
+			expires_in: 3600,
+		}),
+		{ status: 200 },
+	)
+}
+
+function createInvalidGrantResponse(): Response {
+	return new Response(JSON.stringify({ error: "invalid_grant" }), {
+		status: 400,
+		statusText: "Bad Request",
+	})
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	for (let attempts = 0; attempts < 200; attempts++) {
+		if (condition()) {
+			return
+		}
+		await new Promise((resolve) => setTimeout(resolve, 10))
+	}
+	throw new Error("Timed out waiting for condition")
+}
+
+describe("OpenAiCodexOAuthManager", () => {
+	let globalStoragePath: string
+
+	beforeEach(async () => {
+		globalStoragePath = await fs.mkdtemp(path.join(os.tmpdir(), "roo-codex-oauth-"))
+	})
+
+	afterEach(async () => {
+		vi.unstubAllGlobals()
+		await fs.rm(globalStoragePath, { recursive: true, force: true })
+	})
+
+	it("keeps one in-process refresh live until rotated credentials are persisted", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		const persistGate = deferred()
+		secrets.storeGate = persistGate.promise
+		const fetchMock = vi.fn().mockResolvedValue(createTokenResponse("at1", "rt1"))
+		vi.stubGlobal("fetch", fetchMock)
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		const first = manager.getAccessToken()
+		await waitFor(() => secrets.storeAttempts === 1)
+		const second = manager.getAccessToken()
+
+		await new Promise((resolve) => setTimeout(resolve, 50))
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+
+		persistGate.resolve()
+		await expect(Promise.all([first, second])).resolves.toEqual(["at1", "at1"])
+		expect(secrets.getCredentials()?.refresh_token).toBe("rt1")
+	})
+
+	it("does not report a rotated token when persistence fails", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		secrets.storeError = new Error("storage unavailable")
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createTokenResponse("at1", "rt1")))
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		await expect(manager.getAccessToken()).resolves.toBeNull()
+		expect(secrets.getCredentials()?.refresh_token).toBe("rt0")
+	})
+
+	it("serializes refresh across managers sharing one durable credential", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		const fetchMock = vi.fn().mockResolvedValue(createTokenResponse("at1", "rt1"))
+		vi.stubGlobal("fetch", fetchMock)
+		const first = new OpenAiCodexOAuthManager()
+		const second = new OpenAiCodexOAuthManager()
+		first.initialize(createContext(globalStoragePath, secrets))
+		second.initialize(createContext(globalStoragePath, secrets))
+		await Promise.all([first.loadCredentials(), second.loadCredentials()])
+
+		await expect(Promise.all([first.getAccessToken(), second.getAccessToken()])).resolves.toEqual(["at1", "at1"])
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		expect(new URLSearchParams(fetchMock.mock.calls[0][1].body).get("refresh_token")).toBe("rt0")
+	})
+
+	it("lets a strict forced refresh run after an ordinary in-process refresh", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		const responseGate = deferred()
+		const fetchMock = vi
+			.fn()
+			.mockImplementationOnce(async () => {
+				await responseGate.promise
+				return createTokenResponse("at1", "rt1")
+			})
+			.mockResolvedValueOnce(createTokenResponse("at2", "rt2"))
+		vi.stubGlobal("fetch", fetchMock)
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		const ordinary = manager.getAccessToken()
+		await waitFor(() => fetchMock.mock.calls.length === 1)
+		const forced = manager.forceRefreshAccessToken()
+		responseGate.resolve()
+
+		await expect(Promise.all([ordinary, forced])).resolves.toEqual(["at1", "at2"])
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(new URLSearchParams(fetchMock.mock.calls[1][1].body).get("refresh_token")).toBe("rt1")
+	})
+
+	it("lets a forced waiter adopt another manager's rotated credential", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials({ expires: Date.now() + 3600_000 }))
+		const fetchMock = vi.fn().mockResolvedValue(createTokenResponse("at1", "rt1"))
+		vi.stubGlobal("fetch", fetchMock)
+		const first = new OpenAiCodexOAuthManager()
+		const second = new OpenAiCodexOAuthManager()
+		first.initialize(createContext(globalStoragePath, secrets))
+		second.initialize(createContext(globalStoragePath, secrets))
+		await Promise.all([first.loadCredentials(), second.loadCredentials()])
+
+		await expect(Promise.all([first.forceRefreshAccessToken(), second.forceRefreshAccessToken()])).resolves.toEqual(
+			["at1", "at1"],
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("preserves a newer stored credential after an invalid_grant response", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(async () => {
+				secrets.setCredentials(
+					createCredentials({ accessToken: "at1", refreshToken: "rt1", expires: Date.now() + 3600_000 }),
+				)
+				return createInvalidGrantResponse()
+			}),
+		)
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		await expect(manager.getAccessToken()).resolves.toBe("at1")
+		expect(secrets.getCredentials()?.refresh_token).toBe("rt1")
+		expect(secrets.deleteAttempts).toBe(0)
+	})
+
+	it("preserves a newer stored access token even when the refresh token did not rotate", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(async () => {
+				secrets.setCredentials(createCredentials({ accessToken: "at1", expires: Date.now() + 3600_000 }))
+				return createInvalidGrantResponse()
+			}),
+		)
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		await expect(manager.getAccessToken()).resolves.toBe("at1")
+		expect(secrets.getCredentials()?.refresh_token).toBe("rt0")
+		expect(secrets.deleteAttempts).toBe(0)
+	})
+
+	it("clears the stored credential when its refresh token is rejected", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createInvalidGrantResponse()))
+		const manager = new OpenAiCodexOAuthManager()
+		manager.initialize(createContext(globalStoragePath, secrets))
+
+		await expect(manager.getAccessToken()).resolves.toBeNull()
+		expect(secrets.getCredentials()).toBeNull()
+		expect(secrets.deleteAttempts).toBe(1)
+	})
+
+	it("keeps the lock alive while a delayed refresh response is in flight", async () => {
+		const secrets = new SharedSecretStorage()
+		secrets.setCredentials(createCredentials())
+		const responseGate = deferred()
+		const fetchMock = vi.fn().mockImplementation(async () => {
+			await responseGate.promise
+			return createTokenResponse("at1", "rt1")
+		})
+		vi.stubGlobal("fetch", fetchMock)
+		const lockOptions = { refreshLockStaleMs: 2000, refreshLockUpdateMs: 1000 }
+		const first = new OpenAiCodexOAuthManager(lockOptions)
+		const second = new OpenAiCodexOAuthManager(lockOptions)
+		first.initialize(createContext(globalStoragePath, secrets))
+		second.initialize(createContext(globalStoragePath, secrets))
+		await Promise.all([first.loadCredentials(), second.loadCredentials()])
+
+		const firstAccessToken = first.getAccessToken()
+		await waitFor(() => fetchMock.mock.calls.length === 1)
+		await new Promise((resolve) => setTimeout(resolve, 2400))
+		const secondAccessToken = second.getAccessToken()
+		await new Promise((resolve) => setTimeout(resolve, 150))
+
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+		responseGate.resolve()
+		await expect(Promise.all([firstAccessToken, secondAccessToken])).resolves.toEqual(["at1", "at1"])
+		expect(fetchMock).toHaveBeenCalledTimes(1)
+	}, 10_000)
+})
+
+describe("OpenAI Codex OAuth requests", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it("identifies Roo Code on authorization-code and refresh requests", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(createTokenResponse("at0", "rt0"))
+			.mockResolvedValueOnce(createTokenResponse("at1", "rt1"))
+		vi.stubGlobal("fetch", fetchMock)
+
+		await exchangeCodeForTokens("code", "verifier")
+		await refreshAccessToken(createCredentials())
+
+		expect(fetchMock.mock.calls[0][1].headers["User-Agent"]).toMatch(/^zoo-code\//)
+		expect(fetchMock.mock.calls[1][1].headers["User-Agent"]).toMatch(/^zoo-code\//)
+	})
+})

--- a/src/integrations/openai-codex/oauth.ts
+++ b/src/integrations/openai-codex/oauth.ts
@@ -1,8 +1,12 @@
 import * as crypto from "crypto"
+import * as fs from "fs/promises"
 import * as http from "http"
+import * as path from "path"
 import { URL } from "url"
 import type { ExtensionContext } from "vscode"
 import { z } from "zod"
+import * as lockfile from "proper-lockfile"
+import { version as zooCodeVersion } from "../../package.json"
 
 /**
  * OpenAI Codex OAuth Configuration
@@ -25,6 +29,9 @@ export const OPENAI_CODEX_OAUTH_CONFIG = {
 
 // Token storage key
 const OPENAI_CODEX_CREDENTIALS_KEY = "openai-codex-oauth-credentials"
+const OPENAI_CODEX_REFRESH_LOCK_NAME = "openai-codex-oauth-refresh"
+const OPENAI_CODEX_REFRESH_LOCK_STALE_MS = 60_000
+const OPENAI_CODEX_REFRESH_LOCK_UPDATE_MS = 10_000
 
 // Credentials schema
 const openAiCodexCredentialsSchema = z.object({
@@ -237,6 +244,7 @@ export async function exchangeCodeForTokens(code: string, codeVerifier: string):
 		method: "POST",
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",
+			"User-Agent": `zoo-code/${zooCodeVersion}`,
 		},
 		body: body.toString(),
 		signal: AbortSignal.timeout(30000),
@@ -288,6 +296,7 @@ export async function refreshAccessToken(credentials: OpenAiCodexCredentials): P
 		method: "POST",
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",
+			"User-Agent": `zoo-code/${zooCodeVersion}`,
 		},
 		body: body.toString(),
 		signal: AbortSignal.timeout(30000),
@@ -335,6 +344,16 @@ export function isTokenExpired(credentials: OpenAiCodexCredentials): boolean {
 	return Date.now() >= credentials.expires - bufferMs
 }
 
+function credentialsMatch(first: OpenAiCodexCredentials, second: OpenAiCodexCredentials): boolean {
+	return (
+		first.access_token === second.access_token &&
+		first.refresh_token === second.refresh_token &&
+		first.expires === second.expires &&
+		first.email === second.email &&
+		first.accountId === second.accountId
+	)
+}
+
 /**
  * OpenAiCodexOAuthManager - Handles OAuth flow and token management
  */
@@ -342,12 +361,20 @@ export class OpenAiCodexOAuthManager {
 	private context: ExtensionContext | null = null
 	private credentials: OpenAiCodexCredentials | null = null
 	private logFn: ((message: string) => void) | null = null
-	private refreshPromise: Promise<OpenAiCodexCredentials> | null = null
+	private refreshPromise: Promise<OpenAiCodexCredentials | null> | null = null
+	private refreshPromiseForce = false
+	private readonly refreshLockStaleMs: number
+	private readonly refreshLockUpdateMs: number
 	private pendingAuth: {
 		codeVerifier: string
 		state: string
 		server?: http.Server
 	} | null = null
+
+	constructor(options?: { refreshLockStaleMs?: number; refreshLockUpdateMs?: number }) {
+		this.refreshLockStaleMs = options?.refreshLockStaleMs ?? OPENAI_CODEX_REFRESH_LOCK_STALE_MS
+		this.refreshLockUpdateMs = options?.refreshLockUpdateMs ?? OPENAI_CODEX_REFRESH_LOCK_UPDATE_MS
+	}
 
 	private log(message: string): void {
 		if (this.logFn) {
@@ -386,33 +413,10 @@ export class OpenAiCodexOAuthManager {
 		}
 
 		try {
-			// De-dupe concurrent refreshes
-			if (!this.refreshPromise) {
-				const prevRefreshToken = this.credentials.refresh_token
-				this.log(`[openai-codex-oauth] Forcing token refresh (expires=${this.credentials.expires})...`)
-				this.refreshPromise = refreshAccessToken(this.credentials).then((newCreds) => {
-					const rotated = newCreds.refresh_token !== prevRefreshToken
-					this.log(
-						`[openai-codex-oauth] Forced refresh response received (expires_in≈${Math.round(
-							(newCreds.expires - Date.now()) / 1000,
-						)}s, refresh_token_rotated=${rotated})`,
-					)
-					return newCreds
-				})
-			}
-
-			const newCredentials = await this.refreshPromise
-			this.refreshPromise = null
-			await this.saveCredentials(newCredentials)
-			this.log(`[openai-codex-oauth] Forced token persisted (expires=${newCredentials.expires})`)
-			return newCredentials.access_token
+			const newCredentials = await this.refreshCredentials(true)
+			return newCredentials?.access_token ?? null
 		} catch (error) {
-			this.refreshPromise = null
 			this.logError("[openai-codex-oauth] Failed to force refresh token:", error)
-			if (error instanceof OpenAiCodexOAuthTokenError && error.isLikelyInvalidGrant()) {
-				this.log("[openai-codex-oauth] Refresh token appears invalid; clearing stored credentials")
-				await this.clearCredentials()
-			}
 			return null
 		}
 	}
@@ -421,6 +425,10 @@ export class OpenAiCodexOAuthManager {
 	 * Load credentials from storage
 	 */
 	async loadCredentials(): Promise<OpenAiCodexCredentials | null> {
+		return this.loadCredentialsFromStorage()
+	}
+
+	private async loadCredentialsFromStorage(): Promise<OpenAiCodexCredentials | null> {
 		if (!this.context) {
 			return null
 		}
@@ -428,6 +436,7 @@ export class OpenAiCodexOAuthManager {
 		try {
 			const credentialsJson = await this.context.secrets.get(OPENAI_CODEX_CREDENTIALS_KEY)
 			if (!credentialsJson) {
+				this.credentials = null
 				return null
 			}
 
@@ -435,6 +444,7 @@ export class OpenAiCodexOAuthManager {
 			this.credentials = openAiCodexCredentialsSchema.parse(parsed)
 			return this.credentials
 		} catch (error) {
+			this.credentials = null
 			this.logError("[openai-codex-oauth] Failed to load credentials:", error)
 			return null
 		}
@@ -464,6 +474,96 @@ export class OpenAiCodexOAuthManager {
 		this.credentials = null
 	}
 
+	private async refreshCredentials(force: boolean): Promise<OpenAiCodexCredentials | null> {
+		if (this.refreshPromise) {
+			const refreshPromise = this.refreshPromise
+			const refreshPromiseForce = this.refreshPromiseForce
+			const credentials = await refreshPromise
+			return force && !refreshPromiseForce ? this.refreshCredentials(true) : credentials
+		}
+
+		this.refreshPromiseForce = force
+		const refreshPromise = this.refreshCredentialsUnderLock(force).finally(() => {
+			if (this.refreshPromise === refreshPromise) {
+				this.refreshPromise = null
+				this.refreshPromiseForce = false
+			}
+		})
+		this.refreshPromise = refreshPromise
+		return refreshPromise
+	}
+
+	private async refreshCredentialsUnderLock(force: boolean): Promise<OpenAiCodexCredentials | null> {
+		if (!this.context) {
+			throw new Error("OAuth manager not initialized")
+		}
+
+		const lockPath = path.join(this.context.globalStorageUri.fsPath, OPENAI_CODEX_REFRESH_LOCK_NAME)
+		await fs.mkdir(this.context.globalStorageUri.fsPath, { recursive: true })
+		const releaseLock = await lockfile.lock(lockPath, {
+			stale: this.refreshLockStaleMs,
+			update: this.refreshLockUpdateMs,
+			realpath: false,
+			retries: {
+				retries: 60,
+				factor: 1.2,
+				minTimeout: 100,
+				maxTimeout: 1000,
+				randomize: true,
+			},
+		})
+
+		try {
+			const cachedCredentials = this.credentials
+			const storedCredentials = await this.loadCredentialsFromStorage()
+			if (!storedCredentials) {
+				return null
+			}
+
+			const storedCredentialsChanged =
+				cachedCredentials !== null && !credentialsMatch(cachedCredentials, storedCredentials)
+
+			if (!isTokenExpired(storedCredentials) && (!force || storedCredentialsChanged)) {
+				return storedCredentials
+			}
+
+			const previousRefreshToken = storedCredentials.refresh_token
+			this.log(
+				force
+					? `[openai-codex-oauth] Forcing token refresh (expires=${storedCredentials.expires})...`
+					: `[openai-codex-oauth] Access token expired (expires=${storedCredentials.expires}). Refreshing...`,
+			)
+
+			try {
+				const newCredentials = await refreshAccessToken(storedCredentials)
+				const rotated = newCredentials.refresh_token !== previousRefreshToken
+				this.log(
+					`[openai-codex-oauth] ${force ? "Forced refresh" : "Refresh"} response received (expires_in≈${Math.round(
+						(newCredentials.expires - Date.now()) / 1000,
+					)}s, refresh_token_rotated=${rotated})`,
+				)
+				await this.saveCredentials(newCredentials)
+				this.log(
+					`[openai-codex-oauth] ${force ? "Forced token" : "Token"} persisted (expires=${newCredentials.expires})`,
+				)
+				return newCredentials
+			} catch (error) {
+				if (error instanceof OpenAiCodexOAuthTokenError && error.isLikelyInvalidGrant()) {
+					const replacementCredentials = await this.loadCredentialsFromStorage()
+					if (!replacementCredentials || !credentialsMatch(replacementCredentials, storedCredentials)) {
+						return replacementCredentials
+					}
+
+					this.log("[openai-codex-oauth] Refresh token appears invalid; clearing stored credentials")
+					await this.clearCredentials()
+				}
+				throw error
+			}
+		} finally {
+			await releaseLock()
+		}
+	}
+
 	/**
 	 * Get a valid access token, refreshing if necessary
 	 */
@@ -480,36 +580,10 @@ export class OpenAiCodexOAuthManager {
 		// Check if token is expired and refresh if needed
 		if (isTokenExpired(this.credentials)) {
 			try {
-				// De-dupe concurrent refreshes
-				if (!this.refreshPromise) {
-					this.log(
-						`[openai-codex-oauth] Access token expired (expires=${this.credentials.expires}). Refreshing...`,
-					)
-					const prevRefreshToken = this.credentials.refresh_token
-					this.refreshPromise = refreshAccessToken(this.credentials).then((newCreds) => {
-						const rotated = newCreds.refresh_token !== prevRefreshToken
-						this.log(
-							`[openai-codex-oauth] Refresh response received (expires_in≈${Math.round(
-								(newCreds.expires - Date.now()) / 1000,
-							)}s, refresh_token_rotated=${rotated})`,
-						)
-						return newCreds
-					})
-				}
-
-				const newCredentials = await this.refreshPromise
-				this.refreshPromise = null
-				await this.saveCredentials(newCredentials)
-				this.log(`[openai-codex-oauth] Token persisted (expires=${newCredentials.expires})`)
+				const newCredentials = await this.refreshCredentials(false)
+				return newCredentials?.access_token ?? null
 			} catch (error) {
-				this.refreshPromise = null
 				this.logError("[openai-codex-oauth] Failed to refresh token:", error)
-
-				// Only clear secrets when the refresh token is clearly invalid/revoked.
-				if (error instanceof OpenAiCodexOAuthTokenError && error.isLikelyInvalidGrant()) {
-					this.log("[openai-codex-oauth] Refresh token appears invalid; clearing stored credentials")
-					await this.clearCredentials()
-				}
 				return null
 			}
 		}


### PR DESCRIPTION
Fixes #406

## Summary

- serialize OpenAI Codex OAuth refresh across extension hosts with a stable `proper-lockfile` lock under global storage
- reread durable credentials under lock, keep the in-process refresh promise live through persistence, and preserve newer credentials after stale `invalid_grant` failures
- identify authorization-code and refresh requests with `User-Agent: zoo-code/<version>`
- reload file-backed shim secrets on reads so concurrent CLI hosts can adopt a peer's rotated credential

## Validation

- Passed after replay onto Zoo Code: `pnpm --dir src exec vitest run integrations/openai-codex/__tests__/oauth.spec.ts integrations/openai-codex/__tests__/rate-limits.spec.ts`
- Passed after replay onto Zoo Code: `pnpm --dir packages/vscode-shim test`
- Passed after replay onto Zoo Code: `pnpm --filter @roo-code/cli build`
- Passed after replay onto Zoo Code: `node apps/cli/dist/index.js --help`
- Passed before replay on the archived Roo Code base: `pnpm lint`, `pnpm check-types`, `pnpm bundle`
- Passed before replay on the archived Roo Code base: 25 repeated contention runs covering delayed persistence, two-manager refresh, strict forced refresh ordering, and forced-waiter adoption
- Passed before replay on the archived Roo Code base: 5 repeated delayed-response runs verifying lock heartbeat beyond the configured stale interval

## Environment

Local validation ran under Node `25.9.0`; this checkout's requested Node `20.20.2` is not installed locally.

After the focused Zoo Code validation passed, `pnpm install --ignore-scripts` was needed to hydrate newly added workspace packages for broader checks. The install is externally blocked by a registry `403` fetching `hasown@2.0.4`, so full-workspace Zoo Code lint, type-check, and bundle reruns could not complete locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth token refresh reliability when multiple instances run concurrently, preventing duplicate refresh requests and ensuring consistent credential state across instances.
  * Enhanced error handling for expired or invalid OAuth credentials with better recovery behavior.

* **Tests**
  * Added comprehensive test coverage for OAuth token refresh, storage persistence, and concurrent instance scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Zoo-Code-Org/Zoo-Code/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->