### PR TITLE
fix(zoo-gateway): stop unauthenticated model discovery 401 spam

### DIFF
--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -38,6 +38,7 @@ export interface ExtensionMessage {
 		| "commitSearchResults"
 		| "listApiConfig"
 		| "routerModels"
+		| "zooGatewayCredentialsReady"
 		| "openAiModels"
 		| "ollamaModels"
 		| "lmStudioModels"

--- a/src/api/providers/fetchers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/fetchers/__tests__/zoo-gateway.spec.ts
@@ -77,13 +77,11 @@ describe("Zoo Gateway Fetchers", () => {
 			expect(models["anthropic/claude-sonnet-4"]).toBeDefined()
 		})
 
-		it("omits the Authorization header when no token is provided", async () => {
-			mockedAxios.get.mockResolvedValueOnce(mockResponse)
+		it("skips the request and returns {} when no token is available", async () => {
+			const models = await getZooGatewayModels({ zooGatewayBaseUrl: baseUrl } as any)
 
-			await getZooGatewayModels({ zooGatewayBaseUrl: baseUrl } as any)
-
-			const call = mockedAxios.get.mock.calls[0]
-			expect(call[1].headers.Authorization).toBeUndefined()
+			expect(mockedAxios.get).not.toHaveBeenCalled()
+			expect(models).toEqual({})
 		})
 
 		it("returns {} and never leaks the error object when the request fails", async () => {

--- a/src/api/providers/fetchers/zoo-gateway.ts
+++ b/src/api/providers/fetchers/zoo-gateway.ts
@@ -25,9 +25,12 @@ export async function getZooGatewayModels(options?: ApiHandlerOptions): Promise<
 	const baseURL = options?.zooGatewayBaseUrl ?? `${getZooCodeBaseUrl()}/api/gateway/v1`
 
 	const sessionToken = resolveZooGatewaySessionToken(options?.zooSessionToken)
-	const headers: Record<string, string> = {}
-	if (sessionToken) {
-		headers["Authorization"] = `Bearer ${sessionToken}`
+	if (!sessionToken) {
+		return models
+	}
+
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${sessionToken}`,
 	}
 
 	try {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -943,7 +943,8 @@ export class ClineProvider
 			}
 
 			if (allUpToDate) {
-				// All profiles have the current token — nothing to do
+				const { postZooGatewayCredentialsReady } = await import("../../services/zoo-gateway-credentials-sync")
+				postZooGatewayCredentialsReady((message) => this.postMessageToWebview(message))
 				return
 			}
 		}
@@ -1815,6 +1816,8 @@ export class ClineProvider
 			)
 		}
 		await this.postStateToWebview()
+		const { postZooGatewayCredentialsReady } = await import("../../services/zoo-gateway-credentials-sync")
+		postZooGatewayCredentialsReady((message) => this.postMessageToWebview(message))
 	}
 
 	// Requesty

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -3707,12 +3707,14 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 				} as any)
 				const upsertSpy = vi.spyOn(provider, "upsertProviderProfile").mockResolvedValue("profile-id")
 				vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+				const postMessageSpy = vi.spyOn(provider, "postMessageToWebview").mockResolvedValue(undefined)
 				;(provider as any).providerSettingsManager = {
 					listConfig: vi.fn().mockResolvedValue([]),
 				}
 
 				await provider.handleZooCodeCallback("zoo_ext_token")
 
+				expect(postMessageSpy).toHaveBeenCalledWith({ type: "zooGatewayCredentialsReady" })
 				expect(upsertSpy).toHaveBeenCalledWith(
 					"Zoo Gateway",
 					expect.objectContaining({
@@ -3809,6 +3811,7 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 				const { getCachedZooCodeToken } = await import("../../../services/zoo-code-auth")
 				vi.mocked(getCachedZooCodeToken).mockReturnValue("current-token")
 				const handleSpy = vi.spyOn(provider, "handleZooCodeCallback").mockResolvedValue(undefined)
+				const postMessageSpy = vi.spyOn(provider, "postMessageToWebview").mockResolvedValue(undefined)
 
 				;(provider as any).providerSettingsManager = {
 					listConfig: vi.fn().mockResolvedValue([{ name: "Zoo Gateway", apiProvider: "zoo-gateway" }]),
@@ -3821,6 +3824,7 @@ describe("ClineProvider - Comprehensive Edit/Delete Edge Cases", () => {
 				await (provider as any).ensureZooGatewayProfileSeeded()
 
 				expect(handleSpy).not.toHaveBeenCalled()
+				expect(postMessageSpy).toHaveBeenCalledWith({ type: "zooGatewayCredentialsReady" })
 			})
 
 			it("re-seeds when any zoo-gateway profile has a stale or missing token", async () => {

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -981,6 +981,7 @@ export const webviewMessageHandler = async (
 					key: "zoo-gateway",
 					options: {
 						provider: "zoo-gateway",
+						apiKey: apiConfiguration.zooSessionToken,
 						baseUrl: apiConfiguration.zooGatewayBaseUrl,
 					},
 				},

--- a/src/services/zoo-gateway-credentials-sync.ts
+++ b/src/services/zoo-gateway-credentials-sync.ts
@@ -1,0 +1,6 @@
+import type { ExtensionMessage } from "@roo-code/types"
+
+/** Notifies the webview that Zoo Gateway credentials are available for model discovery. */
+export function postZooGatewayCredentialsReady(postMessage: (message: ExtensionMessage) => void): void {
+	postMessage({ type: "zooGatewayCredentialsReady" })
+}

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -25,6 +25,7 @@ import { vscode } from "@src/utils/vscode"
 import { validateApiConfigurationExcludingModelErrors, getModelValidationError } from "@src/utils/validate"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { useRouterModels } from "@src/components/ui/hooks/useRouterModels"
+import { useZooGatewayRouterModelsSync } from "@src/components/ui/hooks/useZooGatewayRouterModelsSync"
 import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
 import { requestLmStudioModels } from "@src/components/ui/hooks/useLmStudioModels"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
@@ -171,6 +172,7 @@ const ApiOptions = ({
 		typeof apiConfiguration.apiProvider === "string" && isRetiredProvider(apiConfiguration.apiProvider)
 
 	const { data: routerModels, refetch: refetchRouterModels } = useRouterModels()
+	useZooGatewayRouterModelsSync()
 
 	const { data: openRouterModelProviders } = useOpenRouterModelProviders(
 		apiConfiguration?.openRouterModelId,

--- a/webview-ui/src/components/ui/hooks/__tests__/useZooGatewayRouterModelsSync.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useZooGatewayRouterModelsSync.spec.ts
@@ -110,6 +110,8 @@ describe("useZooGatewayRouterModelsSync", () => {
 		await waitFor(() => expect(mockFetchRouterModels).toHaveBeenCalled())
 		const cached = queryClient.getQueryData<RouterModels>(["routerModels", "all"])
 		expect(cached?.["zoo-gateway"]).toBeUndefined()
+		// The whole cache must survive an empty result, not just the zoo-gateway key.
+		expect(cached?.openrouter).toEqual({ "openai/gpt-4": modelInfo })
 	})
 
 	it("swallows fetch errors", async () => {

--- a/webview-ui/src/components/ui/hooks/__tests__/useZooGatewayRouterModelsSync.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useZooGatewayRouterModelsSync.spec.ts
@@ -1,0 +1,127 @@
+// npx vitest src/components/ui/hooks/__tests__/useZooGatewayRouterModelsSync.spec.ts
+
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { Mock } from "vitest"
+
+import type { ModelInfo, RouterModels } from "@roo-code/types"
+
+import { useZooGatewayRouterModelsSync } from "../useZooGatewayRouterModelsSync"
+import { fetchRouterModels } from "../useRouterModels"
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+
+vi.mock("../useRouterModels")
+vi.mock("@src/context/ExtensionStateContext")
+
+const mockFetchRouterModels = fetchRouterModels as Mock<typeof fetchRouterModels>
+const mockUseExtensionState = useExtensionState as unknown as Mock
+
+const modelInfo: ModelInfo = {
+	maxTokens: 8192,
+	contextWindow: 200000,
+	supportsImages: false,
+	supportsPromptCache: false,
+}
+
+const zooModels = { "anthropic/claude-sonnet-4": modelInfo }
+
+// Test fixtures intentionally carry a single provider key; RouterModels requires
+// every provider key, so cast through unknown for these partial literals.
+const asRouterModels = (value: Record<string, Record<string, ModelInfo>>) => value as unknown as RouterModels
+
+const setAuthenticated = (zooCodeIsAuthenticated: boolean) => {
+	mockUseExtensionState.mockReturnValue({ zooCodeIsAuthenticated })
+}
+
+const renderSyncHook = (queryClient: QueryClient) =>
+	renderHook(() => useZooGatewayRouterModelsSync(), {
+		wrapper: ({ children }: { children: React.ReactNode }) =>
+			React.createElement(QueryClientProvider, { client: queryClient }, children),
+	})
+
+const makeQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	mockFetchRouterModels.mockResolvedValue(asRouterModels({ "zoo-gateway": zooModels }))
+})
+
+describe("useZooGatewayRouterModelsSync", () => {
+	it("does not fetch when the user is not authenticated", async () => {
+		setAuthenticated(false)
+		const queryClient = makeQueryClient()
+
+		renderSyncHook(queryClient)
+		window.dispatchEvent(new MessageEvent("message", { data: { type: "zooGatewayCredentialsReady" } }))
+
+		await Promise.resolve()
+		expect(mockFetchRouterModels).not.toHaveBeenCalled()
+	})
+
+	it("fetches zoo-gateway models on the zooGatewayCredentialsReady message when authenticated", async () => {
+		setAuthenticated(true)
+		const queryClient = makeQueryClient()
+
+		renderSyncHook(queryClient)
+		window.dispatchEvent(new MessageEvent("message", { data: { type: "zooGatewayCredentialsReady" } }))
+
+		await waitFor(() => expect(mockFetchRouterModels).toHaveBeenCalledWith("zoo-gateway"))
+	})
+
+	it("fetches once on the false -> true authentication transition", async () => {
+		setAuthenticated(false)
+		const queryClient = makeQueryClient()
+
+		const { rerender } = renderSyncHook(queryClient)
+		expect(mockFetchRouterModels).not.toHaveBeenCalled()
+
+		setAuthenticated(true)
+		rerender()
+
+		await waitFor(() => expect(mockFetchRouterModels).toHaveBeenCalledTimes(1))
+	})
+
+	it("merges into the routerModels cache without clobbering other providers", async () => {
+		setAuthenticated(true)
+		const queryClient = makeQueryClient()
+		const existingOpenrouter = { "openai/gpt-4": modelInfo }
+		queryClient.setQueryData(["routerModels", "all"], asRouterModels({ openrouter: existingOpenrouter }))
+
+		renderSyncHook(queryClient)
+		window.dispatchEvent(new MessageEvent("message", { data: { type: "zooGatewayCredentialsReady" } }))
+
+		await waitFor(() => {
+			const cached = queryClient.getQueryData<RouterModels>(["routerModels", "all"])
+			expect(cached?.["zoo-gateway"]).toEqual(zooModels)
+			expect(cached?.openrouter).toEqual(existingOpenrouter)
+		})
+	})
+
+	it("does not overwrite the cache when the fetch returns no zoo-gateway models", async () => {
+		setAuthenticated(true)
+		mockFetchRouterModels.mockResolvedValue(asRouterModels({ "zoo-gateway": {} }))
+		const queryClient = makeQueryClient()
+		queryClient.setQueryData(["routerModels", "all"], asRouterModels({ openrouter: { "openai/gpt-4": modelInfo } }))
+
+		renderSyncHook(queryClient)
+		window.dispatchEvent(new MessageEvent("message", { data: { type: "zooGatewayCredentialsReady" } }))
+
+		await waitFor(() => expect(mockFetchRouterModels).toHaveBeenCalled())
+		const cached = queryClient.getQueryData<RouterModels>(["routerModels", "all"])
+		expect(cached?.["zoo-gateway"]).toBeUndefined()
+	})
+
+	it("swallows fetch errors", async () => {
+		setAuthenticated(true)
+		mockFetchRouterModels.mockRejectedValue(new Error("router fetch in flight"))
+		const queryClient = makeQueryClient()
+
+		renderSyncHook(queryClient)
+		expect(() =>
+			window.dispatchEvent(new MessageEvent("message", { data: { type: "zooGatewayCredentialsReady" } })),
+		).not.toThrow()
+
+		await waitFor(() => expect(mockFetchRouterModels).toHaveBeenCalled())
+	})
+})

--- a/webview-ui/src/components/ui/hooks/useRouterModels.ts
+++ b/webview-ui/src/components/ui/hooks/useRouterModels.ts
@@ -9,7 +9,7 @@ type UseRouterModelsOptions = {
 	enabled?: boolean // gate fetching entirely
 }
 
-const getRouterModels = async (provider?: string) =>
+export const fetchRouterModels = async (provider?: string) =>
 	new Promise<RouterModels>((resolve, reject) => {
 		const cleanup = () => {
 			if (typeof window !== "undefined") {
@@ -57,7 +57,7 @@ export const useRouterModels = (opts: UseRouterModelsOptions = {}) => {
 	const provider = opts.provider || undefined
 	return useQuery({
 		queryKey: ["routerModels", provider || "all"],
-		queryFn: () => getRouterModels(provider),
+		queryFn: () => fetchRouterModels(provider),
 		enabled: opts.enabled !== false,
 	})
 }

--- a/webview-ui/src/components/ui/hooks/useZooGatewayRouterModelsSync.ts
+++ b/webview-ui/src/components/ui/hooks/useZooGatewayRouterModelsSync.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+
+import type { ExtensionMessage, RouterModels } from "@roo-code/types"
+
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+
+import { fetchRouterModels } from "./useRouterModels"
+
+/**
+ * Keeps zoo-gateway models in the shared routerModels query fresh when credentials
+ * become available (sign-in or profile seeding) without coupling auth to modelCache.
+ */
+export function useZooGatewayRouterModelsSync() {
+	const queryClient = useQueryClient()
+	const { zooCodeIsAuthenticated } = useExtensionState()
+	const wasAuthenticatedRef = useRef<boolean | undefined>(undefined)
+
+	const syncZooGatewayModels = useCallback(async () => {
+		if (!zooCodeIsAuthenticated) {
+			return
+		}
+
+		try {
+			const partial = await fetchRouterModels("zoo-gateway")
+			const zooModels = partial["zoo-gateway"]
+			if (!zooModels || Object.keys(zooModels).length === 0) {
+				return
+			}
+
+			queryClient.setQueryData<RouterModels>(["routerModels", "all"], (current) =>
+				current ? { ...current, "zoo-gateway": zooModels } : partial,
+			)
+		} catch {
+			// Ignore: bulk router fetch may still be in flight.
+		}
+	}, [queryClient, zooCodeIsAuthenticated])
+
+	useEffect(() => {
+		const onMessage = (event: MessageEvent) => {
+			const message = event.data as ExtensionMessage
+			if (message.type === "zooGatewayCredentialsReady") {
+				void syncZooGatewayModels()
+			}
+		}
+
+		window.addEventListener("message", onMessage)
+		return () => window.removeEventListener("message", onMessage)
+	}, [syncZooGatewayModels])
+
+	useEffect(() => {
+		const wasAuthenticated = wasAuthenticatedRef.current
+		wasAuthenticatedRef.current = zooCodeIsAuthenticated
+
+		if (zooCodeIsAuthenticated && wasAuthenticated === false) {
+			void syncZooGatewayModels()
+		}
+	}, [zooCodeIsAuthenticated, syncZooGatewayModels])
+}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -414,7 +414,13 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					break
 				}
 				case "routerModels": {
-					setExtensionRouterModels(message.routerModels)
+					const provider = message.values?.provider as string | undefined
+					const incoming = message.routerModels
+					if (provider && incoming) {
+						setExtensionRouterModels((current) => (current ? { ...current, ...incoming } : incoming))
+					} else {
+						setExtensionRouterModels(incoming)
+					}
 					break
 				}
 				case "marketplaceData": {


### PR DESCRIPTION
## Summary
- Skip Zoo Gateway `/models` requests when no session token resolves, eliminating repeated 401s from `requestRouterModels` for signed-out users.
- Pass the profile `zooSessionToken` into model discovery so already-signed-in users are not stuck on an empty list until re-login.
- Notify the webview when credentials are ready and refetch zoo-gateway models after sign-in or profile seeding.

## Test plan
- [x] Extension unit tests (zoo-gateway fetcher/handler, webviewMessageHandler, ClineProvider auth seed)
- [x] Webview unit tests (ExtensionStateContext, ApiOptions, ZooGateway)
- [x] `tsc` on src, webview-ui, packages/types
- [x] Manual: signed-in user sees models without re-login; signed-out user does not spam `/api/gateway/v1/models` 401s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit credential-ready notifications for Zoo Gateway
  * Automatically sync Zoo Gateway router models when credentials become available

* **Bug Fixes**
  * Skip network requests and return empty result when Zoo Gateway session token is missing

* **Refactor**
  * Centralized credential-ready messaging and merge router-model updates into existing state

* **Tests**
  * Added/updated tests for credential readiness, sync behavior, fetch skipping, and model-cache merging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->