### PR TITLE
feat: better securing release workflows and github actions

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish-stable:
     runs-on: ubuntu-latest
+    environment: marketplace-production
     permissions:
       contents: write
 
@@ -28,6 +29,13 @@ jobs:
 
           test "$package_name" = "zoo-code"
           test "$publisher" = "ZooCodeOrganization"
+
+      - name: Validate publish ref
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "Manual stable publishes must run from main, not ${GITHUB_REF_NAME}."
+            exit 1
+          fi
 
       - name: Validate release tag
         if: github.event_name == 'push'

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   publish-prerelease:
     runs-on: ubuntu-latest
+    environment: marketplace-prerelease
 
     steps:
       - name: Checkout code
@@ -32,6 +33,13 @@ jobs:
 
           test "$package_name" = "zoo-code"
           test "$publisher" = "ZooCodeOrganization"
+
+      - name: Validate publish ref
+        run: |
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "Pre-release publishes must run from main, not ${GITHUB_REF_NAME}."
+            exit 1
+          fi
 
       - name: Set pre-release version
         id: version


### PR DESCRIPTION
### Related GitHub Issue

Closes: #

### Description

Adds GitHub environment references and ref guards to the release publish workflows so marketplace credentials are exposed through narrower, auditable release paths.

Key changes:

- Stable extension publishing now targets the `marketplace-production` environment.
- Pre-release extension publishing now targets the `marketplace-prerelease` environment.
- Manual stable publishes are rejected unless the workflow is run from `main`.
- Pre-release publishes are rejected unless the workflow is run from `main`, preventing manual dispatch from arbitrary feature branches.

The intended live GitHub environment setup is:

- `marketplace-production`: required reviewer gate for stable marketplace publishing.
- `marketplace-prerelease`: no required reviewer gate, preserving automatic pre-release publishing from protected `main`.

### Test Procedure

- Parsed the updated workflow YAML files locally.
- Ran `git diff --check`.
- Verified the live GitHub environments exist:
  - `marketplace-production` with the `Admins` team as required reviewers.
  - `marketplace-prerelease` with no required reviewers.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

After this merges, move marketplace publish tokens into environment-scoped secrets:

- Move production `VSCE_PAT` and `OVSX_PAT` into `marketplace-production`.
- Optionally use a separate pre-release `VSCE_PAT` in `marketplace-prerelease`.
- Delete repository-level marketplace publish PATs once environment-scoped secrets are in place.

### Get in Touch



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline with additional validation controls to improve the reliability and consistency of stable and pre-release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->