### PR TITLE
chore: gate marketplace publish behind PR approval check

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -7,7 +7,51 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-pr-approval:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR approval status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          pr_number=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+            --header "Accept: application/vnd.github+json" \
+            --jq '.[0].number // empty')
+
+          if [ -z "$pr_number" ]; then
+            echo "No PR found for commit ${SHA}. Deployment requires an approved PR."
+            exit 1
+          fi
+
+          review_decision=$(gh api graphql \
+            -f owner="${REPO%%/*}" \
+            -f name="${REPO#*/}" \
+            -F number="$pr_number" \
+            -f query='
+              query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    reviewDecision
+                  }
+                }
+              }' \
+            --jq '.data.repository.pullRequest.reviewDecision // "NONE"')
+
+          echo "PR #${pr_number} review_decision: ${review_decision}"
+
+          if [ "$review_decision" != "APPROVED" ]; then
+            echo "PR #${pr_number} is not approved (state: ${review_decision}). Deployment blocked."
+            exit 1
+          fi
+
+          echo "PR #${pr_number} is approved. Proceeding."
+
   publish-stable:
+    needs: [check-pr-approval]
     runs-on: ubuntu-latest
     environment: marketplace-production
     permissions:

--- a/.roo/commands/release.md
+++ b/.roo/commands/release.md
@@ -82,32 +82,31 @@ mode: code
     - If the release includes translated README or package-localization updates, include those files in the same PR.
     - Let the release validation workflow and normal PR checks run before merge.
 
-11. After the release PR is merged, stop for a release review on the resulting `main` commit.
+11. Once the release PR is open and passing checks, get it approved by a reviewer before proceeding.
+
+    - Do not create the tag until the PR has at least one approval — the publish workflow enforces this automatically and will fail if no approved PR is found for the tagged commit.
+
+12. After the PR is approved, create the release tag on the release branch tip and push it:
 
     ```bash
-    git switch main
-    git pull origin main
-    REVIEWED_SHA=$(git rev-parse HEAD)
-    git rev-parse --short "$REVIEWED_SHA"
-    ```
-
-    - Review the merged release state before any publish step.
-    - Confirm that `src/package.json`, `CHANGELOG.md`, `src/CHANGELOG.md`, and the Marketplace-facing `README.md` all reflect the intended release.
-    - Check that the release PR checks passed and that the merged commit is the one you want to ship.
-    - Share that review summary, including `REVIEWED_SHA`, with the user and wait for explicit confirmation before creating the tag.
-    - Do not create the tag or trigger publishing until the user says to proceed.
-
-12. Only after explicit confirmation, create the release tag on that reviewed `main` commit:
-
-    ```bash
-    git tag v[version] "$REVIEWED_SHA"
+    git tag v[version]
     git push origin v[version]
     ```
 
-    - If `main` advances after the review pause, keep using the pinned `REVIEWED_SHA` for the tag instead of silently tagging a newer commit.
-
-13. The stable publish workflow runs from the `v[version]` tag.
-
-    - Do not create the tag before the release PR is merged.
+    - Tag the branch tip as-is. Do not rebase or merge additional commits into the release branch before tagging — doing so changes the commit SHA and may pull in unreviewed changes that weren't part of the approval.
     - The publish workflow validates that the tag version matches `src/package.json`.
-    - Marketplace and Open VSX publishing use the configured CI secrets.
+
+13. The tag push triggers the stable publish workflow.
+
+    - The workflow first checks that the tagged commit belongs to an approved PR. If the PR is not yet approved this step fails — approve the PR first, then retrigger by recreating and pushing the tag: `git tag -d v[version] && git push origin :refs/tags/v[version] && git tag v[version] && git push origin v[version]`.
+    - Once the approval check passes, the `marketplace-production` environment gate fires and notifies the configured approvers.
+    - A human approver must then approve the deployment before the extension is published to VS Code Marketplace and Open VSX.
+
+14. After a successful deployment, add the release PR to the merge queue.
+
+    ```bash
+    gh pr merge [pr-number] --auto --squash
+    ```
+
+    - Do not merge before the deployment succeeds — merging first and then discovering a publish failure leaves `main` ahead of what was actually shipped.
+    - The merge queue runs all required checks against the release branch before merging to `main`.


### PR DESCRIPTION
## Summary

- Adds a `check-pr-approval` job to `marketplace-publish.yml` that runs before the `publish-stable` job
- Uses the GitHub REST API to find the PR associated with the triggering commit, then queries the GraphQL API for `reviewDecision`
- If no PR exists, or `reviewDecision` is not `APPROVED`, the check job fails with a non-zero exit — blocking the `marketplace-production` environment gate from surfacing entirely
- `publish-stable` depends on `check-pr-approval` via `needs:`, so a failed check produces a visible red failure rather than a silent green skip

## Why GraphQL over REST

`reviewDecision` is only available on the GraphQL `PullRequest` object — the REST `GET /pulls/{number}` endpoint does not expose it. Using `reviewDecision` means GitHub's own computed effective state is used, which correctly accounts for:
- Reviewer write-permission requirements
- Superseded approvals (CHANGES\_REQUESTED after an approval)
- Blocking reviews and stale approvals

## Security note

The `check-pr-approval` job uses `GITHUB_TOKEN` with `pull-requests: read` only. This is safe because the workflow triggers on `push` to tags — only collaborators with write access to the repo can push tags, so untrusted fork contributors cannot trigger this workflow or leak the token.

## Test plan

- [ ] Push a tag from a branch whose PR has no approvals → `check-pr-approval` fails, no environment approval prompt appears
- [ ] Push a tag from a branch whose PR is approved → `check-pr-approval` passes, `marketplace-production` environment gate fires as normal
- [ ] Push a tag from a branch whose PR had an approval later superseded by CHANGES\_REQUESTED → `check-pr-approval` fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an approval gate to the stable publish workflow so only commits tied to APPROVED pull requests are published.
* **Documentation**
  * Updated release procedure: require an approved release PR before tagging, retry tagging if approval fails, enqueue the PR for merge after successful deployment, and prevent merging to main until deployment succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->