### PR TITLE
fix(prompts): prevent models from hallucinating line numbers in apply_diff

### DIFF
--- a/src/core/prompts/tools/native-tools/apply_diff.ts
+++ b/src/core/prompts/tools/native-tools/apply_diff.ts
@@ -1,15 +1,18 @@
 import type OpenAI from "openai"
 
-const APPLY_DIFF_DESCRIPTION = `Apply precise, targeted modifications to an existing file using one or more search/replace blocks. This tool is for surgical edits only; the 'SEARCH' block must exactly match the existing content, including whitespace and indentation. To make multiple targeted changes, provide multiple SEARCH/REPLACE blocks in the 'diff' parameter. Use the 'read_file' tool first if you are not confident in the exact content to search for.`
+const APPLY_DIFF_DESCRIPTION = `Apply precise, targeted modifications to an existing file using one or more search/replace blocks. This tool is for surgical edits only; the 'SEARCH' block must exactly match the existing content, including whitespace and indentation. To make multiple targeted changes, provide multiple SEARCH/REPLACE blocks in the 'diff' parameter. Use the 'read_file' tool first if you are not confident in the exact content to search for.
+CRITICAL WARNING: The 'read_file' tool outputs line numbers (e.g. '1: ', '2: ') for your convenience, but these line numbers DO NOT exist in the actual file! You MUST STRIP all line numbers from the 'SEARCH' block. Your 'SEARCH' block must match the RAW file content exactly.`
 
 const DIFF_PARAMETER_DESCRIPTION = `A string containing one or more search/replace blocks defining the changes. The ':start_line:' is required and indicates the starting line number of the original content. You must not add a start line for the replacement content. Each block must follow this format:
 <<<<<<< SEARCH
 :start_line:[line_number]
 -------
-[exact content to find]
+[exact content to find WITHOUT line numbers]
 =======
 [new content to replace with]
->>>>>>> REPLACE`
+>>>>>>> REPLACE
+
+CRITICAL: DO NOT include line numbers (like '137: ') in the [exact content to find] section! It must match the actual file content, which does not have line numbers.`
 
 export const apply_diff = {
 	type: "function",


### PR DESCRIPTION
## Description

Models such as Gemini output line numbers in the `read_file` tool (e.g. `137: ...`). When attempting to use `apply_diff`, models often copy these line numbers verbatim into the `<<<<<<< SEARCH` block. Since the actual source files do not contain these line numbers, the `apply_diff` tool strictly fails with an `Edit Unsuccessful` error, eventually leading to a `consecutiveMistakeLimit` failure in the extension.

This PR strictly updates the system prompt and instructions for the `apply_diff` tool to explicitly instruct models to **strip line numbers** from the `SEARCH` block so that it correctly matches the raw file content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified guidance for applying search-and-replace changes so line numbers are not included in exact-match text.
  * Added stronger warnings to prevent mismatches when using file content from read-only previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->