### PR TITLE
fix(McpHub): resolve persistently flaky McpHub.spec.ts tests after Vitest 4 upgrade

### DIFF
--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -2439,7 +2439,7 @@ describe("McpHub", () => {
 
 			mockSecretStorage = {
 				getOAuthData: vi.fn().mockResolvedValue(null),
-				onDidChange: vi.fn().mockReturnValue(vi.fn()),
+				onDidChange: vi.fn().mockImplementation(() => vi.fn()),
 			}
 			;(mcpHub as any).secretStorage = mockSecretStorage
 
@@ -2585,11 +2585,9 @@ describe("McpHub", () => {
 				mockConnection,
 			)
 
-			// _initiateOAuthFlow awaits getOAuthData() before calling withProgress.
-			// Two ticks: tick 1 resolves getOAuthData, tick 2 runs the continuation
-			// that calls withProgress, setting capturedCancellationToken.
-			await Promise.resolve()
-			await Promise.resolve()
+			// Wait for withProgress to be invoked: getOAuthData must resolve first,
+			// then the continuation calls withProgress synchronously, setting capturedCancellationToken.
+			await vi.waitFor(() => expect(capturedCancellationToken).toBeDefined())
 			capturedCancellationToken._fire()
 
 			await flowPromise
@@ -2917,9 +2915,9 @@ describe("McpHub", () => {
 				mockConnection,
 			)
 
-			// Two ticks: getOAuthData resolves, then withProgress registers the watcher
-			await Promise.resolve()
-			await Promise.resolve()
+			// Flush microtasks: getOAuthData resolves, then withProgress fires synchronously
+			// (registering the watcher) — no tick-counting needed.
+			await vi.advanceTimersByTimeAsync(0)
 			expect((mcpHub as any)._oauthWatchers.size).toBe(1)
 			const firstEntry = (mcpHub as any)._oauthWatchers.get(`${serverName}:${source}`)
 
@@ -2933,10 +2931,11 @@ describe("McpHub", () => {
 				mockConnection,
 			)
 
-			await Promise.resolve()
-			await Promise.resolve()
+			await vi.advanceTimersByTimeAsync(0)
 			// Still exactly one watcher for this server key
 			expect((mcpHub as any)._oauthWatchers.size).toBe(1)
+			// The first watcher's unsubscribe must have been called before replacement
+			expect(firstEntry.unsubscribe).toHaveBeenCalledOnce()
 			// Watcher entry was replaced (second flow's entry, not first)
 			const secondEntry = (mcpHub as any)._oauthWatchers.get(`${serverName}:${source}`)
 			expect(secondEntry).not.toBe(firstEntry)

--- a/src/services/mcp/__tests__/McpHub.spec.ts
+++ b/src/services/mcp/__tests__/McpHub.spec.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises"
+import * as fs from "fs/promises"
 
 import type { Mock } from "vitest"
 import type { ExtensionContext, Uri } from "vscode"
@@ -10,33 +10,20 @@ import { ServerConfigSchema, McpHub } from "../McpHub"
 import { OAUTH_FLOW_TIMEOUT_MS } from "../constants"
 import { t } from "../../../i18n"
 
-// Mock fs/promises before importing anything that uses it
-vi.mock("fs/promises", () => ({
-	default: {
-		access: vi.fn().mockResolvedValue(undefined),
-		writeFile: vi.fn().mockResolvedValue(undefined),
-		readFile: vi.fn().mockResolvedValue("{}"),
-		unlink: vi.fn().mockResolvedValue(undefined),
-		rename: vi.fn().mockResolvedValue(undefined),
-		lstat: vi.fn().mockImplementation(() => {
-			return Promise.resolve({
-				isDirectory: () => true,
-			})
-		}),
-		mkdir: vi.fn().mockResolvedValue(undefined),
-	},
-	access: vi.fn().mockResolvedValue(undefined),
-	writeFile: vi.fn().mockResolvedValue(undefined),
-	readFile: vi.fn().mockResolvedValue("{}"),
-	unlink: vi.fn().mockResolvedValue(undefined),
-	rename: vi.fn().mockResolvedValue(undefined),
-	lstat: vi.fn().mockImplementation(() => {
-		return Promise.resolve({
-			isDirectory: () => true,
-		})
-	}),
-	mkdir: vi.fn().mockResolvedValue(undefined),
-}))
+// Mock fs/promises before importing anything that uses it.
+// Named exports and the default export must share the same vi.fn() instances so that
+// `import * as fs` (used by McpHub.ts) and `import fs` (default) both see the same mocks.
+vi.mock("fs/promises", () => {
+	const access = vi.fn().mockResolvedValue(undefined)
+	const writeFile = vi.fn().mockResolvedValue(undefined)
+	const readFile = vi.fn().mockResolvedValue("{}")
+	const unlink = vi.fn().mockResolvedValue(undefined)
+	const rename = vi.fn().mockResolvedValue(undefined)
+	const lstat = vi.fn().mockImplementation(() => Promise.resolve({ isDirectory: () => true }))
+	const mkdir = vi.fn().mockResolvedValue(undefined)
+	const shared = { access, writeFile, readFile, unlink, rename, lstat, mkdir }
+	return { default: shared, ...shared }
+})
 
 // Import safeWriteJson to use in mocks
 import { safeWriteJson } from "../../../utils/safeWriteJson"
@@ -93,7 +80,6 @@ vi.mock("vscode", () => ({
 		from: vi.fn(),
 	},
 }))
-vi.mock("fs/promises")
 vi.mock("../../../core/webview/ClineProvider")
 
 // Mock the MCP SDK modules
@@ -124,7 +110,7 @@ describe("McpHub", () => {
 	const originalConsoleError = console.error
 	const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.clearAllMocks()
 
 		// Mock console.error to suppress error messages during tests
@@ -194,6 +180,7 @@ describe("McpHub", () => {
 		)
 
 		mcpHub = new McpHub(mockProvider as ClineProvider)
+		await mcpHub.waitUntilReady()
 	})
 
 	afterEach(() => {
@@ -426,7 +413,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Verify watcher was created
 			expect(chokidar.watch).toHaveBeenCalledWith(["/path/to/watch"], expect.any(Object))
@@ -503,7 +490,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Verify watchers were created
 			expect(chokidar.watch).toHaveBeenCalled()
@@ -537,7 +524,7 @@ describe("McpHub", () => {
 			vi.mocked(chokidar.watch).mockClear()
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Verify no watcher was created for disabled server
 			expect(chokidar.watch).not.toHaveBeenCalled()
@@ -561,7 +548,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Find the connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "mcp-disabled-server")
@@ -587,7 +574,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Find the connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "server-disabled-server")
@@ -614,7 +601,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Find the connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "both-reasons-server")
@@ -645,7 +632,7 @@ describe("McpHub", () => {
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
 
 			// Wait for initialization
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// The server should be created as a disconnected connection with null client/transport
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "null-safety-server")
@@ -715,7 +702,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Get the connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "type-check-server")
@@ -733,7 +720,7 @@ describe("McpHub", () => {
 
 		it("should handle missing connections safely", async () => {
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Try operations on non-existent server
 			await expect(mcpHub.callTool("non-existent-server", "test-tool", {})).rejects.toThrow(
@@ -791,7 +778,7 @@ describe("McpHub", () => {
 			)
 
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Delete the connection
 			await mcpHub.deleteConnection("delete-safety-server")
@@ -1414,7 +1401,7 @@ describe("McpHub", () => {
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
 
 			// Wait for initialization
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// The server should be created as a disconnected connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "disabled-server")
@@ -1445,7 +1432,7 @@ describe("McpHub", () => {
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
 
 			// Wait for initialization
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// The server should be created as a disconnected connection
 			const connection = mcpHub.connections.find((conn) => conn.server.name === "disabled-server")
@@ -1831,7 +1818,7 @@ describe("McpHub", () => {
 
 			// Create McpHub and let it initialize with MCP enabled
 			const mcpHub = new McpHub(mockProvider as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Verify server is connected
 			const connectedServer = mcpHub.connections.find((conn) => conn.server.name === "toggle-test-server")
@@ -1889,7 +1876,7 @@ describe("McpHub", () => {
 			const mcpHub = new McpHub(disabledMockProvider as unknown as ClineProvider)
 
 			// Wait for initialization
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Find the disabled-test-server
 			const disabledServer = mcpHub.connections.find((conn) => conn.server.name === "disabled-test-server")
@@ -1961,7 +1948,7 @@ describe("McpHub", () => {
 			const mcpHub = new McpHub(enabledMockProvider as unknown as ClineProvider)
 
 			// Wait for initialization
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Find the enabled-test-server
 			const enabledServer = mcpHub.connections.find((conn) => conn.server.name === "enabled-test-server")
@@ -2000,7 +1987,7 @@ describe("McpHub", () => {
 
 			// Create McpHub with disabled MCP
 			const mcpHub = new McpHub(disabledMockProvider as unknown as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Clear previous calls
 			vi.clearAllMocks()
@@ -2047,7 +2034,7 @@ describe("McpHub", () => {
 
 			// Create McpHub with disabled MCP
 			const mcpHub = new McpHub(disabledMockProvider as unknown as ClineProvider)
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			await mcpHub.waitUntilReady()
 
 			// Set isConnecting to false to ensure it's properly reset
 			mcpHub.isConnecting = false
@@ -2125,10 +2112,7 @@ describe("McpHub", () => {
 				}
 			})
 
-			// Create a new McpHub instance
-			const mcpHub = new McpHub(mockProvider as ClineProvider)
-
-			// Mock the config file read
+			// Mock the config file read BEFORE creating McpHub
 			vi.mocked(fs.readFile).mockResolvedValue(
 				JSON.stringify({
 					mcpServers: {
@@ -2140,8 +2124,9 @@ describe("McpHub", () => {
 				}),
 			)
 
-			// Initialize servers (this will trigger connectToServer)
-			await mcpHub["initializeGlobalMcpServers"]()
+			// Create a new McpHub instance and wait for initialization
+			const mcpHub = new McpHub(mockProvider as ClineProvider)
+			await mcpHub.waitUntilReady()
 
 			// Verify StdioClientTransport was called with wrapped command
 			expect(StdioClientTransport).toHaveBeenCalledWith(
@@ -2189,10 +2174,7 @@ describe("McpHub", () => {
 				}
 			})
 
-			// Create a new McpHub instance
-			const mcpHub = new McpHub(mockProvider as ClineProvider)
-
-			// Mock the config file read
+			// Mock the config file read BEFORE creating McpHub
 			vi.mocked(fs.readFile).mockResolvedValue(
 				JSON.stringify({
 					mcpServers: {
@@ -2204,8 +2186,9 @@ describe("McpHub", () => {
 				}),
 			)
 
-			// Initialize servers (this will trigger connectToServer)
-			await mcpHub["initializeGlobalMcpServers"]()
+			// Create a new McpHub instance and wait for initialization
+			const mcpHub = new McpHub(mockProvider as ClineProvider)
+			await mcpHub.waitUntilReady()
 
 			// Verify StdioClientTransport was called without wrapping
 			expect(StdioClientTransport).toHaveBeenCalledWith(
@@ -2253,10 +2236,7 @@ describe("McpHub", () => {
 				}
 			})
 
-			// Create a new McpHub instance
-			const mcpHub = new McpHub(mockProvider as ClineProvider)
-
-			// Mock the config file read with cmd.exe already as command
+			// Mock the config file read BEFORE creating McpHub
 			vi.mocked(fs.readFile).mockResolvedValue(
 				JSON.stringify({
 					mcpServers: {
@@ -2268,8 +2248,9 @@ describe("McpHub", () => {
 				}),
 			)
 
-			// Initialize servers (this will trigger connectToServer)
-			await mcpHub["initializeGlobalMcpServers"]()
+			// Create a new McpHub instance and wait for initialization
+			const mcpHub = new McpHub(mockProvider as ClineProvider)
+			await mcpHub.waitUntilReady()
 
 			// Verify StdioClientTransport was called without double-wrapping
 			expect(StdioClientTransport).toHaveBeenCalledWith(
@@ -2324,10 +2305,7 @@ describe("McpHub", () => {
 				}
 			})
 
-			// Create a new McpHub instance
-			const mcpHub = new McpHub(mockProvider as ClineProvider)
-
-			// Mock the config file read - simulating fnm/nvm-windows scenario
+			// Mock the config file read BEFORE creating McpHub - simulating fnm/nvm-windows scenario
 			vi.mocked(fs.readFile).mockResolvedValue(
 				JSON.stringify({
 					mcpServers: {
@@ -2345,8 +2323,9 @@ describe("McpHub", () => {
 				}),
 			)
 
-			// Initialize servers (this will trigger connectToServer)
-			await mcpHub["initializeGlobalMcpServers"]()
+			// Create a new McpHub instance and wait for initialization
+			const mcpHub = new McpHub(mockProvider as ClineProvider)
+			await mcpHub.waitUntilReady()
 
 			// Verify that the command was wrapped with cmd.exe
 			expect(StdioClientTransport).toHaveBeenCalledWith(
@@ -2399,10 +2378,7 @@ describe("McpHub", () => {
 				}
 			})
 
-			// Create a new McpHub instance
-			const mcpHub = new McpHub(mockProvider as ClineProvider)
-
-			// Mock the config file read with CMD (uppercase) as command
+			// Mock the config file read BEFORE creating McpHub
 			vi.mocked(fs.readFile).mockResolvedValue(
 				JSON.stringify({
 					mcpServers: {
@@ -2414,8 +2390,9 @@ describe("McpHub", () => {
 				}),
 			)
 
-			// Initialize servers (this will trigger connectToServer)
-			await mcpHub["initializeGlobalMcpServers"]()
+			// Create a new McpHub instance and wait for initialization
+			const mcpHub = new McpHub(mockProvider as ClineProvider)
+			await mcpHub.waitUntilReady()
 
 			// Verify StdioClientTransport was called without double-wrapping
 			expect(StdioClientTransport).toHaveBeenCalledWith(


### PR DESCRIPTION
### Related GitHub Issue

Closes: #489

### Description

This PR fixes 35 persistently failing tests in `services/mcp/__tests__/McpHub.spec.ts` that regressed after the Vitest 4 upgrade. Three compounding root causes were identified and fixed:

**1. `import fs` vs `import * as fs` mock instance mismatch**

`McpHub.ts` uses `import * as fs from "fs/promises"` (namespace import). The test used `import fs from "fs/promises"` (default import). The `vi.mock` factory created separate `vi.fn()` instances for the default and named exports, so `vi.mocked(fs.readFile).mockResolvedValue(...)` in tests was controlling a dead mock — the SUT called the named-export binding which still returned the factory default `"{}"`. Fix: align to `import * as fs` and share all `vi.fn()` instances via a closure: `const shared = {...}; return { default: shared, ...shared }`.

**2. Duplicate `vi.mock("fs/promises")` silently overriding the factory**

A bare `vi.mock("fs/promises")` (no factory) at line ~96 was silently overriding the factory mock above it with Vitest's auto-mock, replacing all carefully constructed `vi.fn()` instances with new stubs. Removed.

**3. Non-async `beforeEach` racing against async initialization**

The outer `beforeEach` was synchronous, so test bodies started running while `initializationPromise` (from `Promise.all([initializeGlobalMcpServers(), initializeProjectMcpServers()])`) was still in flight. Fix: make `beforeEach` async and await `mcpHub.waitUntilReady()`.

**Additional fixes:**
- Replaced 15× `await new Promise(r => setTimeout(r, 100))` timing hacks with `await mcpHub.waitUntilReady()` (deterministic)
- Restructured 5× Windows command-wrapping tests: set `fs.readFile` mock before `new McpHub()` and removed direct calls to the private `initializeGlobalMcpServers()` method
- Replaced 3× `await Promise.resolve(); await Promise.resolve()` microtask tick-counting with `vi.waitFor()` / `vi.advanceTimersByTimeAsync(0)` to decouple tests from the SUT's internal async structure
- Added `expect(firstEntry.unsubscribe).toHaveBeenCalledOnce()` to the OAuth watcher-replacement test, closing a mutation gap (required changing `mockReturnValue(vi.fn())` → `mockImplementation(() => vi.fn())` so each `onDidChange` call gets its own spy)

### Test Procedure

```bash
pnpm vitest run services/mcp/__tests__/McpHub.spec.ts
```

All 62 tests pass. Verified across 3 consecutive runs before and after the fix.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: No documentation updates required (test-only change).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored module mocking in test suite to ensure consistent mock instances across different import styles.
  * Replaced ad-hoc timing delays with deterministic initialization waits across multiple test cases for improved reliability.
  * Reordered test setup to mock configuration reads before component construction.
  * Tightened synchronization in OAuth-flow tests for more predictable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->