### PR TITLE
fix(code-index): limit embedding batch size by item count to prevent provider 422 errors

### DIFF
--- a/src/services/code-index/constants/index.ts
+++ b/src/services/code-index/constants/index.ts
@@ -24,6 +24,7 @@ export const MAX_PENDING_BATCHES = 20 // Maximum number of batches to accumulate
 
 /**OpenAI Embedder */
 export const MAX_BATCH_TOKENS = 100000
+export const MAX_BATCH_ITEMS = 32 // Maximum number of items per embedding API call (provider limit, fixes #335)
 export const MAX_ITEM_TOKENS = 8191
 export const BATCH_PROCESSING_CONCURRENCY = 10
 

--- a/src/services/code-index/embedders/bedrock.ts
+++ b/src/services/code-index/embedders/bedrock.ts
@@ -3,6 +3,7 @@ import { fromIni, fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { IEmbedder, EmbeddingResponse, EmbedderInfo } from "../interfaces"
 import {
 	MAX_BATCH_TOKENS,
+	MAX_BATCH_ITEMS,
 	MAX_ITEM_TOKENS,
 	MAX_BATCH_RETRIES as MAX_RETRIES,
 	INITIAL_RETRY_DELAY_MS as INITIAL_DELAY_MS,
@@ -83,7 +84,7 @@ export class BedrockEmbedder implements IEmbedder {
 					continue
 				}
 
-				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS) {
+				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS && currentBatch.length < MAX_BATCH_ITEMS) {
 					currentBatch.push(text)
 					currentBatchTokens += itemTokens
 					processedIndices.push(i)

--- a/src/services/code-index/embedders/openai-compatible.ts
+++ b/src/services/code-index/embedders/openai-compatible.ts
@@ -2,6 +2,7 @@ import { OpenAI } from "openai"
 import { IEmbedder, EmbeddingResponse, EmbedderInfo } from "../interfaces/embedder"
 import {
 	MAX_BATCH_TOKENS,
+	MAX_BATCH_ITEMS,
 	MAX_ITEM_TOKENS,
 	MAX_BATCH_RETRIES as MAX_RETRIES,
 	INITIAL_RETRY_DELAY_MS as INITIAL_DELAY_MS,
@@ -144,7 +145,7 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
 					continue
 				}
 
-				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS) {
+				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS && currentBatch.length < MAX_BATCH_ITEMS) {
 					currentBatch.push(text)
 					currentBatchTokens += itemTokens
 					processedIndices.push(i)

--- a/src/services/code-index/embedders/openai.ts
+++ b/src/services/code-index/embedders/openai.ts
@@ -4,6 +4,7 @@ import { ApiHandlerOptions } from "../../../shared/api"
 import { IEmbedder, EmbeddingResponse, EmbedderInfo } from "../interfaces"
 import {
 	MAX_BATCH_TOKENS,
+	MAX_BATCH_ITEMS,
 	MAX_ITEM_TOKENS,
 	MAX_BATCH_RETRIES as MAX_RETRIES,
 	INITIAL_RETRY_DELAY_MS as INITIAL_DELAY_MS,
@@ -100,7 +101,7 @@ export class OpenAiEmbedder extends OpenAiNativeHandler implements IEmbedder {
 					continue
 				}
 
-				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS) {
+				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS && currentBatch.length < MAX_BATCH_ITEMS) {
 					currentBatch.push(text)
 					currentBatchTokens += itemTokens
 					processedIndices.push(i)

--- a/src/services/code-index/embedders/openrouter.ts
+++ b/src/services/code-index/embedders/openrouter.ts
@@ -2,6 +2,7 @@ import { OpenAI } from "openai"
 import { IEmbedder, EmbeddingResponse, EmbedderInfo } from "../interfaces/embedder"
 import {
 	MAX_BATCH_TOKENS,
+	MAX_BATCH_ITEMS,
 	MAX_ITEM_TOKENS,
 	MAX_BATCH_RETRIES as MAX_RETRIES,
 	INITIAL_RETRY_DELAY_MS as INITIAL_DELAY_MS,
@@ -148,7 +149,7 @@ export class OpenRouterEmbedder implements IEmbedder {
 					continue
 				}
 
-				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS) {
+				if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS && currentBatch.length < MAX_BATCH_ITEMS) {
 					currentBatch.push(text)
 					currentBatchTokens += itemTokens
 					processedIndices.push(i)


### PR DESCRIPTION
### Related GitHub Issue

Closes: #335

### Description

**Root cause:** Embedders batched by token count only (`MAX_BATCH_TOKENS=100000`). When many small code segments are sent, they all fit in one token-based batch (e.g., 60 segments × ~100 tokens = 6000 < 100000), resulting in API calls with 60+ items. Providers like `qwen3-embedding` via LiteLLM enforce a maximum of 32 items per call, returning HTTP 422.

**Fix:**

1. Added `MAX_BATCH_ITEMS = 32` constant in `src/services/code-index/constants/index.ts`
2. Applied item count constraint alongside the existing token limit in all four embedders:
   - `OpenAICompatibleEmbedder` — the one reported in #335
   - `OpenAIEmbedder`
   - `OpenRouterEmbedder`
   - `BedrockEmbedder`

The batching condition changed from:
```ts
if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS)
```
to:
```ts
if (currentBatchTokens + itemTokens <= MAX_BATCH_TOKENS && currentBatch.length < MAX_BATCH_ITEMS)
```

The existing `codeIndex.embeddingBatchSize` setting (scanner-level, default 60) remains configurable. The embedder-level limit ensures no single API call exceeds 32 items regardless of scanner batch size.

### Test Procedure

- **Unit tests:** All 53 existing tests pass (no regressions)
- **Type check:** Passes cleanly
- **Manual test:** Configure a provider with batch limit <60 (e.g., qwen3-embedding via LiteLLM), run code indexing → should no longer get HTTP 422

### Pre-Submission Checklist

- [x] **Issue Linked**: Closes #335
- [x] **Scope**: Focused — only adds item count batching constraint to embedders
- [x] **Self-Review**: Thorough review performed
- [x] **Testing**: All existing tests pass
- [x] **Documentation Impact**: No documentation changes needed
- [x] **Contribution Guidelines**: Read and agreed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced embedding batch management to enforce a maximum item-count limit across all embedding services, improving request reliability and API compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->