### PR TITLE
feat(experiments): register PARALLEL_TOOL_EXECUTION flag (internal-only)

### DIFF
--- a/packages/types/src/experiment.ts
+++ b/packages/types/src/experiment.ts
@@ -6,7 +6,13 @@ import type { Keys, Equals, AssertEqual } from "./type-fu.js"
  * ExperimentId
  */
 
-export const experimentIds = ["preventFocusDisruption", "imageGeneration", "runSlashCommand", "customTools"] as const
+export const experimentIds = [
+	"preventFocusDisruption",
+	"imageGeneration",
+	"runSlashCommand",
+	"customTools",
+	"parallelToolExecution",
+] as const
 
 export const experimentIdsSchema = z.enum(experimentIds)
 
@@ -21,6 +27,7 @@ export const experimentsSchema = z.object({
 	imageGeneration: z.boolean().optional(),
 	runSlashCommand: z.boolean().optional(),
 	customTools: z.boolean().optional(),
+	parallelToolExecution: z.boolean().optional(),
 })
 
 export type Experiments = z.infer<typeof experimentsSchema>

--- a/src/shared/__tests__/experiments.spec.ts
+++ b/src/shared/__tests__/experiments.spec.ts
@@ -21,6 +21,7 @@ describe("experiments", () => {
 				imageGeneration: false,
 				runSlashCommand: false,
 				customTools: false,
+				parallelToolExecution: false,
 			}
 			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(false)
 		})
@@ -31,6 +32,7 @@ describe("experiments", () => {
 				imageGeneration: false,
 				runSlashCommand: false,
 				customTools: false,
+				parallelToolExecution: false,
 			}
 			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(true)
 		})
@@ -41,8 +43,27 @@ describe("experiments", () => {
 				imageGeneration: false,
 				runSlashCommand: false,
 				customTools: false,
+				parallelToolExecution: false,
 			}
 			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(false)
+		})
+	})
+
+	describe("PARALLEL_TOOL_EXECUTION", () => {
+		it("is configured correctly", () => {
+			expect(EXPERIMENT_IDS.PARALLEL_TOOL_EXECUTION).toBe("parallelToolExecution")
+			expect(experimentConfigsMap.PARALLEL_TOOL_EXECUTION).toMatchObject({
+				enabled: false,
+				showInSettings: false,
+			})
+		})
+
+		it("returns false by default", () => {
+			expect(Experiments.isEnabled({}, "parallelToolExecution")).toBe(false)
+		})
+
+		it("returns true when enabled", () => {
+			expect(Experiments.isEnabled({ parallelToolExecution: true }, "parallelToolExecution")).toBe(true)
 		})
 	})
 })

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -14,6 +14,7 @@ type ExperimentKey = Keys<typeof EXPERIMENT_IDS>
 
 interface ExperimentConfig {
 	enabled: boolean
+	/** Defaults to true; set to false to hide from the Settings panel. */
 	showInSettings?: boolean
 }
 
@@ -22,6 +23,7 @@ export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
 	IMAGE_GENERATION: { enabled: false },
 	RUN_SLASH_COMMAND: { enabled: false },
 	CUSTOM_TOOLS: { enabled: false },
+	// TODO: add i18n keys (settings:experimental.PARALLEL_TOOL_EXECUTION.name/.description) in the same PR that sets showInSettings: true
 	PARALLEL_TOOL_EXECUTION: { enabled: false, showInSettings: false },
 }
 

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -5,6 +5,7 @@ export const EXPERIMENT_IDS = {
 	IMAGE_GENERATION: "imageGeneration",
 	RUN_SLASH_COMMAND: "runSlashCommand",
 	CUSTOM_TOOLS: "customTools",
+	PARALLEL_TOOL_EXECUTION: "parallelToolExecution",
 } as const satisfies Record<string, ExperimentId>
 
 type _AssertExperimentIds = AssertEqual<Equals<ExperimentId, Values<typeof EXPERIMENT_IDS>>>
@@ -13,6 +14,7 @@ type ExperimentKey = Keys<typeof EXPERIMENT_IDS>
 
 interface ExperimentConfig {
 	enabled: boolean
+	showInSettings?: boolean
 }
 
 export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
@@ -20,6 +22,7 @@ export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
 	IMAGE_GENERATION: { enabled: false },
 	RUN_SLASH_COMMAND: { enabled: false },
 	CUSTOM_TOOLS: { enabled: false },
+	PARALLEL_TOOL_EXECUTION: { enabled: false, showInSettings: false },
 }
 
 export const experimentDefault = Object.fromEntries(

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -51,6 +51,7 @@ export const ExperimentalSettings = ({
 			<Section>
 				{Object.entries(experimentConfigsMap)
 					.filter(([key]) => key in EXPERIMENT_IDS)
+					.filter(([, config]) => config.showInSettings !== false)
 					.map((config) => {
 						// Use the same translation key pattern as ExperimentalFeature
 						const experimentKey = config[0]

--- a/webview-ui/src/components/settings/__tests__/ExperimentalSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ExperimentalSettings.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react"
+
+import { experimentDefault } from "@roo/experiments"
+
+import { ExperimentalSettings } from "../ExperimentalSettings"
+
+vi.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}))
+
+describe("ExperimentalSettings", () => {
+	const defaultProps = {
+		experiments: experimentDefault,
+		setExperimentEnabled: vi.fn(),
+		setImageGenerationProvider: vi.fn(),
+		setOpenRouterImageApiKey: vi.fn(),
+		setImageGenerationSelectedModel: vi.fn(),
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("does not render internal-only experiment flags", () => {
+		render(<ExperimentalSettings {...defaultProps} />)
+
+		expect(screen.getByText("settings:experimental.PREVENT_FOCUS_DISRUPTION.name")).toBeInTheDocument()
+		expect(screen.getByText("settings:experimental.RUN_SLASH_COMMAND.name")).toBeInTheDocument()
+		expect(screen.queryByText("settings:experimental.PARALLEL_TOOL_EXECUTION.name")).not.toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/ExperimentalSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ExperimentalSettings.spec.tsx
@@ -28,6 +28,8 @@ describe("ExperimentalSettings", () => {
 
 		expect(screen.getByText("settings:experimental.PREVENT_FOCUS_DISRUPTION.name")).toBeInTheDocument()
 		expect(screen.getByText("settings:experimental.RUN_SLASH_COMMAND.name")).toBeInTheDocument()
+		expect(screen.getByText("settings:experimental.IMAGE_GENERATION.name")).toBeInTheDocument()
+		expect(screen.getByText("settings:experimental.CUSTOM_TOOLS.name")).toBeInTheDocument()
 		expect(screen.queryByText("settings:experimental.PARALLEL_TOOL_EXECUTION.name")).not.toBeInTheDocument()
 	})
 })


### PR DESCRIPTION
### Related GitHub Issue

Closes: #363

### Description

Registers the `PARALLEL_TOOL_EXECUTION` experiment flag as an internal-only, preloaded flag (default `false`, `showInSettings: false`).

- Added `"parallelToolExecution"` to `experimentIds` and `experimentsSchema` in `packages/types/src/experiment.ts`
- Added `PARALLEL_TOOL_EXECUTION: "parallelToolExecution"` to `EXPERIMENT_IDS` and `{ enabled: false, showInSettings: false }` to `experimentConfigsMap` in `src/shared/experiments.ts`
- Added `showInSettings?: boolean` to `ExperimentConfig` interface; `ExperimentalSettings.tsx` filters out configs where `showInSettings === false`, so the flag is wired up but invisible in the Settings UI until Epic 4 is ready
- Added unit tests asserting default-off behavior and that the flag does not render in the Settings panel

### Test Procedure

```
nvm use 20.20.2
pnpm --filter zoo-code exec vitest run shared/__tests__/experiments.spec.ts
pnpm --filter @roo-code/vscode-webview exec vitest run src/components/settings/__tests__/ExperimentalSettings.spec.tsx
```

Both pass with no failures.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: No documentation updates required — flag is internal-only and not visible in Settings.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new experimental flag (`parallelToolExecution`) and updated the experiment definitions and validation.
  * Added settings visibility control so certain experiments can be hidden from the UI by default.

* **Bug Fixes**
  * Improved experimental settings rendering to show only flags meant to appear in settings.

* **Tests**
  * Extended experiment-related unit tests to cover the new flag, default behavior, and settings visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->