### PR TITLE
fix: remove unsupported --no-absolute-filenames tar arg and fix tests

### DIFF
--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -235,7 +235,6 @@ describe("semble-downloader", () => {
 						"-C",
 						path.join("/storage", "semble.new"),
 						"--no-same-owner",
-						"--no-absolute-filenames",
 						"--no-overwrite-dir",
 					],
 					expect.any(Object),

--- a/src/services/code-index/semble/semble-downloader.ts
+++ b/src/services/code-index/semble/semble-downloader.ts
@@ -258,11 +258,11 @@ export async function getSembleBinaryPath(storageDir: string): Promise<string | 
 function extractTarGz(archivePath: string, destDir: string): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const args = ["-xzf", archivePath, "-C", destDir, "--no-same-owner"]
-		// GNU tar: --no-absolute-filenames blocks leading-slash entries,
-		// --no-overwrite-dir adds defense-in-depth against ../relative traversal.
-		// macOS bsdtar strips absolute paths by default.
+		// GNU tar: --no-overwrite-dir preserves existing directory metadata.
+		// Both GNU tar and macOS bsdtar strip leading '/' and reject '..' path
+		// components by default, so no extra flag is needed for path traversal safety.
 		if (process.platform === "linux") {
-			args.push("--no-absolute-filenames", "--no-overwrite-dir")
+			args.push("--no-overwrite-dir")
 		}
 		const child = spawn("tar", args, {
 			shell: false,


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @navedmerchant :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Fixes the failing unit tests for PR #492 by updating both the source and test to remove the unsupported `--no-absolute-filenames` tar argument.

## Changes

- **`src/services/code-index/semble/semble-downloader.ts`**: Removed `--no-absolute-filenames` from Linux tar extraction args and updated the comment to document that both GNU tar and macOS bsdtar strip leading `/` and reject `..` path components by default.
- **`src/services/code-index/semble/__tests__/semble-downloader.spec.ts`**: Removed `"--no-absolute-filenames"` from the expected `spawn` arguments assertion.

## Testing

- All 27 tests in `semble-downloader.spec.ts` pass
- Pre-commit hooks (prettier + ESLint) passed

## Related

Closes #491, supersedes #492 (original branch `patch-1` no longer exists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive extraction behavior on Linux systems to ensure correct file permissions and directory handling during extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->