### PR TITLE
fix(branding): replace all residual 'Roo Code' strings with 'Zoo Code' (#551)

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/build",
-	"description": "ESBuild utilities for Roo Code.",
+	"description": "ESBuild utilities for Zoo Code.",
 	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cloud",
-	"description": "Roo Code Cloud services.",
+	"description": "Zoo Code Cloud services.",
 	"version": "0.0.1",
 	"type": "module",
 	"exports": "./src/index.ts",

--- a/packages/cloud/src/WebAuthService.ts
+++ b/packages/cloud/src/WebAuthService.ts
@@ -283,16 +283,16 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			await vscode.env.openExternal(vscode.Uri.parse(url))
 		} catch (error) {
 			const context = landingPageSlug ? ` (landing page: ${landingPageSlug})` : ""
-			this.log(`[auth] Error initiating Roo Code Cloud auth${context}: ${error}`)
-			throw new Error(`Failed to initiate Roo Code Cloud authentication${context}: ${error}`)
+			this.log(`[auth] Error initiating Zoo Code Cloud auth${context}: ${error}`)
+			throw new Error(`Failed to initiate Zoo Code Cloud authentication${context}: ${error}`)
 		}
 	}
 
 	/**
-	 * Handle the callback from Roo Code Cloud
+	 * Handle the callback from Zoo Code Cloud
 	 *
 	 * This method is called when the user is redirected back to the extension
-	 * after authenticating with Roo Code Cloud.
+	 * after authenticating with Zoo Code Cloud.
 	 *
 	 * @param code The authorization code from the callback
 	 * @param state The state parameter from the callback
@@ -309,7 +309,7 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			const vscode = await importVscode()
 
 			if (vscode) {
-				vscode.window.showInformationMessage("Invalid Roo Code Cloud sign in url")
+				vscode.window.showInformationMessage("Invalid Zoo Code Cloud sign in url")
 			}
 
 			return
@@ -345,14 +345,14 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			const vscode = await importVscode()
 
 			if (vscode) {
-				vscode.window.showInformationMessage("Successfully authenticated with Roo Code Cloud")
+				vscode.window.showInformationMessage("Successfully authenticated with Zoo Code Cloud")
 			}
 
-			this.log("[auth] Successfully authenticated with Roo Code Cloud")
+			this.log("[auth] Successfully authenticated with Zoo Code Cloud")
 		} catch (error) {
-			this.log(`[auth] Error handling Roo Code Cloud callback: ${error}`)
+			this.log(`[auth] Error handling Zoo Code Cloud callback: ${error}`)
 			this.changeState("logged-out")
-			throw new Error(`Failed to handle Roo Code Cloud callback: ${error}`)
+			throw new Error(`Failed to handle Zoo Code Cloud callback: ${error}`)
 		}
 	}
 
@@ -380,13 +380,13 @@ export class WebAuthService extends EventEmitter<AuthServiceEvents> implements A
 			const vscode = await importVscode()
 
 			if (vscode) {
-				vscode.window.showInformationMessage("Logged out from Roo Code Cloud")
+				vscode.window.showInformationMessage("Logged out from Zoo Code Cloud")
 			}
 
-			this.log("[auth] Logged out from Roo Code Cloud")
+			this.log("[auth] Logged out from Zoo Code Cloud")
 		} catch (error) {
-			this.log(`[auth] Error logging out from Roo Code Cloud: ${error}`)
-			throw new Error(`Failed to log out from Roo Code Cloud: ${error}`)
+			this.log(`[auth] Error logging out from Zoo Code Cloud: ${error}`)
+			throw new Error(`Failed to log out from Zoo Code Cloud: ${error}`)
 		}
 	}
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/core",
-	"description": "Platform agnostic core functionality for Roo Code.",
+	"description": "Platform agnostic core functionality for Zoo Code.",
 	"version": "0.0.1",
 	"type": "module",
 	"exports": {

--- a/packages/ipc/package.json
+++ b/packages/ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/ipc",
-	"description": "IPC server and client for remote Roo Code access.",
+	"description": "IPC server and client for remote Zoo Code access.",
 	"version": "0.0.1",
 	"type": "module",
 	"exports": "./src/index.ts",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/telemetry",
-	"description": "Roo Code telemetry service and clients.",
+	"description": "Zoo Code telemetry service and clients.",
 	"version": "0.0.1",
 	"type": "module",
 	"exports": "./src/index.ts",

--- a/packages/telemetry/src/PostHogTelemetryClient.ts
+++ b/packages/telemetry/src/PostHogTelemetryClient.ts
@@ -17,7 +17,7 @@ import {
 import { BaseTelemetryClient } from "./BaseTelemetryClient"
 
 /**
- * PostHogTelemetryClient handles telemetry event tracking for the Roo Code extension.
+ * PostHogTelemetryClient handles telemetry event tracking for the Zoo Code extension.
  * Uses PostHog analytics to track user interactions and system events.
  * Respects user privacy settings and VSCode's global telemetry configuration.
  */

--- a/packages/types/src/cookie-consent.ts
+++ b/packages/types/src/cookie-consent.ts
@@ -1,6 +1,6 @@
 /**
  * Cookie consent constants and types
- * Shared across all Roo Code repositories
+ * Shared across all Zoo Code repositories
  */
 
 /**

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -224,7 +224,7 @@ export const globalSettingsSchema = z.object({
 
 	/**
 	 * Path to worktree to auto-open after switching workspaces.
-	 * Used by the worktree feature to open the Roo Code sidebar in a new window.
+	 * Used by the worktree feature to open the Zoo Code sidebar in a new window.
 	 */
 	worktreeAutoOpenPath: z.string().optional(),
 	/**

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -81,7 +81,7 @@ export const isInternalProvider = (key: string): key is InternalProvider =>
 /**
  * CustomProvider
  *
- * Custom providers are completely configurable within Roo Code settings.
+ * Custom providers are completely configurable within Zoo Code settings.
  */
 
 export const customProviders = ["openai"] as const

--- a/packages/types/src/roomodes-schema.ts
+++ b/packages/types/src/roomodes-schema.ts
@@ -51,8 +51,8 @@ export function generateRoomodesJsonSchema(): Record<string, unknown> {
 	}) as Record<string, unknown>
 
 	jsonSchema["$id"] = "https://github.com/RooCodeInc/Roo-Code/blob/main/schemas/roomodes.json"
-	jsonSchema["title"] = "Roo Code Custom Modes"
-	jsonSchema["description"] = "Schema for .roomodes configuration files used by Roo Code to define custom modes."
+	jsonSchema["title"] = "Zoo Code Custom Modes"
+	jsonSchema["description"] = "Schema for .roomodes configuration files used by Zoo Code to define custom modes."
 
 	return jsonSchema
 }

--- a/src/__mocks__/vscode.js
+++ b/src/__mocks__/vscode.js
@@ -71,7 +71,7 @@ export const window = {
 	}),
 	createTerminal: () => ({
 		exitStatus: undefined,
-		name: "Roo Code",
+		name: "Zoo Code",
 		processId: Promise.resolve(123),
 		creationOptions: {},
 		state: { isInteractedWith: true },

--- a/src/activate/__tests__/handleUri.spec.ts
+++ b/src/activate/__tests__/handleUri.spec.ts
@@ -58,7 +58,7 @@ describe("handleUri", () => {
 		expect(mockVisibleProvider.handleOpenRouterCallback).not.toHaveBeenCalled()
 		expect(mockVisibleProvider.handleRequestyCallback).not.toHaveBeenCalled()
 		expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-			"Roo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
+			"Zoo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
 		)
 	})
 

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -114,7 +114,7 @@ describe("getVisibleProviderOrLog", () => {
 		const result = getVisibleProviderOrLog(mockOutputChannel)
 
 		expect(result).toBeUndefined()
-		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Roo Code instances.")
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Zoo Code instances.")
 	})
 })
 

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -21,7 +21,7 @@ import { t } from "../i18n"
 export function getVisibleProviderOrLog(outputChannel: vscode.OutputChannel): ClineProvider | undefined {
 	const visibleProvider = ClineProvider.getVisibleInstance()
 	if (!visibleProvider) {
-		outputChannel.appendLine("Cannot find any visible Roo Code instances.")
+		outputChannel.appendLine("Cannot find any visible Zoo Code instances.")
 		return undefined
 	}
 	return visibleProvider
@@ -232,7 +232,7 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 
 	const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
 
-	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Roo Code", targetCol, {
+	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Zoo Code", targetCol, {
 		enableScripts: true,
 		retainContextWhenHidden: true,
 		localResourceRoots: [context.extensionUri],

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -165,7 +165,7 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 			} as const
 		} catch (error) {
 			throw new Error(
-				"Please check the LM Studio developer logs to debug what went wrong. You may need to load the model with a larger context length to work with Roo Code's prompts.",
+				"Please check the LM Studio developer logs to debug what went wrong. You may need to load the model with a larger context length to work with Zoo Code's prompts.",
 			)
 		}
 	}
@@ -209,7 +209,7 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			throw new Error(
-				"Please check the LM Studio developer logs to debug what went wrong. You may need to load the model with a larger context length to work with Roo Code's prompts.",
+				"Please check the LM Studio developer logs to debug what went wrong. You may need to load the model with a larger context length to work with Zoo Code's prompts.",
 			)
 		}
 	}

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -91,7 +91,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			this.dispose()
 
 			throw new Error(
-				`Roo Code <Language Model API>: Failed to initialize handler: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Zoo Code <Language Model API>: Failed to initialize handler: ${error instanceof Error ? error.message : "Unknown error"}`,
 			)
 		}
 	}
@@ -106,17 +106,17 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		try {
 			// Check if the client is already initialized
 			if (this.client) {
-				console.debug("Roo Code <Language Model API>: Client already initialized")
+				console.debug("Zoo Code <Language Model API>: Client already initialized")
 				return
 			}
 			// Create a new client instance
 			this.client = await this.createClient(this.options.vsCodeLmModelSelector || {})
-			console.debug("Roo Code <Language Model API>: Client initialized successfully")
+			console.debug("Zoo Code <Language Model API>: Client initialized successfully")
 		} catch (error) {
 			// Handle errors during client initialization
 			const errorMessage = error instanceof Error ? error.message : "Unknown error"
-			console.error("Roo Code <Language Model API>: Client initialization failed:", errorMessage)
-			throw new Error(`Roo Code <Language Model API>: Failed to initialize client: ${errorMessage}`)
+			console.error("Zoo Code <Language Model API>: Client initialization failed:", errorMessage)
+			throw new Error(`Zoo Code <Language Model API>: Failed to initialize client: ${errorMessage}`)
 		}
 	}
 	/**
@@ -164,7 +164,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			}
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : "Unknown error"
-			throw new Error(`Roo Code <Language Model API>: Failed to select model: ${errorMessage}`)
+			throw new Error(`Zoo Code <Language Model API>: Failed to select model: ${errorMessage}`)
 		}
 	}
 
@@ -225,13 +225,13 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 	private async internalCountTokens(text: string | vscode.LanguageModelChatMessage): Promise<number> {
 		// Check for required dependencies
 		if (!this.client) {
-			console.warn("Roo Code <Language Model API>: No client available for token counting")
+			console.warn("Zoo Code <Language Model API>: No client available for token counting")
 			return 0
 		}
 
 		// Validate input
 		if (!text) {
-			console.debug("Roo Code <Language Model API>: Empty text provided for token counting")
+			console.debug("Zoo Code <Language Model API>: Empty text provided for token counting")
 			return 0
 		}
 
@@ -255,24 +255,24 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			} else if (text instanceof vscode.LanguageModelChatMessage) {
 				// For chat messages, ensure we have content
 				if (!text.content || (Array.isArray(text.content) && text.content.length === 0)) {
-					console.debug("Roo Code <Language Model API>: Empty chat message content")
+					console.debug("Zoo Code <Language Model API>: Empty chat message content")
 					return 0
 				}
 				const countMessage = extractTextCountFromMessage(text)
 				tokenCount = await this.client.countTokens(countMessage, cancellationToken)
 			} else {
-				console.warn("Roo Code <Language Model API>: Invalid input type for token counting")
+				console.warn("Zoo Code <Language Model API>: Invalid input type for token counting")
 				return 0
 			}
 
 			// Validate the result
 			if (typeof tokenCount !== "number") {
-				console.warn("Roo Code <Language Model API>: Non-numeric token count received:", tokenCount)
+				console.warn("Zoo Code <Language Model API>: Non-numeric token count received:", tokenCount)
 				return 0
 			}
 
 			if (tokenCount < 0) {
-				console.warn("Roo Code <Language Model API>: Negative token count received:", tokenCount)
+				console.warn("Zoo Code <Language Model API>: Negative token count received:", tokenCount)
 				return 0
 			}
 
@@ -280,12 +280,12 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		} catch (error) {
 			// Handle specific error types
 			if (error instanceof vscode.CancellationError) {
-				console.debug("Roo Code <Language Model API>: Token counting cancelled by user")
+				console.debug("Zoo Code <Language Model API>: Token counting cancelled by user")
 				return 0
 			}
 
 			const errorMessage = error instanceof Error ? error.message : "Unknown error"
-			console.warn("Roo Code <Language Model API>: Token counting failed:", errorMessage)
+			console.warn("Zoo Code <Language Model API>: Token counting failed:", errorMessage)
 
 			// Log additional error details if available
 			if (error instanceof Error && error.stack) {
@@ -317,7 +317,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 
 	private async getClient(): Promise<vscode.LanguageModelChat> {
 		if (!this.client) {
-			console.debug("Roo Code <Language Model API>: Getting client with options:", {
+			console.debug("Zoo Code <Language Model API>: Getting client with options:", {
 				vsCodeLmModelSelector: this.options.vsCodeLmModelSelector,
 				hasOptions: !!this.options,
 				selectorKeys: this.options.vsCodeLmModelSelector ? Object.keys(this.options.vsCodeLmModelSelector) : [],
@@ -326,12 +326,12 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			try {
 				// Use default empty selector if none provided to get all available models
 				const selector = this.options?.vsCodeLmModelSelector || {}
-				console.debug("Roo Code <Language Model API>: Creating client with selector:", selector)
+				console.debug("Zoo Code <Language Model API>: Creating client with selector:", selector)
 				this.client = await this.createClient(selector)
 			} catch (error) {
 				const message = error instanceof Error ? error.message : "Unknown error"
-				console.error("Roo Code <Language Model API>: Client creation failed:", message)
-				throw new Error(`Roo Code <Language Model API>: Failed to create client: ${message}`)
+				console.error("Zoo Code <Language Model API>: Client creation failed:", message)
+				throw new Error(`Zoo Code <Language Model API>: Failed to create client: ${message}`)
 			}
 		}
 
@@ -395,7 +395,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		try {
 			// Create the response stream with required options
 			const requestOptions: vscode.LanguageModelChatRequestOptions = {
-				justification: `Roo Code would like to use '${client.name}' from '${client.vendor}', Click 'Allow' to proceed.`,
+				justification: `Zoo Code would like to use '${client.name}' from '${client.vendor}', Click 'Allow' to proceed.`,
 				tools: convertToVsCodeLmTools(metadata?.tools ?? []),
 			}
 
@@ -410,7 +410,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 				if (chunk instanceof vscode.LanguageModelTextPart) {
 					// Validate text part value
 					if (typeof chunk.value !== "string") {
-						console.warn("Roo Code <Language Model API>: Invalid text part value received:", chunk.value)
+						console.warn("Zoo Code <Language Model API>: Invalid text part value received:", chunk.value)
 						continue
 					}
 
@@ -423,23 +423,23 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 					try {
 						// Validate tool call parameters
 						if (!chunk.name || typeof chunk.name !== "string") {
-							console.warn("Roo Code <Language Model API>: Invalid tool name received:", chunk.name)
+							console.warn("Zoo Code <Language Model API>: Invalid tool name received:", chunk.name)
 							continue
 						}
 
 						if (!chunk.callId || typeof chunk.callId !== "string") {
-							console.warn("Roo Code <Language Model API>: Invalid tool callId received:", chunk.callId)
+							console.warn("Zoo Code <Language Model API>: Invalid tool callId received:", chunk.callId)
 							continue
 						}
 
 						// Ensure input is a valid object
 						if (!chunk.input || typeof chunk.input !== "object") {
-							console.warn("Roo Code <Language Model API>: Invalid tool input received:", chunk.input)
+							console.warn("Zoo Code <Language Model API>: Invalid tool input received:", chunk.input)
 							continue
 						}
 
 						// Log tool call for debugging
-						console.debug("Roo Code <Language Model API>: Processing tool call:", {
+						console.debug("Zoo Code <Language Model API>: Processing tool call:", {
 							name: chunk.name,
 							callId: chunk.callId,
 							inputSize: JSON.stringify(chunk.input).length,
@@ -457,12 +457,12 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 							}
 						}
 					} catch (error) {
-						console.error("Roo Code <Language Model API>: Failed to process tool call:", error)
+						console.error("Zoo Code <Language Model API>: Failed to process tool call:", error)
 						// Continue processing other chunks even if one fails
 						continue
 					}
 				} else {
-					console.warn("Roo Code <Language Model API>: Unknown chunk type received:", chunk)
+					console.warn("Zoo Code <Language Model API>: Unknown chunk type received:", chunk)
 				}
 			}
 
@@ -479,11 +479,11 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			this.ensureCleanState()
 
 			if (error instanceof vscode.CancellationError) {
-				throw new Error("Roo Code <Language Model API>: Request cancelled by user")
+				throw new Error("Zoo Code <Language Model API>: Request cancelled by user")
 			}
 
 			if (error instanceof Error) {
-				console.error("Roo Code <Language Model API>: Stream error details:", {
+				console.error("Zoo Code <Language Model API>: Stream error details:", {
 					message: error.message,
 					stack: error.stack,
 					name: error.name,
@@ -494,13 +494,13 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			} else if (typeof error === "object" && error !== null) {
 				// Handle error-like objects
 				const errorDetails = JSON.stringify(error, null, 2)
-				console.error("Roo Code <Language Model API>: Stream error object:", errorDetails)
-				throw new Error(`Roo Code <Language Model API>: Response stream error: ${errorDetails}`)
+				console.error("Zoo Code <Language Model API>: Stream error object:", errorDetails)
+				throw new Error(`Zoo Code <Language Model API>: Response stream error: ${errorDetails}`)
 			} else {
 				// Fallback for unknown error types
 				const errorMessage = String(error)
-				console.error("Roo Code <Language Model API>: Unknown stream error:", errorMessage)
-				throw new Error(`Roo Code <Language Model API>: Response stream error: ${errorMessage}`)
+				console.error("Zoo Code <Language Model API>: Unknown stream error:", errorMessage)
+				throw new Error(`Zoo Code <Language Model API>: Response stream error: ${errorMessage}`)
 			}
 		}
 	}
@@ -520,7 +520,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			// Log any missing properties for debugging
 			for (const [prop, value] of Object.entries(requiredProps)) {
 				if (!value && value !== 0) {
-					console.warn(`Roo Code <Language Model API>: Client missing ${prop} property`)
+					console.warn(`Zoo Code <Language Model API>: Client missing ${prop} property`)
 				}
 			}
 
@@ -551,7 +551,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			? stringifyVsCodeLmModelSelector(this.options.vsCodeLmModelSelector)
 			: "vscode-lm"
 
-		console.debug("Roo Code <Language Model API>: No client available, using fallback model info")
+		console.debug("Zoo Code <Language Model API>: No client available, using fallback model info")
 
 		return {
 			id: fallbackId,

--- a/src/api/transform/anthropic-filter.ts
+++ b/src/api/transform/anthropic-filter.ts
@@ -19,7 +19,7 @@ export const VALID_ANTHROPIC_BLOCK_TYPES = new Set([
  * Filters out non-Anthropic content blocks from messages before sending to Anthropic/Vertex API.
  * Uses an allowlist approach - only blocks with types in VALID_ANTHROPIC_BLOCK_TYPES are kept.
  * This automatically filters out:
- * - Internal "reasoning" blocks (Roo Code's internal representation)
+ * - Internal "reasoning" blocks (Zoo Code's internal representation)
  * - Gemini's "thoughtSignature" blocks (encrypted reasoning continuity tokens)
  * - Any other unknown block types
  */

--- a/src/api/transform/vscode-lm-format.ts
+++ b/src/api/transform/vscode-lm-format.ts
@@ -23,7 +23,7 @@ function asObjectSafe(value: any): object {
 
 		return {}
 	} catch (error) {
-		console.warn("Roo Code <Language Model API>: Failed to parse object:", error)
+		console.warn("Zoo Code <Language Model API>: Failed to parse object:", error)
 		return {}
 	}
 }
@@ -184,7 +184,7 @@ export function extractTextCountFromMessage(message: vscode.LanguageModelChatMes
 					try {
 						text += JSON.stringify(item.input)
 					} catch (error) {
-						console.error("Roo Code <Language Model API>: Failed to stringify tool call input:", error)
+						console.error("Zoo Code <Language Model API>: Failed to stringify tool call input:", error)
 					}
 				}
 			}

--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -92,7 +92,7 @@ export class ContextProxy {
 		// Migration: Check for old nested image generation settings and migrate them
 		await this.migrateImageGenerationSettings()
 
-		// Migration: Downgrade legacy Roo Code Router state before generic sanitization.
+		// Migration: Downgrade legacy Zoo Code Router state before generic sanitization.
 		await this.migrateLegacyRooApiProvider()
 
 		// Migration: Sanitize invalid/removed API providers
@@ -228,7 +228,7 @@ export class ContextProxy {
 	}
 
 	/**
-	 * Migrates legacy Roo Code Router selections into a setup-needed state.
+	 * Migrates legacy Zoo Code Router selections into a setup-needed state.
 	 */
 	private async migrateLegacyRooApiProvider() {
 		try {
@@ -240,7 +240,7 @@ export class ContextProxy {
 				return
 			}
 
-			logger.info("[ContextProxy] Migrating legacy Roo Code Router state to setup-needed fallback")
+			logger.info("[ContextProxy] Migrating legacy Zoo Code Router state to setup-needed fallback")
 			this.stateCache = migratedState as GlobalState
 			await Promise.all([
 				this.originalContext.globalState.update("apiProvider", undefined),
@@ -249,7 +249,7 @@ export class ContextProxy {
 			])
 		} catch (error) {
 			logger.error(
-				`Error during Roo Code Router migration: ${error instanceof Error ? error.message : String(error)}`,
+				`Error during Zoo Code Router migration: ${error instanceof Error ? error.message : String(error)}`,
 			)
 		}
 	}

--- a/src/core/config/__tests__/importExport.spec.ts
+++ b/src/core/config/__tests__/importExport.spec.ts
@@ -930,7 +930,7 @@ describe("importExport", () => {
 				})
 
 				expect(result.success).toBe(true)
-				expect((result as { warnings?: string[] }).warnings?.[0]).toContain("Roo Code Router was removed")
+				expect((result as { warnings?: string[] }).warnings?.[0]).toContain("Zoo Code Router was removed")
 
 				const importedProfiles = mockProviderSettingsManager.import.mock.calls[0][0]
 				expect(importedProfiles.currentApiConfigName).toBe("router-profile")

--- a/src/core/config/routerRemoval.ts
+++ b/src/core/config/routerRemoval.ts
@@ -4,11 +4,11 @@ export const LEGACY_ROO_PROVIDER = "roo"
 
 const ROUTER_REMOVAL_I18N_KEY = "common:errors.roo.routerRemoved"
 const ROUTER_REMOVAL_DEFAULT_MESSAGE =
-	"Roo Code Router has been removed. Please select and configure a different provider."
+	"Zoo Code Router has been removed. Please select and configure a different provider."
 
 const ROUTER_SIGN_IN_UNAVAILABLE_I18N_KEY = "common:info.roo.signInUnavailable"
 const ROUTER_SIGN_IN_UNAVAILABLE_DEFAULT_MESSAGE =
-	"Roo Code Cloud sign-in is currently unavailable. Configure another provider to continue."
+	"Zoo Code Cloud sign-in is currently unavailable. Configure another provider to continue."
 
 function getLocalizedMessage(key: string, defaultValue: string) {
 	const translated = t(key, { defaultValue })
@@ -22,7 +22,7 @@ export const getRouterUnavailableSignInMessage = () =>
 	getLocalizedMessage(ROUTER_SIGN_IN_UNAVAILABLE_I18N_KEY, ROUTER_SIGN_IN_UNAVAILABLE_DEFAULT_MESSAGE)
 
 export const ROUTER_REMOVAL_IMPORT_WARNING =
-	"Roo Code Router was removed. The imported profile was downgraded and needs to be reconfigured."
+	"Zoo Code Router was removed. The imported profile was downgraded and needs to be reconfigured."
 
 type LegacyRooConfig = Record<string, unknown> & {
 	apiProvider: typeof LEGACY_ROO_PROVIDER

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1281,7 +1281,7 @@ export class ClineProvider
 						window.AUDIO_BASE_URI = "${audioUri}"
 						window.MATERIAL_ICONS_BASE_URI = "${materialIconsUri}"
 					</script>
-					<title>Roo Code</title>
+					<title>Zoo Code</title>
 				</head>
 				<body>
 					<div id="root"></div>
@@ -1360,7 +1360,7 @@ export class ClineProvider
 				window.AUDIO_BASE_URI = "${audioUri}"
 				window.MATERIAL_ICONS_BASE_URI = "${materialIconsUri}"
 			</script>
-            <title>Roo Code</title>
+            <title>Zoo Code</title>
           </head>
           <body>
             <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/core/webview/__tests__/webviewMessageHandler.cloudAuth.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.cloudAuth.spec.ts
@@ -58,7 +58,7 @@ describe("webviewMessageHandler cloud auth fallbacks", () => {
 
 		expect(CloudService.instance.login).not.toHaveBeenCalled()
 		expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-			"Roo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
+			"Zoo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
 		)
 	})
 
@@ -72,7 +72,7 @@ describe("webviewMessageHandler cloud auth fallbacks", () => {
 
 		expect(CloudService.instance.handleAuthCallback).not.toHaveBeenCalled()
 		expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-			"Roo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
+			"Zoo Code Cloud sign-in is currently unavailable. Configure another provider to continue.",
 		)
 	})
 })

--- a/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
@@ -88,7 +88,7 @@ describe("webviewMessageHandler - requestRouterModels provider filter", () => {
 		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "singleRouterModelFetchResponse",
 			success: false,
-			error: "Roo Code Router has been removed. Please select and configure a different provider.",
+			error: "Zoo Code Router has been removed. Please select and configure a different provider.",
 			values: { provider: "roo" },
 		})
 	})

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -592,7 +592,7 @@ describe("webviewMessageHandler - requestRouterModels", () => {
 		expect(mockClineProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "singleRouterModelFetchResponse",
 			success: false,
-			error: "Roo Code Router has been removed. Please select and configure a different provider.",
+			error: "Zoo Code Router has been removed. Please select and configure a different provider.",
 			values: { provider: "roo" },
 		})
 	})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1343,7 +1343,7 @@ export const webviewMessageHandler = async (
 			break
 		}
 		case "openKeyboardShortcuts": {
-			// Open VSCode keyboard shortcuts settings and optionally filter to show the Roo Code commands
+			// Open VSCode keyboard shortcuts settings and optionally filter to show the Zoo Code commands
 			const searchQuery = message.text || ""
 			if (searchQuery) {
 				// Open with a search query pre-filled

--- a/src/core/webview/worktree/handlers.ts
+++ b/src/core/webview/worktree/handlers.ts
@@ -189,7 +189,7 @@ export async function handleSwitchWorktree(
 		const worktreeUri = vscode.Uri.file(worktreePath)
 
 		if (newWindow) {
-			// Set the auto-open path so the new window opens Roo Code sidebar.
+			// Set the auto-open path so the new window opens Zoo Code sidebar.
 			await provider.contextProxy.setValue("worktreeAutoOpenPath", worktreePath)
 
 			// Open in new window.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,7 +196,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	}
 
-	// Initialize the provider *before* the Roo Code Cloud service.
+	// Initialize the provider *before* the Zoo Code Cloud service.
 	const provider = new ClineProvider(context, outputChannel, "sidebar", contextProxy, mdmService)
 
 	// Initialize Roo Code Cloud service.

--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -115,8 +115,8 @@
 			"thinking_complete_recitation": "(Pensament completat, però la sortida s'ha bloquejat a causa de la comprovació de recitació.)"
 		},
 		"roo": {
-			"authenticationRequired": "El proveïdor Roo requereix autenticació al núvol. Si us plau, inicieu sessió a Roo Code Cloud.",
-			"routerRemoved": "S'ha eliminat Roo Code Router. Selecciona i configura un proveïdor diferent."
+			"authenticationRequired": "El proveïdor Roo requereix autenticació al núvol. Si us plau, inicieu sessió a Zoo Code Cloud.",
+			"routerRemoved": "S'ha eliminat Zoo Code Router. Selecciona i configura un proveïdor diferent."
 		},
 		"openAiCodex": {
 			"notAuthenticated": "No esteu autenticat amb OpenAI Codex. Si us plau, inicieu sessió mitjançant el flux OAuth d'OpenAI Codex.",
@@ -168,7 +168,7 @@
 		"mode_exported": "Mode '{{mode}}' exportat correctament",
 		"mode_imported": "Mode importat correctament",
 		"roo": {
-			"signInUnavailable": "L'inici de sessió de Roo Code Cloud no està disponible en aquest moment. Configura un altre proveïdor per continuar."
+			"signInUnavailable": "L'inici de sessió de Zoo Code Cloud no està disponible en aquest moment. Configura un altre proveïdor per continuar."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Denken abgeschlossen, aber die Ausgabe wurde aufgrund der Rezitationsprüfung blockiert.)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo-Anbieter erfordert Cloud-Authentifizierung. Bitte melde dich bei Roo Code Cloud an.",
-			"routerRemoved": "Roo Code Router wurde entfernt. Bitte wähle einen anderen Anbieter und konfiguriere ihn."
+			"authenticationRequired": "Roo-Anbieter erfordert Cloud-Authentifizierung. Bitte melde dich bei Zoo Code Cloud an.",
+			"routerRemoved": "Zoo Code Router wurde entfernt. Bitte wähle einen anderen Anbieter und konfiguriere ihn."
 		},
 		"openAiCodex": {
 			"notAuthenticated": "Nicht bei OpenAI Codex authentifiziert. Bitte melde dich über den OpenAI Codex OAuth-Flow an.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Modus '{{mode}}' erfolgreich exportiert",
 		"mode_imported": "Modus erfolgreich importiert",
 		"roo": {
-			"signInUnavailable": "Die Anmeldung bei Roo Code Cloud ist derzeit nicht verfügbar. Konfiguriere einen anderen Anbieter, um fortzufahren."
+			"signInUnavailable": "Die Anmeldung bei Zoo Code Cloud ist derzeit nicht verfügbar. Konfiguriere einen anderen Anbieter, um fortzufahren."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Thinking complete, but output was blocked due to recitation check.)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo provider requires cloud authentication. Please sign in to Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router has been removed. Please select and configure a different provider."
+			"authenticationRequired": "Zoo provider requires cloud authentication. Please sign in to Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router has been removed. Please select and configure a different provider."
 		},
 		"openAiCodex": {
 			"notAuthenticated": "Not authenticated with OpenAI Codex. Please sign in using the OpenAI Codex OAuth flow.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Mode '{{mode}}' exported successfully",
 		"mode_imported": "Mode imported successfully",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud sign-in is currently unavailable. Configure another provider to continue."
+			"signInUnavailable": "Zoo Code Cloud sign-in is currently unavailable. Configure another provider to continue."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Pensamiento completado, pero la salida fue bloqueada debido a la comprobación de recitación.)"
 		},
 		"roo": {
-			"authenticationRequired": "El proveedor Roo requiere autenticación en la nube. Por favor, inicia sesión en Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router ha sido eliminado. Selecciona y configura un proveedor diferente."
+			"authenticationRequired": "El proveedor Roo requiere autenticación en la nube. Por favor, inicia sesión en Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router ha sido eliminado. Selecciona y configura un proveedor diferente."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "La clave API contiene caracteres inválidos.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Modo '{{mode}}' exportado correctamente",
 		"mode_imported": "Modo importado correctamente",
 		"roo": {
-			"signInUnavailable": "El inicio de sesión de Roo Code Cloud no está disponible en este momento. Configura otro proveedor para continuar."
+			"signInUnavailable": "El inicio de sesión de Zoo Code Cloud no está disponible en este momento. Configura otro proveedor para continuar."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Réflexion terminée, mais la sortie a été bloquée en raison de la vérification de récitation.)"
 		},
 		"roo": {
-			"authenticationRequired": "Le fournisseur Roo nécessite une authentification cloud. Veuillez vous connecter à Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router a été supprimé. Sélectionne et configure un autre fournisseur."
+			"authenticationRequired": "Le fournisseur Roo nécessite une authentification cloud. Veuillez vous connecter à Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router a été supprimé. Sélectionne et configure un autre fournisseur."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "La clé API contient des caractères invalides.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Mode '{{mode}}' exporté avec succès",
 		"mode_imported": "Mode importé avec succès",
 		"roo": {
-			"signInUnavailable": "La connexion à Roo Code Cloud n'est pas disponible pour le moment. Configure un autre fournisseur pour continuer."
+			"signInUnavailable": "La connexion à Zoo Code Cloud n'est pas disponible pour le moment. Configure un autre fournisseur pour continuer."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(सोचना पूरा हुआ, लेकिन पाठ जाँच के कारण आउटपुट अवरुद्ध कर दिया गया।)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo प्रदाता को क्लाउड प्रमाणीकरण की आवश्यकता है। कृपया Roo Code Cloud में साइन इन करें।",
-			"routerRemoved": "Roo Code Router हटा दिया गया है। कृपया कोई दूसरा प्रदाता चुनें और कॉन्फ़िगर करें।"
+			"authenticationRequired": "Roo प्रदाता को क्लाउड प्रमाणीकरण की आवश्यकता है। कृपया Zoo Code Cloud में साइन इन करें।",
+			"routerRemoved": "Zoo Code Router हटा दिया गया है। कृपया कोई दूसरा प्रदाता चुनें और कॉन्फ़िगर करें।"
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API कुंजी में अमान्य वर्ण हैं।",
@@ -164,7 +164,7 @@
 		"mode_exported": "मोड '{{mode}}' सफलतापूर्वक निर्यात किया गया",
 		"mode_imported": "मोड सफलतापूर्वक आयात किया गया",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud साइन-इन अभी उपलब्ध नहीं है। जारी रखने के लिए कोई दूसरा प्रदाता कॉन्फ़िगर करें।"
+			"signInUnavailable": "Zoo Code Cloud साइन-इन अभी उपलब्ध नहीं है। जारी रखने के लिए कोई दूसरा प्रदाता कॉन्फ़िगर करें।"
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/id/common.json
+++ b/src/i18n/locales/id/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Berpikir selesai, tetapi output diblokir karena pemeriksaan resitasi.)"
 		},
 		"roo": {
-			"authenticationRequired": "Penyedia Roo memerlukan autentikasi cloud. Silakan masuk ke Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router telah dihapus. Pilih dan konfigurasikan penyedia lain."
+			"authenticationRequired": "Penyedia Roo memerlukan autentikasi cloud. Silakan masuk ke Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router telah dihapus. Pilih dan konfigurasikan penyedia lain."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "Kunci API mengandung karakter tidak valid.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Mode '{{mode}}' berhasil diekspor",
 		"mode_imported": "Mode berhasil diimpor",
 		"roo": {
-			"signInUnavailable": "Masuk ke Roo Code Cloud saat ini tidak tersedia. Konfigurasikan penyedia lain untuk melanjutkan."
+			"signInUnavailable": "Masuk ke Zoo Code Cloud saat ini tidak tersedia. Konfigurasikan penyedia lain untuk melanjutkan."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Pensiero completato, ma l'output è stato bloccato a causa del controllo di recitazione.)"
 		},
 		"roo": {
-			"authenticationRequired": "Il provider Roo richiede l'autenticazione cloud. Accedi a Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router è stato rimosso. Seleziona e configura un provider diverso."
+			"authenticationRequired": "Il provider Roo richiede l'autenticazione cloud. Accedi a Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router è stato rimosso. Seleziona e configura un provider diverso."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "La chiave API contiene caratteri non validi.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Modalità '{{mode}}' esportata con successo",
 		"mode_imported": "Modalità importata con successo",
 		"roo": {
-			"signInUnavailable": "L'accesso a Roo Code Cloud non è attualmente disponibile. Configura un altro provider per continuare."
+			"signInUnavailable": "L'accesso a Zoo Code Cloud non è attualmente disponibile. Configura un altro provider per continuare."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "（思考完了、引用チェックにより出力ブロック）"
 		},
 		"roo": {
-			"authenticationRequired": "Rooプロバイダーはクラウド認証が必要です。Roo Code Cloudにサインインしてください。",
-			"routerRemoved": "Roo Code Router は削除されました。別のプロバイダーを選択して設定してください。"
+			"authenticationRequired": "Rooプロバイダーはクラウド認証が必要です。Zoo Code Cloudにサインインしてください。",
+			"routerRemoved": "Zoo Code Router は削除されました。別のプロバイダーを選択して設定してください。"
 		},
 		"api": {
 			"invalidKeyInvalidChars": "APIキーに無効な文字が含まれています。",
@@ -164,7 +164,7 @@
 		"mode_exported": "モード「{{mode}}」が正常にエクスポートされました",
 		"mode_imported": "モードが正常にインポートされました",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud へのサインインは現在利用できません。続行するには別のプロバイダーを設定してください。"
+			"signInUnavailable": "Zoo Code Cloud へのサインインは現在利用できません。続行するには別のプロバイダーを設定してください。"
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(생각 완료, 암송 확인으로 출력 차단됨)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo 제공업체는 클라우드 인증이 필요합니다. Roo Code Cloud에 로그인하세요.",
-			"routerRemoved": "Roo Code Router가 제거되었습니다. 다른 제공업체를 선택하고 구성하세요."
+			"authenticationRequired": "Roo 제공업체는 클라우드 인증이 필요합니다. Zoo Code Cloud에 로그인하세요.",
+			"routerRemoved": "Zoo Code Router가 제거되었습니다. 다른 제공업체를 선택하고 구성하세요."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API 키에 유효하지 않은 문자가 포함되어 있습니다.",
@@ -164,7 +164,7 @@
 		"mode_exported": "'{{mode}}' 모드가 성공적으로 내보내졌습니다",
 		"mode_imported": "모드를 성공적으로 가져왔습니다",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud 로그인은 현재 사용할 수 없습니다. 계속하려면 다른 제공업체를 구성하세요."
+			"signInUnavailable": "Zoo Code Cloud 로그인은 현재 사용할 수 없습니다. 계속하려면 다른 제공업체를 구성하세요."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Nadenken voltooid, maar uitvoer is geblokkeerd vanwege recitatiecontrole.)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo provider vereist cloud authenticatie. Log in bij Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router is verwijderd. Selecteer en configureer een andere provider."
+			"authenticationRequired": "Zoo provider vereist cloud authenticatie. Log in bij Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router is verwijderd. Selecteer en configureer een andere provider."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API-sleutel bevat ongeldige karakters.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Modus '{{mode}}' succesvol geëxporteerd",
 		"mode_imported": "Modus succesvol geïmporteerd",
 		"roo": {
-			"signInUnavailable": "Inloggen bij Roo Code Cloud is momenteel niet beschikbaar. Configureer een andere provider om door te gaan."
+			"signInUnavailable": "Inloggen bij Zoo Code Cloud is momenteel niet beschikbaar. Configureer een andere provider om door te gaan."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Myślenie zakończone, ale dane wyjściowe zostały zablokowane przez kontrolę recytacji.)"
 		},
 		"roo": {
-			"authenticationRequired": "Dostawca Roo wymaga uwierzytelnienia w chmurze. Zaloguj się do Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router został usunięty. Wybierz i skonfiguruj innego dostawcę."
+			"authenticationRequired": "Dostawca Roo wymaga uwierzytelnienia w chmurze. Zaloguj się do Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router został usunięty. Wybierz i skonfiguruj innego dostawcę."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "Klucz API zawiera nieprawidłowe znaki.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Tryb '{{mode}}' pomyślnie wyeksportowany",
 		"mode_imported": "Tryb pomyślnie zaimportowany",
 		"roo": {
-			"signInUnavailable": "Logowanie do Roo Code Cloud jest obecnie niedostępne. Skonfiguruj innego dostawcę, aby kontynuować."
+			"signInUnavailable": "Logowanie do Zoo Code Cloud jest obecnie niedostępne. Skonfiguruj innego dostawcę, aby kontynuować."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -116,8 +116,8 @@
 			"thinking_complete_recitation": "(Pensamento concluído, mas a saída foi bloqueada devido à verificação de recitação.)"
 		},
 		"roo": {
-			"authenticationRequired": "O provedor Roo requer autenticação na nuvem. Faça login no Roo Code Cloud.",
-			"routerRemoved": "O Roo Code Router foi removido. Selecione e configure um provedor diferente."
+			"authenticationRequired": "O provedor Roo requer autenticação na nuvem. Faça login no Zoo Code Cloud.",
+			"routerRemoved": "O Zoo Code Router foi removido. Selecione e configure um provedor diferente."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "A chave API contém caracteres inválidos.",
@@ -168,7 +168,7 @@
 		"mode_exported": "Modo '{{mode}}' exportado com sucesso",
 		"mode_imported": "Modo importado com sucesso",
 		"roo": {
-			"signInUnavailable": "O login do Roo Code Cloud não está disponível no momento. Configure outro provedor para continuar."
+			"signInUnavailable": "O login do Zoo Code Cloud não está disponível no momento. Configure outro provedor para continuar."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Размышление завершено, но вывод заблокирован проверкой цитирования.)"
 		},
 		"roo": {
-			"authenticationRequired": "Провайдер Roo требует облачной аутентификации. Войдите в Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router был удалён. Выберите и настройте другого провайдера."
+			"authenticationRequired": "Провайдер Roo требует облачной аутентификации. Войдите в Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router был удалён. Выберите и настройте другого провайдера."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API-ключ содержит недопустимые символы.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Режим '{{mode}}' успешно экспортирован",
 		"mode_imported": "Режим успешно импортирован",
 		"roo": {
-			"signInUnavailable": "Вход в Roo Code Cloud сейчас недоступен. Настрой другого провайдера, чтобы продолжить."
+			"signInUnavailable": "Вход в Zoo Code Cloud сейчас недоступен. Настрой другого провайдера, чтобы продолжить."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Düşünme tamamlandı, ancak çıktı okuma kontrolü nedeniyle engellendi.)"
 		},
 		"roo": {
-			"authenticationRequired": "Roo sağlayıcısı bulut kimlik doğrulaması gerektirir. Lütfen Roo Code Cloud'a giriş yapın.",
-			"routerRemoved": "Roo Code Router kaldırıldı. Lütfen farklı bir sağlayıcı seçip yapılandırın."
+			"authenticationRequired": "Roo sağlayıcısı bulut kimlik doğrulaması gerektirir. Lütfen Zoo Code Cloud'a giriş yapın.",
+			"routerRemoved": "Zoo Code Router kaldırıldı. Lütfen farklı bir sağlayıcı seçip yapılandırın."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API anahtarı geçersiz karakterler içeriyor.",
@@ -164,7 +164,7 @@
 		"mode_exported": "'{{mode}}' modu başarıyla dışa aktarıldı",
 		"mode_imported": "Mod başarıyla içe aktarıldı",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud girişi şu anda kullanılamıyor. Devam etmek için farklı bir sağlayıcı yapılandırın."
+			"signInUnavailable": "Zoo Code Cloud girişi şu anda kullanılamıyor. Devam etmek için farklı bir sağlayıcı yapılandırın."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -112,8 +112,8 @@
 			"thinking_complete_recitation": "(Đã suy nghĩ xong nhưng kết quả bị chặn do kiểm tra trích dẫn.)"
 		},
 		"roo": {
-			"authenticationRequired": "Nhà cung cấp Roo yêu cầu xác thực đám mây. Vui lòng đăng nhập vào Roo Code Cloud.",
-			"routerRemoved": "Roo Code Router đã bị xóa. Vui lòng chọn và cấu hình một nhà cung cấp khác."
+			"authenticationRequired": "Nhà cung cấp Roo yêu cầu xác thực đám mây. Vui lòng đăng nhập vào Zoo Code Cloud.",
+			"routerRemoved": "Zoo Code Router đã bị xóa. Vui lòng chọn và cấu hình một nhà cung cấp khác."
 		},
 		"api": {
 			"invalidKeyInvalidChars": "Khóa API chứa ký tự không hợp lệ.",
@@ -164,7 +164,7 @@
 		"mode_exported": "Chế độ '{{mode}}' đã được xuất thành công",
 		"mode_imported": "Chế độ đã được nhập thành công",
 		"roo": {
-			"signInUnavailable": "Đăng nhập Roo Code Cloud hiện không khả dụng. Hãy cấu hình nhà cung cấp khác để tiếp tục."
+			"signInUnavailable": "Đăng nhập Zoo Code Cloud hiện không khả dụng. Hãy cấu hình nhà cung cấp khác để tiếp tục."
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -117,8 +117,8 @@
 			"thinking_complete_recitation": "（思考完成，但由于引用检查输出被阻止。）"
 		},
 		"roo": {
-			"authenticationRequired": "Roo 提供商需要云认证。请登录 Roo Code Cloud。",
-			"routerRemoved": "Roo Code Router 已被移除。请选择并配置其他提供商。"
+			"authenticationRequired": "Roo 提供商需要云认证。请登录 Zoo Code Cloud。",
+			"routerRemoved": "Zoo Code Router 已被移除。请选择并配置其他提供商。"
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API 密钥包含无效字符.",
@@ -169,7 +169,7 @@
 		"mode_exported": "模式 '{{mode}}' 已成功导出",
 		"mode_imported": "模式已成功导入",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud 登录当前不可用。请配置其他提供商以继续。"
+			"signInUnavailable": "Zoo Code Cloud 登录当前不可用。请配置其他提供商以继续。"
 		}
 	},
 	"answers": {

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -111,8 +111,8 @@
 			"thinking_complete_recitation": "（思考完成，但由於引用檢查輸出被阻止。）"
 		},
 		"roo": {
-			"authenticationRequired": "Roo 提供者需要雲端認證。請登入 Roo Code Cloud。",
-			"routerRemoved": "Roo Code Router 已被移除。請選擇並設定其他提供者。"
+			"authenticationRequired": "Roo 提供者需要雲端認證。請登入 Zoo Code Cloud。",
+			"routerRemoved": "Zoo Code Router 已被移除。請選擇並設定其他提供者。"
 		},
 		"api": {
 			"invalidKeyInvalidChars": "API 金鑰包含無效字元。",
@@ -164,7 +164,7 @@
 		"mode_exported": "模式 '{{mode}}' 已成功匯出",
 		"mode_imported": "模式已成功匯入",
 		"roo": {
-			"signInUnavailable": "Roo Code Cloud 登入目前無法使用。請設定其他提供者以繼續。"
+			"signInUnavailable": "Zoo Code Cloud 登入目前無法使用。請設定其他提供者以繼續。"
 		}
 	},
 	"answers": {

--- a/src/integrations/terminal/BaseTerminalProcess.ts
+++ b/src/integrations/terminal/BaseTerminalProcess.ts
@@ -174,7 +174,7 @@ export abstract class BaseTerminalProcess extends EventEmitter<RooTerminalProces
 
 	// These markers indicate the command is some kind of local dev
 	// server recompiling the app, which we want to wait for output
-	// of before sending request to Roo Code.
+	// of before sending request to Zoo Code.
 	private static compilingMarkers = ["compiling", "building", "bundling", "transpiling", "generating", "starting"]
 
 	private static compilingMarkerNullifiers = [

--- a/src/services/checkpoints/ShadowCheckpointService.ts
+++ b/src/services/checkpoints/ShadowCheckpointService.ts
@@ -212,7 +212,7 @@ export abstract class ShadowCheckpointService extends EventEmitter {
 			await git.init({ "--template": "" })
 			await git.addConfig("core.worktree", this.workspaceDir) // Sets the working tree to the current workspace.
 			await git.addConfig("commit.gpgSign", "false") // Disable commit signing for shadow repo.
-			await git.addConfig("user.name", "Roo Code")
+			await git.addConfig("user.name", "Zoo Code")
 			await git.addConfig("user.email", "noreply@example.com")
 			await this.writeExcludeFile()
 			await this.stageAll(git)

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -696,7 +696,7 @@ export class McpHub {
 		try {
 			const client = new Client(
 				{
-					name: "Roo Code",
+					name: "Zoo Code",
 					version: this.providerRef.deref()?.context.extension?.packageJSON?.version ?? "1.0.0",
 				},
 				{

--- a/src/services/mcp/McpOAuthClientProvider.ts
+++ b/src/services/mcp/McpOAuthClientProvider.ts
@@ -150,7 +150,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
 			state,
 			authServerMeta,
 			resourceIndicator,
-			serverName || "Roo Code",
+			serverName || "Zoo Code",
 		)
 	}
 

--- a/src/services/mcp/__tests__/McpOAuthClientProvider.spec.ts
+++ b/src/services/mcp/__tests__/McpOAuthClientProvider.spec.ts
@@ -188,7 +188,7 @@ describe("McpOAuthClientProvider", () => {
 
 			const metadata = provider.clientMetadata
 
-			expect(metadata.client_name).toBe("Roo Code")
+			expect(metadata.client_name).toBe("Zoo Code")
 			expect(metadata.redirect_uris).toEqual(["http://localhost:0/callback"])
 			expect(metadata.grant_types).toContain("authorization_code")
 			expect(metadata.response_types).toContain("code")
@@ -786,7 +786,7 @@ describe("McpOAuthClientProvider", () => {
 					Promise.resolve({
 						client_id: "new-client-id",
 						redirect_uris: ["http://localhost:12345/callback"],
-						client_name: "Roo Code",
+						client_name: "Zoo Code",
 						grant_types: ["authorization_code", "refresh_token"],
 						response_types: ["code"],
 						token_endpoint_auth_method: "none",
@@ -832,7 +832,7 @@ describe("McpOAuthClientProvider", () => {
 					Promise.resolve({
 						client_id: "consistency-client-id",
 						redirect_uris: ["http://localhost:12345/callback"],
-						client_name: "Roo Code",
+						client_name: "Zoo Code",
 						grant_types: ["authorization_code", "refresh_token"],
 						response_types: ["code"],
 						token_endpoint_auth_method: "none",

--- a/src/utils/networkProxy.ts
+++ b/src/utils/networkProxy.ts
@@ -1,7 +1,7 @@
 /**
  * Network Proxy Configuration Module
  *
- * Provides proxy configuration for all outbound HTTP/HTTPS requests from the Roo Code extension.
+ * Provides proxy configuration for all outbound HTTP/HTTPS requests from the Zoo Code extension.
  * When running in debug mode (F5), a proxy can be enabled for outbound traffic.
  * Optionally, TLS certificate verification can be disabled (debug only) to allow
  * MITM proxy inspection.


### PR DESCRIPTION
## Summary

Closes #551

Replaces **~40 residual "Roo Code" strings** across source files, packages, and i18n locales. The published marketplace bundle v3.58.1 contained **67 occurrences** of "Roo Code" in `dist/extension.js`.

## Changes (53 files, 147 lines)

### Source — User-visible strings
| File | Change |
|------|--------|
| `src/core/webview/ClineProvider.ts` | HTML `<title>` tags (sidebar + tab webview) |
| `src/activate/registerCommands.ts` | `createWebviewPanel()` title + log message |
| `src/services/mcp/McpOAuthClientProvider.ts` | OAuth `client_name` default |
| `src/services/mcp/McpHub.ts` | MCP server display name |
| `src/services/checkpoints/ShadowCheckpointService.ts` | Git `user.name` for checkpoints |
| `src/core/config/routerRemoval.ts` | 3 user-facing router removal messages |
| `src/api/providers/vscode-lm.ts` | 34 debug/error log prefixes |
| `src/api/providers/lm-studio.ts` | Context length error messages |
| `src/api/transform/vscode-lm-format.ts` | Console log prefixes |

### Packages — Auth & types
| File | Change |
|------|--------|
| `packages/cloud/src/WebAuthService.ts` | 13 auth flow messages (sign-in, sign-out, errors) |
| `packages/types/src/roomodes-schema.ts` | JSON schema title/description |
| `packages/types/src/provider-settings.ts` | Comment |
| `packages/types/src/global-settings.ts` | Comment |
| `packages/types/src/cookie-consent.ts` | Comment |
| `packages/telemetry/src/PostHogTelemetryClient.ts` | Comment |
| 5 `package.json` files | Package descriptions |

### i18n — 18 locales
All `common.json` locale files updated for 3 keys:
- `errors.roo.authenticationRequired` — "Roo Code Cloud" → "Zoo Code Cloud"
- `errors.roo.routerRemoved` — "Roo Code Router" → "Zoo Code Router"  
- `info.roo.signInUnavailable` — "Roo Code Cloud" → "Zoo Code Cloud"

### Tests — 7 files
Updated assertions in `importExport.spec.ts`, `registerCommands.spec.ts`, `McpOAuthClientProvider.spec.ts`, `handleUri.spec.ts`, `webviewMessageHandler.spec.ts`, `webviewMessageHandler.cloudAuth.spec.ts`, `webviewMessageHandler.routerModels.spec.ts`.

### Comments & logs
Updated comments in `ContextProxy.ts`, `extension.ts`, `networkProxy.ts`, `worktree/handlers.ts`, `webviewMessageHandler.ts`, `BaseTerminalProcess.ts`, `anthropic-filter.ts`.

## Intentionally preserved
- `@roo-code/*` npm package names (scope name, not user-visible)
- Handoff announcement i18n strings (historical context about the Roo→Zoo transition)
- `LEGACY_ROO_PROVIDER = "roo"` constant (API compatibility)
- `LegacyRooConfig` type (would be a breaking change)
- `downgradeLegacyRooConfig()` function name (internal API)

## Testing
- ✅ 147 tests passing across all affected test files
- ✅ 11/11 turbo type-checks passing
- ✅ Lint passing (pre-commit hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product branding from "Roo Code" to "Zoo Code" across the application, including package descriptions, user-facing error messages, UI titles, and webview content.
  * Updated localization strings across 17 languages to reflect the new "Zoo Code" branding.
  * Updated documentation comments and inline notes referencing the product name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->