### PR TITLE
fix: use VS Code default shell for command execution instead of /bin/sh

### DIFF
--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -3,6 +3,7 @@ import psTree from "ps-tree"
 import process from "process"
 
 import type { RooTerminal } from "./types"
+import { getShell } from "../../utils/shell"
 import { BaseTerminal } from "./BaseTerminal"
 import { BaseTerminalProcess } from "./BaseTerminalProcess"
 
@@ -40,7 +41,7 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 			this.isHot = true
 
 			this.subprocess = execa({
-				shell: BaseTerminal.getExecaShellPath() || true,
+					shell: BaseTerminal.getExecaShellPath() || getShell(),
 				cwd: this.terminal.getCurrentWorkingDirectory(),
 				all: true,
 				// Ignore stdin to ensure non-interactive mode and prevent hanging

--- a/src/integrations/terminal/__tests__/ExecaTerminalProcess.spec.ts
+++ b/src/integrations/terminal/__tests__/ExecaTerminalProcess.spec.ts
@@ -1,6 +1,7 @@
 // npx vitest run integrations/terminal/__tests__/ExecaTerminalProcess.spec.ts
 
 const mockPid = 12345
+const mockGetShell = vitest.fn(() => "/bin/bash")
 
 vitest.mock("execa", () => {
 	const mockKill = vitest.fn()
@@ -19,6 +20,10 @@ vitest.mock("execa", () => {
 
 vitest.mock("ps-tree", () => ({
 	default: vitest.fn((_: number, cb: any) => cb(null, [])),
+}))
+
+vitest.mock("../../../utils/shell", () => ({
+	getShell: () => mockGetShell(),
 }))
 
 import { execa } from "execa"
@@ -63,7 +68,7 @@ describe("ExecaTerminalProcess", () => {
 			const execaMock = vitest.mocked(execa)
 			expect(execaMock).toHaveBeenCalledWith(
 				expect.objectContaining({
-					shell: true,
+					shell: "/bin/bash",
 					cwd: "/test/cwd",
 					all: true,
 					env: expect.objectContaining({
@@ -105,13 +110,14 @@ describe("ExecaTerminalProcess", () => {
 			)
 		})
 
-		it("should fall back to shell=true when execaShellPath is undefined", async () => {
+		it("should fall back to getShell() when execaShellPath is undefined", async () => {
 			BaseTerminal.setExecaShellPath(undefined)
+			mockGetShell.mockReturnValue("/usr/bin/zsh")
 			await terminalProcess.run("echo test")
 			const execaMock = vitest.mocked(execa)
 			expect(execaMock).toHaveBeenCalledWith(
 				expect.objectContaining({
-					shell: true,
+					shell: "/usr/bin/zsh",
 				}),
 			)
 		})


### PR DESCRIPTION
### Related GitHub Issue

Closes: #508 

### Description

When terminalShellIntegrationDisabled is true (the default), commands are executed via execa. Previously, execa used shell: true which defaults to /bin/sh on Linux, ignoring the user's VS Code terminal shell settings.

Now execa falls back to getShell() which respects:
- VS Code terminal.integrated.defaultProfile.linux
- os.userInfo().shell
- $SHELL environment variable
- Platform-specific defaults (/bin/bash on Linux, /bin/zsh on macOS)

### Test Procedure

- Select bash as VS code shell
- Reload window to get clean state
- Give zoo code this prompt "please run sleep 60"
- Run ps aux | grep sleep to observe how Zoo code launched the command
- See that /bin/bash being used as expected.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

n/a

### Documentation Updates

not needed

### Additional Notes

n/a

### Get in Touch

povilas_78868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved shell selection mechanism for terminal processes.
* **Tests**
  * Updated test suite to verify shell selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->