### PR TITLE
fix: provider cache reset after settings import

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -148,6 +148,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 	const contentRef = useRef<HTMLDivElement | null>(null)
 
 	const prevApiConfigName = useRef(currentApiConfigName)
+	const handledSettingsImportedAt = useRef<number | undefined>(undefined)
 	const confirmDialogHandler = useRef<() => void>()
 
 	const [cachedState, setCachedState] = useState(() => extensionState)
@@ -233,10 +234,13 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 
 	// Bust the cache when settings are imported.
 	useEffect(() => {
-		if (settingsImportedAt) {
-			setCachedState((prevCachedState) => ({ ...prevCachedState, ...extensionState }))
-			setChangeDetected(false)
+		if (!settingsImportedAt || handledSettingsImportedAt.current === settingsImportedAt) {
+			return
 		}
+
+		handledSettingsImportedAt.current = settingsImportedAt
+		setCachedState((prevCachedState) => ({ ...prevCachedState, ...extensionState }))
+		setChangeDetected(false)
 	}, [settingsImportedAt, extensionState])
 
 	const setCachedStateField: SetCachedStateField<keyof ExtensionStateContextType> = useCallback((field, value) => {

--- a/webview-ui/src/components/settings/__tests__/SettingsView.change-detection.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.change-detection.spec.tsx
@@ -4,11 +4,17 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import React from "react"
 
 // Mock vscode API
-const mockPostMessage = vi.fn()
+const mockPostMessage = vi.hoisted(() => vi.fn())
 const mockVscode = {
 	postMessage: mockPostMessage,
 }
 ;(global as any).acquireVsCodeApi = () => mockVscode
+
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: mockPostMessage,
+	},
+}))
 
 // Import the actual component
 import SettingsView from "../SettingsView"
@@ -187,7 +193,24 @@ vi.mock("../ApiConfigManager", () => ({
 }))
 
 vi.mock("../ApiOptions", () => ({
-	default: () => null,
+	default: ({ apiConfiguration, setApiConfigurationField }: any) => (
+		<div>
+			<span data-testid="provider-value">{apiConfiguration.apiProvider}</span>
+			<input
+				data-testid="baseten-api-key"
+				value={apiConfiguration.basetenApiKey ?? ""}
+				onChange={(event) => setApiConfigurationField("basetenApiKey", event.target.value)}
+			/>
+			{["openrouter", "baseten", "deepseek"].map((provider) => (
+				<button
+					key={provider}
+					data-testid={`set-provider-${provider}`}
+					onClick={() => setApiConfigurationField("apiProvider", provider)}>
+					{provider}
+				</button>
+			))}
+		</div>
+	),
 }))
 
 vi.mock("../AutoApproveSettings", () => ({
@@ -368,5 +391,75 @@ describe("SettingsView - Change Detection Fix", () => {
 		// - null -> value (initialization from null)
 
 		expect(true).toBe(true) // Placeholder - the real test is the running system
+	})
+
+	it("preserves a DeepSeek provider edit after saving Baseten when the same import timestamp replays", async () => {
+		const onDone = vi.fn()
+		let extensionState = createExtensionState({
+			settingsImportedAt: 123,
+			apiConfiguration: {
+				apiProvider: "openai",
+				apiModelId: "gpt-4.1",
+			},
+		})
+
+		;(useExtensionState as any).mockImplementation(() => extensionState)
+
+		const { rerender } = render(
+			<QueryClientProvider client={queryClient}>
+				<SettingsView onDone={onDone} />
+			</QueryClientProvider>,
+		)
+
+		await waitFor(() => {
+			expect(screen.getByTestId("provider-value")).toHaveTextContent("openai")
+		})
+
+		fireEvent.click(screen.getByTestId("set-provider-baseten"))
+		fireEvent.change(screen.getByTestId("baseten-api-key"), { target: { value: "test-baseten-key" } })
+		expect(screen.getByTestId("provider-value")).toHaveTextContent("baseten")
+
+		mockPostMessage.mockClear()
+		fireEvent.click(screen.getByTestId("save-button"))
+		expect(mockPostMessage).toHaveBeenCalledWith({
+			type: "upsertApiConfiguration",
+			text: "default",
+			apiConfiguration: expect.objectContaining({
+				apiProvider: "baseten",
+				basetenApiKey: "test-baseten-key",
+			}),
+		})
+
+		fireEvent.click(screen.getByTestId("set-provider-deepseek"))
+		expect(screen.getByTestId("provider-value")).toHaveTextContent("deepseek")
+
+		extensionState = createExtensionState({
+			settingsImportedAt: 123,
+			soundEnabled: true,
+			apiConfiguration: {
+				apiProvider: "baseten",
+				apiModelId: "zai-org/GLM-4.6",
+				basetenApiKey: "test-baseten-key",
+			},
+		})
+
+		rerender(
+			<QueryClientProvider client={queryClient}>
+				<SettingsView onDone={onDone} />
+			</QueryClientProvider>,
+		)
+
+		expect(screen.getByTestId("provider-value")).toHaveTextContent("deepseek")
+
+		mockPostMessage.mockClear()
+		fireEvent.click(screen.getByTestId("save-button"))
+
+		expect(mockPostMessage).toHaveBeenCalledWith({
+			type: "upsertApiConfiguration",
+			text: "default",
+			apiConfiguration: expect.objectContaining({
+				apiProvider: "deepseek",
+			}),
+		})
 	})
 })


### PR DESCRIPTION
<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #689

### Description

SettingsView uses a local cachedState buffer so settings edits do not write through to live extension state before Save. After importing settings, the cache-busting effect could run multiple times for the same settingsImportedAt value whenever extensionState changed identity.

That could overwrite an in-progress provider edit with the previously saved provider, making the UI briefly switch and then revert.

This change tracks the handled settingsImportedAt value and resets cachedState only once per import event. It also adds a regression test covering the imported-settings flow where Baseten is saved with an API key, the same import timestamp replays, and a later DeepSeek provider edit is preserved and saved.

### Test Procedure
- Ran the focused webview regression test: - all 3 tests passed.

  ```shell
  pnpm --dir webview-ui exec vitest run src/components/settings/__tests__/SettingsView.change-detection.spec.tsx

- Verified the new regression coverage for the imported-settings flow:
    1. Start with settingsImportedAt set.
    2. Change Provider to Baseten.
    3. Enter a Baseten API key.
    4. Save the settings.
    5. Change Provider to DeepSeek.
    6. Replay the same imported extension state timestamp.
    7. Confirm the Provider remains DeepSeek and Save posts apiProvider: "deepseek".

- This verifies that SettingsView only busts cachedState once per settingsImportedAt value, so a replayed imported state does not overwrite an in-progress Provider edit.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated settings-import cache resets by applying cache-busting only once per distinct `settingsImportedAt` timestamp.

* **Tests**
  * Improved VS Code message mocking by using a single shared `postMessage` mock for consistent assertions.
  * Enhanced the API options test mock to support interactive API provider editing.
  * Added a regression test confirming API provider selection persists correctly after editing and subsequent state replay/saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->