### PR TITLE
feat(security): introduce WorkspaceFileAccess — central workspace boundary authorization (#390)

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -101,6 +101,7 @@ export const globalSettingsSchema = z.object({
 	alwaysAllowWrite: z.boolean().optional(),
 	alwaysAllowWriteOutsideWorkspace: z.boolean().optional(),
 	alwaysAllowWriteProtected: z.boolean().optional(),
+	allowSymlinksOutsideWorkspace: z.boolean().optional(),
 	writeDelayMs: z.number().min(0).optional(),
 	requestDelaySeconds: z.number().optional(),
 	alwaysAllowMcp: z.boolean().optional(),

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -252,6 +252,7 @@ export type ExtensionState = Pick<
 	| "alwaysAllowWrite"
 	| "alwaysAllowWriteOutsideWorkspace"
 	| "alwaysAllowWriteProtected"
+	| "allowSymlinksOutsideWorkspace"
 	| "alwaysAllowMcp"
 	| "alwaysAllowModeSwitch"
 	| "alwaysAllowSubtasks"

--- a/src/core/workspace/WorkspaceFileAccess.ts
+++ b/src/core/workspace/WorkspaceFileAccess.ts
@@ -1,0 +1,166 @@
+import * as path from "path"
+
+import * as vscode from "vscode"
+
+import type { Task } from "../task/Task"
+import { resolveRealPath } from "../../utils/WorkspacePathResolver"
+
+/**
+ * Why an authorization was denied. Distinguishing `symlink_escapes_workspace` from
+ * `outside_workspace` lets callers (and telemetry) tell a deliberate out-of-tree path apart from a
+ * path that *looks* inside the workspace but resolves out of it via a symlink (#169).
+ */
+export type AuthorizeDenyReason =
+	| "outside_workspace"
+	| "symlink_escapes_workspace"
+	| "realpath_failed"
+	| "permission_denied"
+
+export type AuthorizeResult =
+	| { ok: true; resolvedPath: string }
+	| { ok: false; reason: AuthorizeDenyReason; message: string }
+
+export interface AuthorizeOptions {
+	/** Task whose provider state supplies the `allowSymlinksOutsideWorkspace` opt-in. */
+	task: Task
+	/** Absolute path as supplied by the tool. */
+	requestedPath: string
+	/** Tool name, used to prefix error messages. */
+	source: string
+}
+
+/** Lowercase on case-insensitive filesystems, matching {@link resolveRealPath}'s own normalization. */
+function normalizeCase(p: string): string {
+	return process.platform === "darwin" || process.platform === "win32" ? p.toLowerCase() : p
+}
+
+/** True when `child` is `parent` itself or nested under it. Both paths must already be normalized. */
+function isContained(parent: string, child: string): boolean {
+	return child === parent || child.startsWith(parent + path.sep)
+}
+
+/**
+ * Read the `allowSymlinksOutsideWorkspace` opt-in from provider state, defaulting to `false`
+ * (fail-closed). The provider may have been torn down mid-operation, in which case `getState()`
+ * rejects — that must not abort the file operation, so we swallow it and keep the safe default.
+ */
+async function readAllowSymlinksOutsideWorkspace(task: Task): Promise<boolean> {
+	try {
+		return (await task.providerRef.deref()?.getState())?.allowSymlinksOutsideWorkspace ?? false
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Central authorization for file access against the workspace boundary.
+ *
+ * Tools call this instead of doing a raw `isPathOutsideWorkspace()` boolean check followed by their
+ * own `fs` operation. The decoupled check-then-act pattern is structurally easy to get wrong — one
+ * missed call site (like `ApplyDiffTool` in #241) leaves a hole. Here a tool requests an authorized
+ * operation and gets back either a resolved path it may use, or a structured error it must surface.
+ *
+ * Default (fail-closed) behavior follows symlinks: the requested path and every workspace folder are
+ * canonicalized via {@link resolveRealPath}, and access is granted only when the real path lands
+ * inside a real workspace folder. When the user opts in via `allowSymlinksOutsideWorkspace`, the
+ * pre-#169 lexical behavior is restored (symlinks are not followed for the boundary decision).
+ *
+ * This layer owns policy only — it performs no `fs` read/write itself.
+ */
+async function authorize(options: AuthorizeOptions): Promise<AuthorizeResult> {
+	const { task, requestedPath, source } = options
+	const allowSymlinksOutsideWorkspace = await readAllowSymlinksOutsideWorkspace(task)
+
+	// Canonicalize the requested path (follows symlinks; walks up to the nearest existing ancestor
+	// for not-yet-created files). A non-ENOENT error here means we can't prove anything about the
+	// path, so we fail closed with a structured reason.
+	let resolvedPath: string
+	try {
+		resolvedPath = await resolveRealPath(requestedPath)
+	} catch (err) {
+		const code = (err as NodeJS.ErrnoException)?.code
+		const detail = err instanceof Error ? err.message : String(err)
+		if (code === "EACCES" || code === "EPERM") {
+			return {
+				ok: false,
+				reason: "permission_denied",
+				message: `[${source}] Permission denied resolving ${requestedPath}: ${detail}`,
+			}
+		}
+		return {
+			ok: false,
+			reason: "realpath_failed",
+			message: `[${source}] Could not resolve real path for ${requestedPath}: ${detail}`,
+		}
+	}
+
+	const folders = vscode.workspace.workspaceFolders ?? []
+
+	// Opt-in: restore pre-#169 lexical behavior — compare the literal path, never the symlink target.
+	if (allowSymlinksOutsideWorkspace) {
+		const lexicalPath = normalizeCase(path.resolve(requestedPath))
+		const insideLexically = folders.some((folder) =>
+			isContained(normalizeCase(path.resolve(folder.uri.fsPath)), lexicalPath),
+		)
+		if (insideLexically) {
+			return { ok: true, resolvedPath }
+		}
+		return {
+			ok: false,
+			reason: "outside_workspace",
+			message: `[${source}] ${requestedPath} is outside the workspace.`,
+		}
+	}
+
+	// Fail-closed: with no workspace open nothing can be proven inside.
+	if (folders.length === 0) {
+		return {
+			ok: false,
+			reason: "outside_workspace",
+			message: `[${source}] No workspace folder is open; ${requestedPath} cannot be authorized.`,
+		}
+	}
+
+	// Compare the resolved path against each *resolved* workspace folder. A folder we can't resolve
+	// (e.g. permissions) can't prove containment, so it's skipped rather than treated as a match.
+	for (const folder of folders) {
+		let resolvedFolder: string
+		try {
+			resolvedFolder = await resolveRealPath(folder.uri.fsPath)
+		} catch {
+			continue
+		}
+		if (isContained(resolvedFolder, resolvedPath)) {
+			return { ok: true, resolvedPath }
+		}
+	}
+
+	// Outside every folder. If the literal path looked inside but the resolved path escaped, a
+	// symlink is responsible — surface that distinctly from a plainly out-of-workspace path.
+	const lexicalPath = normalizeCase(path.resolve(requestedPath))
+	const lexicallyInside = folders.some((folder) =>
+		isContained(normalizeCase(path.resolve(folder.uri.fsPath)), lexicalPath),
+	)
+	if (lexicallyInside) {
+		return {
+			ok: false,
+			reason: "symlink_escapes_workspace",
+			message: `[${source}] ${requestedPath} resolves via symlink to ${resolvedPath}, which is outside the workspace.`,
+		}
+	}
+	return {
+		ok: false,
+		reason: "outside_workspace",
+		message: `[${source}] ${requestedPath} is outside the workspace.`,
+	}
+}
+
+/** Authorize a read against the workspace boundary. See {@link authorize}. */
+export function authorizeRead(options: AuthorizeOptions): Promise<AuthorizeResult> {
+	return authorize(options)
+}
+
+/** Authorize a write against the workspace boundary. See {@link authorize}. */
+export function authorizeWrite(options: AuthorizeOptions): Promise<AuthorizeResult> {
+	return authorize(options)
+}

--- a/src/core/workspace/__tests__/WorkspaceFileAccess.spec.ts
+++ b/src/core/workspace/__tests__/WorkspaceFileAccess.spec.ts
@@ -1,0 +1,193 @@
+import * as os from "os"
+import * as path from "path"
+import * as fs from "fs/promises"
+
+import * as vscode from "vscode"
+
+import type { Task } from "../../task/Task"
+import { authorizeRead, authorizeWrite } from "../WorkspaceFileAccess"
+
+vi.mock("vscode", () => ({
+	workspace: { workspaceFolders: [] as { uri: { fsPath: string } }[] },
+}))
+
+// Real symlinks in a real temp directory (no fs mocking, per #389/#390). Some scenarios can't be
+// reproduced everywhere: symlink creation needs privileges on Windows, and chmod-based EACCES is
+// meaningless as root. Such cases are skipped at runtime rather than mocked.
+const isWindows = process.platform === "win32"
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0
+
+/** Lowercase on case-insensitive filesystems, matching the resolver's own normalization. */
+const expectCase = (p: string) => (process.platform === "darwin" || process.platform === "win32" ? p.toLowerCase() : p)
+
+/** Minimal Task stub exposing only what WorkspaceFileAccess reads. */
+function makeTask(opts: { allow?: boolean; providerGone?: boolean; getStateThrows?: boolean } = {}): Task {
+	const provider = {
+		getState: async () => {
+			if (opts.getStateThrows) {
+				throw new Error("provider torn down")
+			}
+			return { allowSymlinksOutsideWorkspace: opts.allow }
+		},
+	}
+	return {
+		providerRef: { deref: () => (opts.providerGone ? undefined : provider) },
+	} as unknown as Task
+}
+
+function setWorkspaceFolders(...paths: string[]) {
+	;(vscode.workspace as any).workspaceFolders = paths.map((p) => ({ uri: { fsPath: p } }))
+}
+
+describe("WorkspaceFileAccess", () => {
+	let tmpRoot: string
+	let workspace: string
+	let outside: string
+	let symlinksSupported = false
+
+	beforeEach(async () => {
+		// realpath the temp root so comparisons aren't tripped up by /var -> /private/var (macOS).
+		tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "zoo-wfa-")))
+		workspace = path.join(tmpRoot, "workspace")
+		outside = path.join(tmpRoot, "outside")
+		await fs.mkdir(workspace, { recursive: true })
+		await fs.mkdir(outside, { recursive: true })
+		setWorkspaceFolders(workspace)
+
+		const probeTarget = path.join(tmpRoot, "probe-target")
+		const probeLink = path.join(tmpRoot, "probe-link")
+		await fs.writeFile(probeTarget, "probe")
+		try {
+			await fs.symlink(probeTarget, probeLink)
+			symlinksSupported = true
+		} catch {
+			symlinksSupported = false
+		}
+	})
+
+	afterEach(async () => {
+		await fs.chmod(path.join(workspace, "restricted"), 0o755).catch(() => {})
+		await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+		;(vscode.workspace as any).workspaceFolders = []
+	})
+
+	it("authorizes a real file inside the workspace and returns its canonical path", async () => {
+		const file = path.join(workspace, "file.txt")
+		await fs.writeFile(file, "x")
+
+		const result = await authorizeRead({ task: makeTask(), requestedPath: file, source: "read_file" })
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.resolvedPath).toBe(expectCase(await fs.realpath(file)))
+		}
+	})
+
+	it("denies a symlink inside the workspace that escapes it (symlink_escapes_workspace)", async () => {
+		if (!symlinksSupported) return
+		const secret = path.join(outside, "secret.txt")
+		await fs.writeFile(secret, "x")
+		const link = path.join(workspace, "link.txt")
+		await fs.symlink(secret, link)
+
+		const result = await authorizeRead({ task: makeTask(), requestedPath: link, source: "read_file" })
+
+		expect(result).toMatchObject({ ok: false, reason: "symlink_escapes_workspace" })
+	})
+
+	it("allows an escaping symlink when allowSymlinksOutsideWorkspace is true", async () => {
+		if (!symlinksSupported) return
+		const secret = path.join(outside, "secret.txt")
+		await fs.writeFile(secret, "x")
+		const link = path.join(workspace, "link.txt")
+		await fs.symlink(secret, link)
+
+		const result = await authorizeRead({ task: makeTask({ allow: true }), requestedPath: link, source: "read_file" })
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.resolvedPath).toBe(expectCase(await fs.realpath(secret)))
+		}
+	})
+
+	it("denies a path that is plainly outside the workspace (outside_workspace)", async () => {
+		const file = path.join(outside, "file.txt")
+		await fs.writeFile(file, "x")
+
+		const result = await authorizeRead({ task: makeTask(), requestedPath: file, source: "read_file" })
+
+		expect(result).toMatchObject({ ok: false, reason: "outside_workspace" })
+	})
+
+	it("returns permission_denied when the path cannot be resolved due to EACCES", async () => {
+		if (isWindows || isRoot) return
+		const restricted = path.join(workspace, "restricted")
+		await fs.mkdir(restricted)
+		const target = path.join(restricted, "file.txt")
+		await fs.writeFile(target, "x")
+		await fs.chmod(restricted, 0o000)
+
+		const result = await authorizeRead({ task: makeTask(), requestedPath: target, source: "read_file" })
+
+		expect(result).toMatchObject({ ok: false, reason: "permission_denied" })
+	})
+
+	it("authorizes a not-yet-created file under a symlinked ancestor that stays inside the workspace", async () => {
+		if (!symlinksSupported) return
+		const realDir = path.join(workspace, "real-dir")
+		await fs.mkdir(realDir)
+		const linkDir = path.join(workspace, "link-dir")
+		await fs.symlink(realDir, linkDir)
+		const newFile = path.join(linkDir, "not-created-yet.txt")
+
+		const result = await authorizeWrite({ task: makeTask(), requestedPath: newFile, source: "write_to_file" })
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.resolvedPath).toBe(expectCase(path.join(await fs.realpath(realDir), "not-created-yet.txt")))
+		}
+	})
+
+	it("fails closed when the provider has been torn down (deref returns undefined)", async () => {
+		if (!symlinksSupported) return
+		const secret = path.join(outside, "secret.txt")
+		await fs.writeFile(secret, "x")
+		const link = path.join(workspace, "link.txt")
+		await fs.symlink(secret, link)
+
+		// providerGone => allowSymlinksOutsideWorkspace defaults to false => symlink is followed and blocked.
+		const result = await authorizeRead({
+			task: makeTask({ providerGone: true }),
+			requestedPath: link,
+			source: "read_file",
+		})
+
+		expect(result).toMatchObject({ ok: false, reason: "symlink_escapes_workspace" })
+	})
+
+	it("fails closed when reading provider state throws", async () => {
+		if (!symlinksSupported) return
+		const secret = path.join(outside, "secret.txt")
+		await fs.writeFile(secret, "x")
+		const link = path.join(workspace, "link.txt")
+		await fs.symlink(secret, link)
+
+		const result = await authorizeRead({
+			task: makeTask({ getStateThrows: true }),
+			requestedPath: link,
+			source: "read_file",
+		})
+
+		expect(result).toMatchObject({ ok: false, reason: "symlink_escapes_workspace" })
+	})
+
+	it("fails closed when no workspace folder is open", async () => {
+		;(vscode.workspace as any).workspaceFolders = []
+		const file = path.join(workspace, "file.txt")
+		await fs.writeFile(file, "x")
+
+		const result = await authorizeWrite({ task: makeTask(), requestedPath: file, source: "write_to_file" })
+
+		expect(result).toMatchObject({ ok: false, reason: "outside_workspace" })
+	})
+})

--- a/src/utils/WorkspacePathResolver.ts
+++ b/src/utils/WorkspacePathResolver.ts
@@ -1,0 +1,66 @@
+import * as path from "path"
+import * as fs from "fs/promises"
+
+/** Narrow an unknown error to a Node errno exception with the given `code`. */
+function isErrnoException(err: unknown, code: string): boolean {
+	return err instanceof Error && (err as NodeJS.ErrnoException).code === code
+}
+
+// macOS APFS/HFS+ and Windows are case-insensitive: `realpath` can return a different case
+// than the one VS Code registered, so we lowercase the result before returning to keep later
+// comparisons (e.g. against `uri.fsPath`) reliable on those platforms only. Platform is read at
+// call time (not cached) so the behavior stays correct and testable.
+function normalizeCase(p: string): string {
+	const caseInsensitive = process.platform === "darwin" || process.platform === "win32"
+	return caseInsensitive ? p.toLowerCase() : p
+}
+
+/**
+ * Resolve a filesystem path to its canonical, symlink-followed form.
+ *
+ * This is the canonicalization primitive for the workspace boundary check (issue #169). It owns
+ * **only** path resolution — no workspace policy, no settings, no tool logic. The authorization
+ * decision (and the `allowSymlinksOutsideWorkspace` opt-in) lives in `WorkspaceFileAccess`.
+ *
+ * Behavior:
+ * - **Async only** (`fs.promises.realpath`); never blocks the extension host event loop.
+ * - If `target` does not exist yet (e.g. a file about to be created), the realpath of the nearest
+ *   existing ancestor is resolved and the remaining segments are re-appended, so a symlink
+ *   anywhere along the path is still followed while not-yet-created paths can still be evaluated.
+ * - Only `ENOENT` triggers the walk-up. Any other error (e.g. `EACCES`, `ELOOP`) is **re-thrown**
+ *   so a caller performing a security check can fail closed. Silently walking up would mask the
+ *   symlink and could make an out-of-workspace target look "inside" (#169).
+ * - The result is case-normalized on case-insensitive filesystems (macOS, Windows).
+ *
+ * Workspace folder paths should be resolved through this same function by callers, since a folder
+ * may itself be reached via a symlink.
+ */
+export async function resolveRealPath(target: string): Promise<string> {
+	let current = path.resolve(target)
+	const trailing: string[] = []
+
+	// Walk up until an existing path can be resolved, bounded by the filesystem root.
+	while (true) {
+		try {
+			const resolved = await fs.realpath(current)
+			const joined = trailing.length > 0 ? path.join(resolved, ...trailing.reverse()) : resolved
+			return normalizeCase(joined)
+		} catch (err) {
+			if (!isErrnoException(err, "ENOENT")) {
+				// Non-ENOENT (e.g. EACCES, ELOOP): propagate so the caller's security check can
+				// fail closed instead of falling through to the lexical path.
+				throw err
+			}
+
+			const parent = path.dirname(current)
+			if (parent === current) {
+				// Reached the filesystem root without finding an existing path; fall back to the
+				// lexically resolved path (still case-normalized for consistent comparisons).
+				return normalizeCase(path.resolve(target))
+			}
+
+			trailing.push(path.basename(current))
+			current = parent
+		}
+	}
+}

--- a/src/utils/__tests__/WorkspacePathResolver.spec.ts
+++ b/src/utils/__tests__/WorkspacePathResolver.spec.ts
@@ -1,0 +1,134 @@
+import * as os from "os"
+import * as path from "path"
+import * as fs from "fs/promises"
+
+import { resolveRealPath } from "../WorkspacePathResolver"
+
+// These tests use real symlinks in a real temp directory (no fs mocking, per #389). Some
+// scenarios can't be reproduced everywhere: symlink creation needs privileges on Windows, and
+// chmod-based EACCES is meaningless as root. Such cases are skipped at runtime rather than mocked.
+const isWindows = process.platform === "win32"
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0
+
+/** Lowercase on case-insensitive filesystems, matching the resolver's own normalization. */
+const expectCase = (p: string) => (process.platform === "darwin" || process.platform === "win32" ? p.toLowerCase() : p)
+
+describe("resolveRealPath", () => {
+	let tmpRoot: string
+	let workspace: string
+	let outside: string
+	let symlinksSupported = false
+
+	beforeEach(async () => {
+		// realpath the temp root so comparisons aren't tripped up by /var -> /private/var (macOS).
+		tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "zoo-wpr-")))
+		workspace = path.join(tmpRoot, "workspace")
+		outside = path.join(tmpRoot, "outside")
+		await fs.mkdir(workspace, { recursive: true })
+		await fs.mkdir(outside, { recursive: true })
+
+		// Probe symlink support once so symlink-dependent cases can skip cleanly on locked-down hosts.
+		const probeTarget = path.join(tmpRoot, "probe-target")
+		const probeLink = path.join(tmpRoot, "probe-link")
+		await fs.writeFile(probeTarget, "probe")
+		try {
+			await fs.symlink(probeTarget, probeLink)
+			symlinksSupported = true
+		} catch {
+			symlinksSupported = false
+		}
+	})
+
+	afterEach(async () => {
+		// Restore permissions on any restricted dir (EACCES test) so cleanup can remove it.
+		await fs.chmod(path.join(workspace, "restricted"), 0o755).catch(() => {})
+		await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {})
+	})
+
+	it("resolves a symlink inside the workspace that points to a file outside, to the outside path", async () => {
+		if (!symlinksSupported) return
+		const secret = path.join(outside, "secret.txt")
+		await fs.writeFile(secret, "x")
+		const link = path.join(workspace, "link.txt")
+		await fs.symlink(secret, link)
+
+		const resolved = await resolveRealPath(link)
+
+		expect(resolved).toBe(expectCase(await fs.realpath(secret)))
+		expect(resolved.startsWith(expectCase(workspace) + path.sep)).toBe(false)
+	})
+
+	it("resolves a symlink inside the workspace that points to a directory outside, to the outside path", async () => {
+		if (!symlinksSupported) return
+		const outsideDir = path.join(outside, "dir")
+		await fs.mkdir(outsideDir)
+		const linkDir = path.join(workspace, "linkdir")
+		await fs.symlink(outsideDir, linkDir)
+
+		const resolved = await resolveRealPath(linkDir)
+
+		expect(resolved).toBe(expectCase(await fs.realpath(outsideDir)))
+	})
+
+	it("resolves a not-yet-created file under a symlinked ancestor by resolving the ancestor and re-appending", async () => {
+		if (!symlinksSupported) return
+		const outsideDir = path.join(outside, "dir")
+		await fs.mkdir(outsideDir)
+		const linkDir = path.join(workspace, "linkdir")
+		await fs.symlink(outsideDir, linkDir)
+
+		// Neither "nested" nor "new.txt" exists yet — the walk-up must resolve `linkDir` and
+		// re-append the trailing segments.
+		const notYetCreated = path.join(linkDir, "nested", "new.txt")
+		const resolved = await resolveRealPath(notYetCreated)
+
+		expect(resolved).toBe(expectCase(path.join(await fs.realpath(outsideDir), "nested", "new.txt")))
+	})
+
+	it("re-throws EACCES instead of swallowing it (fail closed)", async () => {
+		if (isWindows || isRoot) return
+		const restricted = path.join(workspace, "restricted")
+		await fs.mkdir(restricted)
+		const target = path.join(restricted, "file.txt")
+		await fs.writeFile(target, "x")
+		await fs.chmod(restricted, 0o000)
+
+		await expect(resolveRealPath(target)).rejects.toMatchObject({ code: "EACCES" })
+	})
+
+	it("re-throws ELOOP for a circular symlink chain", async () => {
+		if (!symlinksSupported) return
+		const a = path.join(workspace, "a")
+		const b = path.join(workspace, "b")
+		// a -> b and b -> a is a cycle realpath cannot resolve.
+		await fs.symlink(b, a)
+		await fs.symlink(a, b)
+
+		await expect(resolveRealPath(a)).rejects.toMatchObject({ code: "ELOOP" })
+	})
+
+	it("resolves correctly even with no workspace context (it owns no policy)", async () => {
+		const real = path.join(outside, "plain.txt")
+		await fs.writeFile(real, "x")
+
+		const resolved = await resolveRealPath(real)
+
+		expect(resolved).toBe(expectCase(await fs.realpath(real)))
+	})
+
+	it("case-normalizes the resolved path to lowercase on case-insensitive platforms (e.g. darwin)", async () => {
+		const mixed = path.join(outside, "MixedCase.txt")
+		await fs.writeFile(mixed, "x")
+		const realMixed = await fs.realpath(mixed)
+
+		const originalPlatform = process.platform
+		Object.defineProperty(process, "platform", { value: "darwin", configurable: true })
+		try {
+			const resolved = await resolveRealPath(mixed)
+			expect(resolved).toBe(realMixed.toLowerCase())
+			expect(resolved).toContain("mixedcase.txt")
+		} finally {
+			Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+		}
+	})
+})


### PR DESCRIPTION
Part of #169. Sub-issue 2 of 4. **Depends on #428 (#389 `WorkspacePathResolver`).**

> [!NOTE]
> **Stacked on #428.** This branch is built on top of `feat/389-workspace-path-resolver`, so the diff currently includes the `WorkspacePathResolver` commit. Once #428 merges to `main`, I'll rebase and that commit drops out, leaving only the `WorkspaceFileAccess` change. Draft until #428 lands.

## What

Adds `src/core/workspace/WorkspaceFileAccess.ts` — the policy layer #390 calls for. Tools request an authorized operation instead of doing a raw `isPathOutsideWorkspace()` boolean check followed by their own `fs` access. The decoupled check-then-act pattern is structurally easy to get wrong; the missed `ApplyDiffTool` check in #241 is exactly the failure mode this prevents.

```ts
type AuthorizeResult =
  | { ok: true; resolvedPath: string }
  | { ok: false; reason: "outside_workspace" | "symlink_escapes_workspace" | "realpath_failed" | "permission_denied"; message: string }

authorizeRead(options): Promise<AuthorizeResult>
authorizeWrite(options): Promise<AuthorizeResult>
```

- **Default (fail-closed):** canonicalizes the requested path and every workspace folder via `resolveRealPath` (#389); grants access only when the real path lands inside a real folder. A folder that can't be resolved is skipped (can't prove containment), never treated as a match.
- **Opt-in:** `allowSymlinksOutsideWorkspace` restores the pre-#169 lexical behavior (symlinks not followed for the boundary decision).
- `allowSymlinksOutsideWorkspace` is read from `task.providerRef.deref()?.getState()` with a try/catch — provider may be torn down — defaulting to `false`.
- `symlink_escapes_workspace` is distinguished from `outside_workspace` so callers/telemetry can tell a deliberate out-of-tree path apart from one that *looks* inside but escapes via a symlink.

The `allowSymlinksOutsideWorkspace` setting is **introduced here** (its home per the issue) in `GlobalSettings` + `ExtensionState`.

## Scope

Per the issue: **does not change any tool behavior.** No UI, no i18n, no tool migrations — those are #391/#392.

## Tests

`src/core/workspace/__tests__/WorkspaceFileAccess.spec.ts` — real temp dirs + real symlinks (no `fs` mocking), covering all six scenarios from the issue plus plainly-outside, provider-throws, and no-workspace-open. Skips symlink/EACCES cases cleanly on Windows/root.

- ✅ `tsc --noEmit` clean
- ✅ `eslint --max-warnings=0` clean (src + types)
- ✅ 9/9 tests pass