### PR TITLE
feat: add gpt-5.5 support

### DIFF
--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -24,6 +24,32 @@ export const openAiNativeModels = {
 		description:
 			"GPT-5.1 Codex Max: Our most intelligent coding model optimized for long-horizon, agentic coding tasks",
 	},
+	"gpt-5.5": {
+		maxTokens: 128000,
+		contextWindow: 1_050_000,
+		includedTools: ["apply_patch"],
+		excludedTools: ["apply_diff", "write_to_file"],
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["none", "low", "medium", "high", "xhigh"],
+		reasoningEffort: "none",
+		inputPrice: 5.0,
+		outputPrice: 30.0,
+		cacheReadsPrice: 0.5,
+		longContextPricing: {
+			thresholdTokens: 272_000,
+			inputPriceMultiplier: 2,
+			outputPriceMultiplier: 1.5,
+			appliesToServiceTiers: ["default", "flex"],
+		},
+		supportsVerbosity: true,
+		supportsTemperature: false,
+		tiers: [
+			{ name: "flex", contextWindow: 1_050_000, inputPrice: 2.5, outputPrice: 15.0, cacheReadsPrice: 0.25 },
+			{ name: "priority", contextWindow: 1_050_000, inputPrice: 12.5, outputPrice: 75.0, cacheReadsPrice: 1.25 },
+		],
+		description: "GPT-5.5: A new class of intelligence for coding and professional work",
+	},
 	"gpt-5.4": {
 		maxTokens: 128000,
 		contextWindow: 1_050_000,

--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -32,7 +32,7 @@ export const openAiNativeModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["none", "low", "medium", "high", "xhigh"],
-		reasoningEffort: "none",
+		reasoningEffort: "medium",
 		inputPrice: 5.0,
 		outputPrice: 30.0,
 		cacheReadsPrice: 0.5,

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -279,7 +279,7 @@ describe("OpenAiNativeHandler", () => {
 			expect(modelInfo.info.contextWindow).toBe(1_050_000)
 			expect(modelInfo.info.supportsVerbosity).toBe(true)
 			expect(modelInfo.info.supportsReasoningEffort).toEqual(["none", "low", "medium", "high", "xhigh"])
-			expect(modelInfo.info.reasoningEffort).toBe("none")
+			expect(modelInfo.info.reasoningEffort).toBe("medium")
 		})
 
 		it("should return GPT-5.4 model info when selected", () => {

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -273,7 +273,7 @@ describe("OpenAiNativeHandler", () => {
 				apiModelId: "gpt-5.5",
 			})
 
-			const modelInfo = gpt54Handler.getModel()
+			const modelInfo = gpt55Handler.getModel()
 			expect(modelInfo.id).toBe("gpt-5.5")
 			expect(modelInfo.info.maxTokens).toBe(128000)
 			expect(modelInfo.info.contextWindow).toBe(1_050_000)

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -487,7 +487,7 @@ describe("OpenAiNativeHandler", () => {
 			expect(parsedBody.max_output_tokens).toBe(128000)
 			expect(parsedBody.temperature).toBeUndefined()
 			expect(parsedBody.include).toEqual(["reasoning.encrypted_content"])
-			expect(parsedBody.reasoning?.effort).toBe("none")
+			expect(parsedBody.reasoning?.effort).toBe("medium")
 			expect(parsedBody.text?.verbosity).toBe("medium")
 
 			const textChunks = chunks.filter((chunk) => chunk.type === "text")

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -267,6 +267,21 @@ describe("OpenAiNativeHandler", () => {
 			expect(modelInfo.info.supportsReasoningEffort).toEqual(["low", "medium", "high", "xhigh"])
 		})
 
+		it("should return GPT-5.5 model info when selected", () => {
+			const gpt54Handler = new OpenAiNativeHandler({
+				...mockOptions,
+				apiModelId: "gpt-5.5",
+			})
+
+			const modelInfo = gpt54Handler.getModel()
+			expect(modelInfo.id).toBe("gpt-5.5")
+			expect(modelInfo.info.maxTokens).toBe(128000)
+			expect(modelInfo.info.contextWindow).toBe(1_050_000)
+			expect(modelInfo.info.supportsVerbosity).toBe(true)
+			expect(modelInfo.info.supportsReasoningEffort).toEqual(["none", "low", "medium", "high", "xhigh"])
+			expect(modelInfo.info.reasoningEffort).toBe("none")
+		})
+
 		it("should return GPT-5.4 model info when selected", () => {
 			const gpt54Handler = new OpenAiNativeHandler({
 				...mockOptions,
@@ -428,6 +443,56 @@ describe("OpenAiNativeHandler", () => {
 			expect(textChunks).toHaveLength(2)
 			expect(textChunks[0].text).toBe("Hello")
 			expect(textChunks[1].text).toBe(" world")
+		})
+
+		it("should handle GPT-5.5 model with Responses API", async () => {
+			const mockFetch = vitest.fn().mockResolvedValue({
+				ok: true,
+				body: new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								'data: {"type":"response.output_item.added","item":{"type":"text","text":"GPT-5.5 reply"}}\n\n',
+							),
+						)
+						controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"))
+						controller.close()
+					},
+				}),
+			})
+			global.fetch = mockFetch as any
+
+			mockResponsesCreate.mockRejectedValue(new Error("SDK not available"))
+
+			handler = new OpenAiNativeHandler({
+				...mockOptions,
+				apiModelId: "gpt-5.5",
+			})
+
+			const stream = handler.createMessage(systemPrompt, messages)
+			const chunks: any[] = []
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://api.openai.com/v1/responses",
+				expect.objectContaining({
+					body: expect.any(String),
+				}),
+			)
+			const body = (mockFetch.mock.calls[0][1] as any).body as string
+			const parsedBody = JSON.parse(body)
+			expect(parsedBody.model).toBe("gpt-5.5")
+			expect(parsedBody.max_output_tokens).toBe(128000)
+			expect(parsedBody.temperature).toBeUndefined()
+			expect(parsedBody.include).toEqual(["reasoning.encrypted_content"])
+			expect(parsedBody.reasoning?.effort).toBe("none")
+			expect(parsedBody.text?.verbosity).toBe("medium")
+
+			const textChunks = chunks.filter((chunk) => chunk.type === "text")
+			expect(textChunks).toHaveLength(1)
+			expect(textChunks[0].text).toBe("GPT-5.5 reply")
 		})
 
 		it("should handle GPT-5.4 model with Responses API", async () => {

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -268,7 +268,7 @@ describe("OpenAiNativeHandler", () => {
 		})
 
 		it("should return GPT-5.5 model info when selected", () => {
-			const gpt54Handler = new OpenAiNativeHandler({
+			const gpt55Handler = new OpenAiNativeHandler({
 				...mockOptions,
 				apiModelId: "gpt-5.5",
 			})


### PR DESCRIPTION
### Related GitHub Issue

Closes: #264

### Description

Added `gpt-5.5` to the OpenAI provider model list.

### Test Procedure

* Verified the model appears in the OpenAI provider model list
* Confirmed the application runs successfully after the change

### Pre-Submission Checklist

* [x] Issue Linked
* [x] Self-Review completed
* [x] Contribution Guidelines reviewed

### Documentation Updates

* [x] No documentation updates are required.

### Additional Notes

This PR only adds a new model configuration entry.
The related [PR](https://github.com/Zoo-Code-Org/Zoo-Code/pull/265) but without tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPT-5.5 model is now available with extended context window, prompt-caching (with retention behavior), configurable reasoning effort levels, verbosity/temperature controls, tool integration, and tiered/flexible pricing including long-context multipliers.
* **Tests**
  * Added coverage validating GPT-5.5 model metadata and streaming response behavior, including reasoning and verbosity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->