### PR TITLE
fix(gha): automate PR review-state and stale labels

### DIFF
--- a/.github/workflows/label-pr-review-state.yml
+++ b/.github/workflows/label-pr-review-state.yml
@@ -6,76 +6,89 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull-requests: read
-  issues: write
+  pull-requests: write
+
+concurrency:
+  group: label-pr-review-state
+  cancel-in-progress: false
 
 jobs:
   reconcile:
     runs-on: ubuntu-latest
     steps:
       - name: Reconcile PR review state labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const { owner, repo } = context.repo;
             const stateLabels = ['awaiting-author', 'awaiting-review'];
+            const failures = [];
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner, repo, state: 'open', per_page: 100,
             });
 
             for (const pr of prs) {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner, repo, pull_number: pr.number, per_page: 100,
-              });
+              try {
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner, repo, pull_number: pr.number, per_page: 100,
+                });
 
-              // Reviews are returned chronologically, so later entries replace
-              // each reviewer's earlier decision.
-              const latest = new Map();
-              for (const r of reviews) {
-                if (r.state !== 'COMMENTED') {
-                  latest.set(r.user.login, r);
+                // Reviews are returned chronologically, so later entries replace
+                // each reviewer's earlier decision.
+                const latest = new Map();
+                for (const r of reviews) {
+                  if (r.state !== 'COMMENTED') {
+                    latest.set(r.user.login, r);
+                  }
                 }
-              }
 
-              const changeRequestReviewers = [...latest.entries()]
-                .filter(([, review]) => review.state === 'CHANGES_REQUESTED')
-                .map(([login]) => login);
-              const requestedReviewers = new Set(
-                pr.requested_reviewers.map(reviewer => reviewer.login),
-              );
+                const changeRequestReviewers = [...latest.entries()]
+                  .filter(([, review]) => review.state === 'CHANGES_REQUESTED')
+                  .map(([login]) => login);
+                const requestedReviewers = new Set(
+                  pr.requested_reviewers.map(reviewer => reviewer.login),
+                );
 
-              let desiredLabel = null;
-              if (changeRequestReviewers.length > 0) {
-                desiredLabel = changeRequestReviewers.every(
-                  reviewer => requestedReviewers.has(reviewer),
-                )
-                  ? 'awaiting-review'
-                  : 'awaiting-author';
-              }
+                let desiredLabel = null;
+                if (changeRequestReviewers.length > 0) {
+                  desiredLabel = changeRequestReviewers.every(
+                    reviewer => requestedReviewers.has(reviewer),
+                  )
+                    ? 'awaiting-review'
+                    : 'awaiting-author';
+                }
 
-              const currentLabels = new Set(pr.labels.map(label => label.name));
-              for (const label of stateLabels) {
-                if (label !== desiredLabel && currentLabels.has(label)) {
-                  await github.rest.issues.removeLabel({
-                    owner, repo, issue_number: pr.number, name: label,
+                const currentLabels = new Set(pr.labels.map(label => label.name));
+                for (const label of stateLabels) {
+                  if (label !== desiredLabel && currentLabels.has(label)) {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: pr.number, name: label,
+                    });
+                  }
+                }
+
+                if (desiredLabel && !currentLabels.has(desiredLabel)) {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: pr.number, labels: [desiredLabel],
                   });
                 }
-              }
 
-              if (desiredLabel && !currentLabels.has(desiredLabel)) {
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: pr.number, labels: [desiredLabel],
-                });
+                if (
+                  desiredLabel !== 'awaiting-author' &&
+                  currentLabels.has('stale-awaiting-author')
+                ) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: pr.number,
+                    name: 'stale-awaiting-author',
+                  });
+                }
+              } catch (error) {
+                failures.push(`#${pr.number}: ${error.message}`);
+                core.error(`Failed to reconcile PR #${pr.number}: ${error.message}`);
               }
+            }
 
-              if (
-                desiredLabel !== 'awaiting-author' &&
-                currentLabels.has('stale-awaiting-author')
-              ) {
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: pr.number,
-                  name: 'stale-awaiting-author',
-                });
-              }
+            if (failures.length > 0) {
+              core.setFailed(`Failed to reconcile ${failures.length} PR(s): ${failures.join('; ')}`);
             }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     name: 60-day inactivity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,7 +38,7 @@ jobs:
     name: 14-day author inactivity after requested changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Description

Automates pull-request review-state labels and aligns stale handling with who is expected to act next.

- Reconciles open PRs hourly from the trusted default-branch workflow.
- Applies `awaiting-author` while requested changes remain unresolved.
- Moves a PR to `awaiting-review` after all change-requesting reviewers are re-requested.
- Removes review-state labels after approval or dismissal.
- Uses separate `stale-inactive` and `stale-awaiting-author` labels so the 60-day and 14-day policies cannot interfere.
- Limits the 14+7 auto-close policy to PRs waiting on author changes; PRs waiting on maintainers are not auto-closed.
- Handles multiple reviewers, pagination, fork PRs, overlapping runs, and per-PR API failures.
- Pins third-party actions to immutable commit SHAs.

### Security Model

The reconciliation runs only on a schedule or manual dispatch, so it executes workflow code from the trusted branch rather than code from a contributor fork. It does not check out or execute PR contents. The token is scoped to `pull-requests: write` for review reads and label mutations.

### Test Procedure

- Ran the reconciliation workflow from this branch: [run #27550134289](https://github.com/Zoo-Code-Org/Zoo-Code/actions/runs/27550134289).
- Verified an untouched draft PR remained unlabeled.
- Verified PR #619 with an unresolved changes-requested review received `awaiting-author`.
- Ran both production stale jobs: [run #27550561929](https://github.com/Zoo-Code-Org/Zoo-Code/actions/runs/27550561929).
- Verified 59 open PRs were evaluated, issues were excluded, no PRs were incorrectly marked stale, and no PRs were closed.
- Validated the workflow YAML and embedded JavaScript syntax locally.

### Notes

`actions/stale@v9` currently emits GitHub’s Node.js 20 deprecation warning. No newer release is available; GitHub will run JavaScript actions with Node.js 24 by default starting June 16, 2026.

### Checklist

- [x] Self-reviewed
- [x] Manually tested against repository PRs
- [x] Documentation and contributor impact considered
- [x] External actions pinned to immutable commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions.
  * Enhanced PR review state labeling workflow with improved error handling and concurrency controls to prevent overlapping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->