### PR TITLE
fix(list-files): validate directory exists before spawning ripgrep

### DIFF
--- a/src/services/glob/__tests__/list-files-limit.spec.ts
+++ b/src/services/glob/__tests__/list-files-limit.spec.ts
@@ -23,6 +23,10 @@ vi.mock("../../../utils/path", () => ({
 	arePathsEqual: vi.fn().mockReturnValue(false),
 }))
 
+vi.mock("../../../services/roo-config", () => ({
+	directoryExists: vi.fn().mockResolvedValue(true),
+}))
+
 import * as childProcess from "child_process"
 
 const createMockRipgrepProcess = (chunks: string[] = [], exitCode = 0) => ({

--- a/src/services/glob/__tests__/list-files.spec.ts
+++ b/src/services/glob/__tests__/list-files.spec.ts
@@ -1,9 +1,13 @@
 import * as path from "path"
 import * as childProcess from "child_process"
 import { listFiles } from "../list-files"
+import { directoryExists } from "../../../services/roo-config"
 
 vi.mock("child_process")
 vi.mock("fs")
+vi.mock("../../../services/roo-config", () => ({
+	directoryExists: vi.fn().mockResolvedValue(true),
+}))
 vi.mock("vscode", () => ({
 	env: {
 		appRoot: "/mock/vscode/app/root",
@@ -48,6 +52,7 @@ vi.mock("fs", () => ({
 		access: vi.fn().mockRejectedValue(new Error("Not found")),
 		readFile: vi.fn().mockResolvedValue(""),
 		readdir: vi.fn().mockResolvedValue([]),
+		stat: vi.fn().mockResolvedValue({ isDirectory: () => true }),
 	},
 }))
 
@@ -93,6 +98,10 @@ function resetFsPromiseMocks() {
 	vi.mocked(fs.promises.readFile).mockResolvedValue("")
 	vi.mocked(fs.promises.readdir).mockReset()
 	vi.mocked(fs.promises.readdir).mockResolvedValue([])
+	vi.mocked(fs.promises.stat).mockReset()
+	vi.mocked(fs.promises.stat).mockResolvedValue({ isDirectory: () => true } as any)
+	vi.mocked(directoryExists).mockReset()
+	vi.mocked(directoryExists).mockResolvedValue(true)
 }
 
 describe("list-files symlink support", () => {
@@ -401,5 +410,33 @@ describe("buildRecursiveArgs edge cases", () => {
 		// Should NOT have the special flags for hidden directories
 		expect(args).not.toContain("--no-ignore-vcs")
 		expect(args).not.toContain("--no-ignore")
+	})
+})
+
+describe("listFiles nonexistent directory", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		resetFsPromiseMocks()
+	})
+
+	it("should throw a clear error instead of a misleading ENOENT naming the executable", async () => {
+		vi.mocked(directoryExists).mockResolvedValue(false)
+
+		await expect(listFiles("/nonexistent/path", true, 100)).rejects.toThrow(
+			"Cannot list files: directory does not exist:",
+		)
+
+		// spawn should never be called when the directory doesn't exist
+		expect(vi.mocked(childProcess.spawn)).not.toHaveBeenCalled()
+	})
+
+	it("should report the missing directory even when ripgrep binary is also unavailable", async () => {
+		vi.mocked(directoryExists).mockResolvedValue(false)
+		const { getBinPath } = await import("../../ripgrep")
+		vi.mocked(getBinPath).mockRejectedValue(new Error("Could not find ripgrep binary"))
+
+		await expect(listFiles("/nonexistent/path", true, 100)).rejects.toThrow(
+			"Cannot list files: directory does not exist:",
+		)
 	})
 })

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode"
 import ignore from "ignore"
 import { arePathsEqual } from "../../utils/path"
 import { getBinPath } from "../../services/ripgrep"
+import { directoryExists } from "../../services/roo-config"
 import { DIRS_TO_IGNORE } from "./constants"
 
 /**
@@ -34,6 +35,10 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 	// Early return for limit of 0 - no need to scan anything
 	if (limit === 0) {
 		return [[], false]
+	}
+
+	if (!(await directoryExists(path.resolve(dirPath)))) {
+		throw new Error(`Cannot list files: directory does not exist: ${path.resolve(dirPath)}`)
 	}
 
 	// Handle special directories


### PR DESCRIPTION
### Related GitHub Issue

Closes: #557

### Description

`list_files` passed a user-supplied path as the `cwd` option to `child_process.spawn`. When that directory did not exist, Node emitted `ENOENT spawn /path/to/rg ENOENT` — naming the ripgrep executable rather than the missing directory, making the error look like a broken ripgrep installation.

**How it's fixed:**

- Added an early `directoryExists()` check at the top of `listFiles()`, before ripgrep resolution, so a missing directory always produces a clear error: `Cannot list files: directory does not exist: <path>`.
- Reuses the existing `directoryExists()` utility from `services/roo-config` (same pattern already used by `SkillsManager`) rather than inlining a new try/catch.
- Removed the redundant check that was briefly inside `listFilesWithRipgrep` — one guard at the entry point is sufficient.

The ordering matters: placing the check before `getRipgrepPath()` ensures the directory error wins even when ripgrep is also unavailable.

### Test Procedure

Two regression tests added to `src/services/glob/__tests__/list-files.spec.ts`:

1. **Missing directory → clear error**: mocks `directoryExists` returning `false`, asserts the error message contains `"Cannot list files: directory does not exist:"` and that `spawn` is never called.
2. **Missing directory wins over missing binary**: same setup plus `getBinPath` rejecting, asserts the directory error still surfaces first.

All 14 tests in the suite pass (`pnpm vitest run services/glob/__tests__/list-files.spec.ts`).

### Pre-Submission Checklist

- [x] **Issue Linked**: Closes #557
- [x] **Scope**: Single focused fix — directory validation before spawn.
- [x] **Self-Review**: Reviewed.
- [x] **Testing**: Regression tests added and passing.
- [x] **Documentation Impact**: No user-facing docs affected.
- [x] **Contribution Guidelines**: Read and agreed.

### Additional Notes

`ExecuteCommandTool` already has an equivalent guard (`fs.access` before running). `regexSearchFiles` (used by `search_files`) passes the path as a ripgrep argument rather than `cwd`, so it has a different (already-handled) failure mode. No other tool calls are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory validation and error handling for file listing operations
  * Enhanced error messages when directories are missing or inaccessible

* **Tests**
  * Expanded test coverage for directory validation and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->