### PR TITLE
fix(terminal): deliver completion signal when end event wins the race against setActiveStream

### DIFF
--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -103,12 +103,21 @@ export class TerminalRegistry {
 					}
 
 					if (!terminal.running) {
-						console.error(
-							"[TerminalRegistry] Shell execution end event received, but process is not running for terminal:",
-							{ terminalId: terminal?.id, command: process?.command, exitCode: e.exitCode },
-						)
+						// The end event can arrive before setActiveStream() has set
+						// running=true (race between the global VS Code event and the
+						// synchronous call in TerminalProcess.run). If a process is
+						// waiting for completion, deliver the signal so it doesn't
+						// hang forever. See #489 / #622.
+						if (process) {
+							console.info(
+								"[TerminalRegistry] End event arrived before running=true (race); delivering completion signal",
+								{ terminalId: terminal.id, exitCode: e.exitCode },
+							)
+							terminal.shellExecutionComplete(exitDetails)
+						} else {
+							terminal.busy = false
+						}
 
-						terminal.busy = false
 						return
 					}
 
@@ -123,7 +132,6 @@ export class TerminalRegistry {
 
 					// Signal completion to any waiting processes.
 					terminal.shellExecutionComplete(exitDetails)
-					terminal.busy = false // Mark terminal as not busy when shell execution ends
 				},
 			)
 

--- a/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
@@ -205,6 +205,88 @@ describe("TerminalRegistry", () => {
 		})
 	})
 
+	describe("onDidEndTerminalShellExecution race condition (#489, #622)", () => {
+		let endHandler: (e: any) => Promise<void>
+
+		beforeEach(() => {
+			// Reset the initialized flag so we can call initialize() in this block.
+			TerminalRegistry["isInitialized"] = false
+
+			// The global vscode mock doesn't define shell execution event
+			// methods, so add them before spying.
+			;(vscode.window as any).onDidStartTerminalShellExecution ??= () => ({ dispose: () => {} })
+			;(vscode.window as any).onDidEndTerminalShellExecution ??= () => ({ dispose: () => {} })
+
+			vi.spyOn(vscode.window, "onDidStartTerminalShellExecution" as any).mockImplementation((_handler: any) => ({
+				dispose: vi.fn(),
+			}))
+
+			vi.spyOn(vscode.window, "onDidEndTerminalShellExecution" as any).mockImplementation((handler: any) => {
+				endHandler = handler
+				return { dispose: vi.fn() }
+			})
+
+			TerminalRegistry.initialize()
+		})
+
+		afterEach(() => {
+			// Reset so other test blocks aren't affected.
+			TerminalRegistry["isInitialized"] = false
+		})
+
+		it("calls shellExecutionComplete when end event fires before running is set (race)", async () => {
+			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode") as Terminal
+			const mockProcess = {
+				command: "echo hello",
+				emit: vi.fn(),
+				hasUnretrievedOutput: vi.fn().mockReturnValue(false),
+			} as any
+			terminal.process = mockProcess
+
+			// Simulate the race: running is still false (setActiveStream hasn't
+			// been called yet), but the end event fires.
+			expect(terminal.running).toBe(false)
+
+			const mockExecution = { commandLine: { value: "echo hello" } }
+			await endHandler({
+				terminal: terminal.terminal,
+				execution: mockExecution,
+				exitCode: 0,
+			})
+
+			// shellExecutionComplete should have been called exactly once, emitting
+			// shell_execution_complete so TerminalProcess.run() unblocks.
+			expect(mockProcess.emit).toHaveBeenCalledWith(
+				"shell_execution_complete",
+				expect.objectContaining({ exitCode: 0 }),
+			)
+			expect(mockProcess.emit).toHaveBeenCalledTimes(1)
+
+			// Terminal should be back to idle state.
+			expect(terminal.busy).toBe(false)
+			expect(terminal.running).toBe(false)
+		})
+
+		it("sets busy=false without calling shellExecutionComplete when no process exists", async () => {
+			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode") as Terminal
+			terminal.busy = true
+			terminal.process = undefined
+			const completeSpy = vi.spyOn(terminal, "shellExecutionComplete")
+
+			expect(terminal.running).toBe(false)
+
+			const mockExecution = { commandLine: { value: "echo hello" } }
+			await endHandler({
+				terminal: terminal.terminal,
+				execution: mockExecution,
+				exitCode: 0,
+			})
+
+			expect(terminal.busy).toBe(false)
+			expect(completeSpy).not.toHaveBeenCalled()
+		})
+	})
+
 	describe("releaseTerminalsForTask", () => {
 		it("aborts a busy terminal's running process and disassociates it from the task (#245)", () => {
 			const terminal = TerminalRegistry.createTerminal("/test/path", "vscode")


### PR DESCRIPTION
## Related GitHub Issue

Closes: #489
Closes: #622

## Description

There is a race condition between two paths that both try to deliver stream and completion events to `TerminalProcess`:

- **Path A** (`TerminalProcess.run()`): calls `executeCommand()` → `setActiveStream(stream)` → sets `terminal.running = true`
- **Path B** (global `onDidEndTerminalShellExecution` in `TerminalRegistry`): fires when VS Code signals the command finished

For fast-completing commands (~25% of the time), VS Code fires the end event **before** Path A's `setActiveStream()` sets `running = true`. The end handler's `!terminal.running` guard then bails out with just `terminal.busy = false` — never calling `shellExecutionComplete()`. The `await shellExecutionComplete` promise in `TerminalProcess.run()` hangs forever, and Zoo appears stuck.

### Fix

When the end event arrives while `!terminal.running` but a `process` is attached and waiting, we now call `terminal.shellExecutionComplete(exitDetails)` instead of silently dropping the signal. When no process exists (spurious end event for a non-Zoo command), the original `busy = false` fallback is preserved.

Also:
- Added `console.info` diagnostic log for the race path (replaces removed `console.error` that misclassified it as an error)
- Removed pre-existing redundant `terminal.busy = false` on the normal completion path (already handled by `shellExecutionComplete()`)

### Key files
- `src/integrations/terminal/TerminalRegistry.ts` — the fix (end handler guard)
- `src/integrations/terminal/BaseTerminal.ts` — `shellExecutionComplete()` and `setActiveStream()` (context)
- `src/integrations/terminal/TerminalProcess.ts` — `run()` with the hanging `await` (context)

## Test Procedure

- Two new unit tests in `TerminalRegistry.spec.ts` simulate the race by firing the captured `onDidEndTerminalShellExecution` handler while `terminal.running === false`:
  1. **Process exists (race):** verifies `shell_execution_complete` is emitted exactly once and terminal returns to idle (`busy=false`, `running=false`)
  2. **No process (spurious):** verifies `busy` is cleared and `shellExecutionComplete` is NOT called
- All 16 tests pass, lint clean

## Pre-Submission Checklist

- [x] **Issue Linked**: Closes #489 and #622
- [x] **Scope**: Focused on the race condition fix
- [x] **Self-Review**: Yes
- [x] **Testing**: Two new unit tests covering both branches
- [x] **Documentation Impact**: No documentation updates required
- [x] **Contribution Guidelines**: Reviewed

## Documentation Updates

- [x] No documentation updates are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal process handling to prevent hangs when shell execution end events arrive during startup.
  * Terminal now correctly manages idle state in edge case scenarios.

* **Tests**
  * Added test coverage for terminal shell execution race condition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->