### PR TITLE
feat(api): add RequestConfigBuilder + completePrompt signal/timeout tests for all providers

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -40,8 +40,15 @@ import {
 } from "./providers"
 import { NativeOllamaHandler } from "./providers/native-ollama"
 
+export interface CompletePromptOptions {
+	/** Abort signal for cancelling the request mid-flight */
+	signal?: AbortSignal
+	/** Optional timeout override (ms) — falls back to provider default if omitted */
+	timeoutMs?: number
+}
+
 export interface SingleCompletionHandler {
-	completePrompt(prompt: string): Promise<string>
+	completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string>
 }
 
 export interface ApiHandlerCreateMessageMetadata {

--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -834,18 +834,22 @@ describe("VertexHandler", () => {
 
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("Test response")
-			expect(handler["client"].messages.create).toHaveBeenCalledWith({
-				model: "claude-3-5-sonnet-v2@20241022",
-				max_tokens: 8192,
-				temperature: 0,
-				messages: [
-					{
-						role: "user",
-						content: [{ type: "text", text: "Test prompt", cache_control: { type: "ephemeral" } }],
-					},
-				],
-				stream: false,
-			})
+			expect(handler["client"].messages.create).toHaveBeenCalledWith(
+				{
+					model: "claude-3-5-sonnet-v2@20241022",
+					max_tokens: 8192,
+					temperature: 0,
+					messages: [
+						{
+							role: "user",
+							content: [{ type: "text", text: "Test prompt", cache_control: { type: "ephemeral" } }],
+						},
+					],
+					stream: false,
+					thinking: undefined,
+				},
+				undefined,
+			)
 		})
 
 		it("should handle API errors for Claude", async () => {
@@ -894,6 +898,42 @@ describe("VertexHandler", () => {
 
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			handler = new AnthropicVertexHandler({
+				apiModelId: "claude-3-5-sonnet-v2@20241022",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const controller = new AbortController()
+			const mockCreate = vitest.fn().mockResolvedValue({
+				content: [{ type: "text", text: "response" }],
+			})
+			;(handler["client"].messages as any).create = mockCreate
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+				signal: controller.signal,
+			})
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			handler = new AnthropicVertexHandler({
+				apiModelId: "claude-3-5-sonnet-v2@20241022",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const mockCreate = vitest.fn().mockResolvedValue({
+				content: [{ type: "text", text: "response" }],
+			})
+			;(handler["client"].messages as any).create = mockCreate
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), undefined)
 		})
 	})
 

--- a/src/api/providers/__tests__/anthropic.spec.ts
+++ b/src/api/providers/__tests__/anthropic.spec.ts
@@ -434,14 +434,17 @@ describe("AnthropicHandler", () => {
 		it("should complete prompt successfully", async () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("Test response")
-			expect(mockCreate).toHaveBeenCalledWith({
-				model: mockOptions.apiModelId,
-				messages: [{ role: "user", content: "Test prompt" }],
-				max_tokens: 8192,
-				temperature: 0,
-				thinking: undefined,
-				stream: false,
-			})
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.apiModelId,
+					messages: [{ role: "user", content: "Test prompt" }],
+					max_tokens: 8192,
+					temperature: 0,
+					thinking: undefined,
+					stream: false,
+				},
+				undefined,
+			)
 		})
 
 		it("should handle API errors", async () => {
@@ -463,6 +466,57 @@ describe("AnthropicHandler", () => {
 			}))
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ content: [{ type: "text", text: "response" }] })
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.apiModelId,
+					messages: [{ role: "user", content: "test prompt" }],
+					max_tokens: 8192,
+					temperature: 0,
+					thinking: undefined,
+					stream: false,
+				},
+				{ signal: controller.signal },
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({ content: [{ type: "text", text: "response" }] })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.apiModelId,
+					messages: [{ role: "user", content: "test prompt" }],
+					max_tokens: 8192,
+					temperature: 0,
+					thinking: undefined,
+					stream: false,
+				},
+				undefined,
+			)
+		})
+
+		it("should merge signal and timeout together", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ content: [{ type: "text", text: "response" }] })
+			await handler.completePrompt("test prompt", { signal: controller.signal, timeoutMs: 10000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.apiModelId,
+					messages: [{ role: "user", content: "test prompt" }],
+					max_tokens: 8192,
+					temperature: 0,
+					thinking: undefined,
+					stream: false,
+				},
+				{ signal: controller.signal },
+			)
 		})
 	})
 

--- a/src/api/providers/__tests__/bedrock.spec.ts
+++ b/src/api/providers/__tests__/bedrock.spec.ts
@@ -1576,6 +1576,48 @@ describe("AwsBedrockHandler", () => {
 				expect(isAdaptiveThinkingModel("anthropic.claude-3-5-sonnet-20241022-v2:0")).toBe(false)
 				expect(isAdaptiveThinkingModel("amazon.nova-lite-v1:0")).toBe(false)
 			})
+
+			it("should pass abort signal through to client.send", async () => {
+				const mockConverseCommand = vi.mocked(ConverseCommand)
+				const mockSend = BedrockRuntimeClient.prototype.send as any
+
+				const handler = new AwsBedrockHandler({
+					apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+					awsAccessKey: "test-access-key",
+					awsSecretKey: "test-secret-key",
+					awsRegion: "us-east-1",
+				})
+
+				const controller = new AbortController()
+				mockSend.mockResolvedValueOnce({
+					output: { message: { content: [{ type: "text", text: "response" }] }, stopReason: null },
+				})
+
+				await handler.completePrompt("test prompt", { signal: controller.signal })
+
+				expect(mockSend).toHaveBeenCalledWith(expect.any(Object), { abortSignal: controller.signal })
+			})
+
+			it("should work without options (backward compatible)", async () => {
+				const mockConverseCommand = vi.mocked(ConverseCommand)
+				const mockSend = BedrockRuntimeClient.prototype.send as any
+
+				const handler = new AwsBedrockHandler({
+					apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+					awsAccessKey: "test-access-key",
+					awsSecretKey: "test-secret-key",
+					awsRegion: "us-east-1",
+				})
+
+				mockSend.mockResolvedValueOnce({
+					output: { message: { content: [{ type: "text", text: "response" }] }, stopReason: null },
+				})
+
+				const result = await handler.completePrompt("test prompt")
+
+				expect(result).toBe("response")
+				expect(mockSend).toHaveBeenCalledWith(expect.any(Object), undefined)
+			})
 		})
 	})
 })

--- a/src/api/providers/__tests__/complete-prompt-options.spec.ts
+++ b/src/api/providers/__tests__/complete-prompt-options.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest"
+
+import type { CompletePromptOptions } from "../../index"
+
+describe("CompletePromptOptions", () => {
+	it("should allow signal property", () => {
+		const controller = new AbortController()
+		const options: CompletePromptOptions = { signal: controller.signal }
+		expect(options.signal).toBe(controller.signal)
+	})
+
+	it("should allow timeoutMs property", () => {
+		const options: CompletePromptOptions = { timeoutMs: 5000 }
+		expect(options.timeoutMs).toBe(5000)
+	})
+
+	it("should allow both signal and timeoutMs together", () => {
+		const controller = new AbortController()
+		const options: CompletePromptOptions = { signal: controller.signal, timeoutMs: 10000 }
+		expect(options.signal).toBe(controller.signal)
+		expect(options.timeoutMs).toBe(10000)
+	})
+
+	it("should allow empty options object", () => {
+		const options: CompletePromptOptions = {}
+		expect(options.signal).toBeUndefined()
+		expect(options.timeoutMs).toBeUndefined()
+	})
+})

--- a/src/api/providers/__tests__/deepseek.spec.ts
+++ b/src/api/providers/__tests__/deepseek.spec.ts
@@ -710,4 +710,45 @@ describe("DeepSeekHandler", () => {
 			expect(toolCallChunks[0].name).toBe("get_weather")
 		})
 	})
+
+	describe("completePrompt", () => {
+		it("should complete prompt successfully", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
+	})
 })

--- a/src/api/providers/__tests__/fireworks.spec.ts
+++ b/src/api/providers/__tests__/fireworks.spec.ts
@@ -609,6 +609,31 @@ describe("FireworksHandler", () => {
 		expect(result).toBe("")
 	})
 
+	it("completePrompt should pass abort signal through to client", async () => {
+		const controller = new AbortController()
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		await handler.completePrompt("test prompt", { signal: controller.signal })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ signal: controller.signal }),
+		)
+	})
+
+	it("completePrompt should pass timeout through to client", async () => {
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ timeout: 5000 }),
+		)
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		const result = await handler.completePrompt("test prompt")
+		expect(result).toBe("response")
+	})
+
 	it("createMessage should handle stream with multiple chunks", async () => {
 		mockCreate.mockImplementationOnce(async () => ({
 			[Symbol.asyncIterator]: async function* () {

--- a/src/api/providers/__tests__/gemini-handler.spec.ts
+++ b/src/api/providers/__tests__/gemini-handler.spec.ts
@@ -55,6 +55,44 @@ describe("GeminiHandler backend support", () => {
 		expect(promptConfig.tools).toBeUndefined()
 	})
 
+	it("completePrompt should pass abort signal through to client via httpOptions", async () => {
+		const options = {
+			apiProvider: "gemini",
+			enableUrlContext: false,
+			enableGrounding: false,
+		} as ApiHandlerOptions
+		const handler = new GeminiHandler(options)
+
+		const controller = new AbortController()
+		const stub = vi.fn().mockResolvedValue({ text: "response" })
+		handler["client"].models.generateContent = stub
+
+		await handler.completePrompt("test prompt", { signal: controller.signal })
+
+		expect(stub).toHaveBeenCalledWith(
+			expect.objectContaining({
+				config: expect.objectContaining({
+					httpOptions: { signal: controller.signal },
+				}),
+			}),
+		)
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		const options = {
+			apiProvider: "gemini",
+			enableUrlContext: false,
+			enableGrounding: false,
+		} as ApiHandlerOptions
+		const handler = new GeminiHandler(options)
+
+		const stub = vi.fn().mockResolvedValue({ text: "response" })
+		handler["client"].models.generateContent = stub
+
+		const result = await handler.completePrompt("test prompt")
+		expect(result).toBe("response")
+	})
+
 	describe("error scenarios", () => {
 		it("should handle grounding metadata extraction failure gracefully", async () => {
 			const options = {

--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -156,6 +156,34 @@ describe("GeminiHandler", () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
 		})
+
+		it("should pass abort signal through to client via httpOptions", async () => {
+			const controller = new AbortController()
+			;(handler["client"].models.generateContent as any).mockResolvedValue({ text: "response" })
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(handler["client"].models.generateContent).toHaveBeenCalledWith({
+				model: GEMINI_MODEL_NAME,
+				contents: [{ role: "user", parts: [{ text: "test prompt" }] }],
+				config: {
+					httpOptions: { signal: controller.signal },
+					temperature: 1,
+				},
+			})
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			;(handler["client"].models.generateContent as any).mockResolvedValue({ text: "response" })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(handler["client"].models.generateContent).toHaveBeenCalledWith({
+				model: GEMINI_MODEL_NAME,
+				contents: [{ role: "user", parts: [{ text: "test prompt" }] }],
+				config: {
+					httpOptions: undefined,
+					temperature: 1,
+				},
+			})
+		})
 	})
 
 	describe("getModel", () => {

--- a/src/api/providers/__tests__/lite-llm.spec.ts
+++ b/src/api/providers/__tests__/lite-llm.spec.ts
@@ -1180,4 +1180,31 @@ describe("LiteLLMHandler", () => {
 			expect(requestHeaders).not.toHaveProperty("X-Zoo-Session-ID")
 		})
 	})
+
+	describe("completePrompt", () => {
+		it("should pass abort signal through to client", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			const controller = new AbortController()
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
+	})
 })

--- a/src/api/providers/__tests__/lmstudio.spec.ts
+++ b/src/api/providers/__tests__/lmstudio.spec.ts
@@ -133,12 +133,15 @@ describe("LmStudioHandler", () => {
 		it("should complete prompt successfully", async () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("Test response")
-			expect(mockCreate).toHaveBeenCalledWith({
-				model: mockOptions.lmStudioModelId,
-				messages: [{ role: "user", content: "Test prompt" }],
-				temperature: 0,
-				stream: false,
-			})
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.lmStudioModelId,
+					messages: [{ role: "user", content: "Test prompt" }],
+					temperature: 0,
+					stream: false,
+				},
+				{},
+			)
 		})
 
 		it("should handle API errors", async () => {
@@ -154,6 +157,37 @@ describe("LmStudioHandler", () => {
 			})
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
 		})
 	})
 

--- a/src/api/providers/__tests__/mimo.spec.ts
+++ b/src/api/providers/__tests__/mimo.spec.ts
@@ -998,5 +998,36 @@ describe("MimoHandler", () => {
 			const params = mockCreate.mock.calls[0][0]
 			expect(params.model).toBe("mimo-v2.5")
 		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
 	})
 })

--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -220,6 +220,30 @@ describe("MiniMaxHandler", () => {
 			await expect(handler.completePrompt("test prompt")).rejects.toThrow()
 		})
 
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "response" }],
+			})
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				{ signal: controller.signal }, // second arg (options)
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "response" }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				undefined, // second arg (options)
+			)
+		})
+
 		it("createMessage should yield text content from stream", async () => {
 			const testContent = "This is test content from MiniMax stream"
 

--- a/src/api/providers/__tests__/mistral.spec.ts
+++ b/src/api/providers/__tests__/mistral.spec.ts
@@ -461,11 +461,14 @@ describe("MistralHandler", () => {
 			const prompt = "Test prompt"
 			const result = await handler.completePrompt(prompt)
 
-			expect(mockComplete).toHaveBeenCalledWith({
-				model: mockOptions.apiModelId,
-				messages: [{ role: "user", content: prompt }],
-				temperature: 0,
-			})
+			expect(mockComplete).toHaveBeenCalledWith(
+				{
+					model: mockOptions.apiModelId,
+					messages: [{ role: "user", content: prompt }],
+					temperature: 0,
+				},
+				undefined,
+			)
 
 			expect(result).toBe("Test response")
 		})
@@ -496,6 +499,26 @@ describe("MistralHandler", () => {
 		it("should handle errors in completePrompt", async () => {
 			mockComplete.mockRejectedValueOnce(new Error("API Error"))
 			await expect(handler.completePrompt("Test prompt")).rejects.toThrow("Mistral completion error: API Error")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockComplete.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockComplete).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+				signal: controller.signal,
+			})
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockComplete.mockResolvedValueOnce({
+				choices: [{ message: { content: "response" } }],
+			})
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockComplete).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), undefined)
 		})
 	})
 })

--- a/src/api/providers/__tests__/moonshot.spec.ts
+++ b/src/api/providers/__tests__/moonshot.spec.ts
@@ -238,6 +238,24 @@ describe("MoonshotHandler", () => {
 				}),
 			)
 		})
+
+		it("should pass abort signal through to generateText", async () => {
+			const controller = new AbortController()
+			mockGenerateText.mockResolvedValueOnce({ text: "response" })
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockGenerateText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					prompt: "test prompt",
+					signal: controller.signal,
+				}),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockGenerateText.mockResolvedValueOnce({ text: "response" })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
 	})
 
 	describe("processUsageMetrics", () => {

--- a/src/api/providers/__tests__/native-ollama.spec.ts
+++ b/src/api/providers/__tests__/native-ollama.spec.ts
@@ -226,6 +226,34 @@ describe("NativeOllamaHandler", () => {
 				}),
 			)
 		})
+
+		it("should accept options param but ignore it (no signal support)", async () => {
+			mockChat.mockResolvedValue({
+				message: { content: "Response" },
+			})
+
+			const controller = new AbortController()
+			await handler.completePrompt("Test prompt", { signal: controller.signal })
+
+			// Verify that the call does NOT include any signal-related options
+			expect(mockChat).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: "llama2",
+					messages: [{ role: "user", content: "Test prompt" }],
+					stream: false,
+					options: { temperature: 0 },
+				}),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockChat.mockResolvedValue({
+				message: { content: "Response" },
+			})
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("Response")
+		})
 	})
 
 	describe("error handling", () => {

--- a/src/api/providers/__tests__/openai-codex-native-tool-calls.spec.ts
+++ b/src/api/providers/__tests__/openai-codex-native-tool-calls.spec.ts
@@ -527,4 +527,49 @@ describe("OpenAiCodexHandler native tool calls", () => {
 			}),
 		)
 	})
+
+	it("completePrompt should pass abort signal through to fetch", async () => {
+		vi.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
+		vi.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				output: [
+					{
+						type: "message",
+						content: [{ type: "output_text", text: "done" }],
+					},
+				],
+			}),
+		})
+		global.fetch = mockFetch as any
+
+		const controller = new AbortController()
+		await handler.completePrompt("Test prompt", { signal: controller.signal })
+
+		const fetchCallArgs = mockFetch.mock.calls[0]
+		expect(fetchCallArgs[1]).toHaveProperty("signal")
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		vi.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
+		vi.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				output: [
+					{
+						type: "message",
+						content: [{ type: "output_text", text: "done" }],
+					},
+				],
+			}),
+		})
+		global.fetch = mockFetch as any
+
+		const result = await handler.completePrompt("Test prompt")
+		expect(result).toBe("done")
+	})
 })

--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -245,6 +245,39 @@ describe("OpenAiNativeHandler", () => {
 
 			expect(result).toBe("")
 		})
+
+		it("should merge incoming signal with existing controller", async () => {
+			mockResponsesCreate.mockResolvedValue({
+				output: [
+					{
+						type: "message",
+						content: [{ type: "output_text", text: "response" }],
+					},
+				],
+			})
+
+			const controller = new AbortController()
+			await handler.completePrompt("Test prompt", { signal: controller.signal })
+
+			expect(mockResponsesCreate).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockResponsesCreate.mockResolvedValue({
+				output: [
+					{
+						type: "message",
+						content: [{ type: "output_text", text: "response" }],
+					},
+				],
+			})
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("response")
+		})
 	})
 
 	describe("getModel", () => {

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -704,6 +704,45 @@ describe("OpenAiHandler", () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
 		})
+
+		it("should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				{ model: mockOptions.openAiModelId, messages: [{ role: "user", content: "test prompt" }] },
+				{ signal: controller.signal },
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				{ model: mockOptions.openAiModelId, messages: [{ role: "user", content: "test prompt" }] },
+				{ timeout: 5000 },
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockCreate).toHaveBeenCalledWith(
+				{ model: mockOptions.openAiModelId, messages: [{ role: "user", content: "test prompt" }] },
+				{},
+			)
+		})
+
+		it("should merge signal and timeout together", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { signal: controller.signal, timeoutMs: 10000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				{ model: mockOptions.openAiModelId, messages: [{ role: "user", content: "test prompt" }] },
+				{ signal: controller.signal, timeout: 10000 },
+			)
+		})
 	})
 
 	describe("getModel", () => {

--- a/src/api/providers/__tests__/opencode-go.spec.ts
+++ b/src/api/providers/__tests__/opencode-go.spec.ts
@@ -394,6 +394,7 @@ describe("OpencodeGoHandler", () => {
 					max_completion_tokens: 40_960,
 					reasoning_effort: "medium",
 				}),
+				{},
 			)
 		})
 
@@ -419,7 +420,7 @@ describe("OpencodeGoHandler", () => {
 			mockCreate.mockResolvedValue({ choices: [{ message: { content: "ok" } }] })
 			const handler = new OpencodeGoHandler({ ...mockOptions, includeMaxTokens: true, modelMaxTokens: 4321 })
 			await handler.completePrompt("ping")
-			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_completion_tokens: 4321 }))
+			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_completion_tokens: 4321 }), {})
 		})
 	})
 
@@ -569,6 +570,7 @@ describe("OpencodeGoHandler", () => {
 					// so the model default is used.
 					max_tokens: 65_536,
 				}),
+				undefined,
 			)
 			expect(mockCreate).not.toHaveBeenCalled()
 		})
@@ -584,7 +586,7 @@ describe("OpencodeGoHandler", () => {
 				modelMaxTokens: 2048,
 			})
 			await handler.completePrompt("ping")
-			expect(mockAnthropicCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 2048 }))
+			expect(mockAnthropicCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 2048 }), undefined)
 		})
 
 		it("completePrompt rethrows non-Error values unchanged from the Anthropic path", async () => {
@@ -597,6 +599,27 @@ describe("OpencodeGoHandler", () => {
 			mockAnthropicCreate.mockResolvedValue({ content: [{ type: "tool_use", id: "x", name: "n", input: {} }] })
 			const handler = new OpencodeGoHandler(anthropicOptions)
 			expect(await handler.completePrompt("ping")).toBe("")
+		})
+
+		it("completePrompt passes abort signal through to Anthropic client", async () => {
+			mockAnthropicCreate.mockResolvedValue({ content: [{ type: "text", text: "response" }] })
+			const controller = new AbortController()
+			const handler = new OpencodeGoHandler(anthropicOptions)
+			await handler.completePrompt("ping", { signal: controller.signal })
+			expect(mockAnthropicCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+				signal: controller.signal,
+			})
+		})
+
+		it("completePrompt works without options (backward compatible, Anthropic path)", async () => {
+			mockAnthropicCreate.mockResolvedValue({ content: [{ type: "text", text: "response" }] })
+			const handler = new OpencodeGoHandler(anthropicOptions)
+			const result = await handler.completePrompt("ping")
+			expect(result).toBe("response")
+			expect(mockAnthropicCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				undefined,
+			)
 		})
 
 		it("omits tools and tool_choice from the Anthropic request when no tools are provided", async () => {

--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -714,5 +714,48 @@ describe("OpenRouterHandler", () => {
 				}),
 			)
 		})
+
+		it("should pass abort signal through to client", async () => {
+			const handler = new OpenRouterHandler(mockOptions)
+			const controller = new AbortController()
+			const mockResponse = { choices: [{ message: { content: "response" } }] }
+			const mockCreate = vitest.fn().mockResolvedValue(mockResponse)
+			;(OpenAI as any).prototype.chat = {
+				completions: { create: mockCreate },
+			} as any
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			const handler = new OpenRouterHandler(mockOptions)
+			const mockResponse = { choices: [{ message: { content: "response" } }] }
+			const mockCreate = vitest.fn().mockResolvedValue(mockResponse)
+			;(OpenAI as any).prototype.chat = {
+				completions: { create: mockCreate },
+			} as any
+
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			const handler = new OpenRouterHandler(mockOptions)
+			const mockResponse = { choices: [{ message: { content: "response" } }] }
+			const mockCreate = vitest.fn().mockResolvedValue(mockResponse)
+			;(OpenAI as any).prototype.chat = {
+				completions: { create: mockCreate },
+			} as any
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
 	})
 })

--- a/src/api/providers/__tests__/poe.spec.ts
+++ b/src/api/providers/__tests__/poe.spec.ts
@@ -309,5 +309,34 @@ describe("PoeHandler", () => {
 				}),
 			)
 		})
+
+		it("completePrompt should pass abort signal through to generateText", async () => {
+			const handler = new PoeHandler({ poeApiKey: "key", apiModelId: "openai/gpt-4o" })
+			const controller = new AbortController()
+			mockGenerateText.mockResolvedValueOnce({ text: "response" })
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockGenerateText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: mockLanguageModel,
+					prompt: "test prompt",
+					signal: controller.signal,
+				}),
+			)
+		})
+
+		it("completePrompt should work without options (backward compatible)", async () => {
+			const handler = new PoeHandler({ poeApiKey: "key", apiModelId: "openai/gpt-4o" })
+			mockGenerateText.mockResolvedValueOnce({ text: "response" })
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+			expect(mockGenerateText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: mockLanguageModel,
+					prompt: "test prompt",
+				}),
+			)
+		})
 	})
 })

--- a/src/api/providers/__tests__/request-config-builder.spec.ts
+++ b/src/api/providers/__tests__/request-config-builder.spec.ts
@@ -1,0 +1,461 @@
+import { describe, expect, test } from "vitest"
+
+import type { ApiHandlerCreateMessageMetadata } from "../../index"
+import { RequestConfigBuilder } from "../config-builder/request-config-builder"
+
+describe("RequestConfigBuilder", () => {
+	describe("constructor", () => {
+		test("should initialize with empty options by default", () => {
+			const builder = new RequestConfigBuilder()
+			expect(builder.build()).toBeUndefined()
+		})
+
+		test("should initialize with provided defaultOptions", () => {
+			const defaults = { modelId: "test-model" }
+			const builder = new RequestConfigBuilder(defaults)
+			const result = builder.build()
+			expect(result).toEqual({ modelId: "test-model" })
+		})
+
+		test("should create a shallow copy of defaultOptions", () => {
+			const defaults = { modelId: "test-model" }
+			const builder = new RequestConfigBuilder(defaults)
+			defaults.modelId = "modified-model"
+			const result = builder.build()
+			expect(result?.modelId).toBe("test-model")
+		})
+	})
+
+	describe("addAbortSignal", () => {
+		test("should set signal when metadata contains abortSignal", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+
+			const builder = new RequestConfigBuilder()
+			const result = builder.addAbortSignal(metadata)
+
+			expect(result).toBe(builder) // chainable
+			const config = builder.build() as { signal?: AbortSignal }
+			expect(config?.signal).toBe(controller.signal)
+		})
+
+		test("should do nothing when metadata is undefined", () => {
+			const builder = new RequestConfigBuilder({ initial: "value" })
+			builder.addAbortSignal(undefined)
+
+			const config = builder.build() as Record<string, any>
+			expect(config.signal).toBeUndefined()
+		})
+
+		test("should do nothing when metadata.abortSignal is undefined", () => {
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+			}
+
+			const builder = new RequestConfigBuilder({ initial: "value" })
+			builder.addAbortSignal(metadata)
+
+			const config = builder.build() as Record<string, any>
+			expect(config.signal).toBeUndefined()
+		})
+
+		test("should replace existing signal if metadata contains abortSignal", () => {
+			const controller1 = new AbortController()
+			const controller2 = new AbortController()
+
+			const builder = new RequestConfigBuilder({ signal: controller1.signal })
+			builder.addAbortSignal({
+				taskId: "test-task",
+				abortSignal: controller2.signal,
+			} as ApiHandlerCreateMessageMetadata)
+
+			const config = builder.build() as { signal?: AbortSignal }
+			expect(config?.signal).toBe(controller2.signal)
+		})
+
+		test("should support chaining with other methods", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+
+			const builder = new RequestConfigBuilder()
+			const result = builder.addAbortSignal(metadata).setOption("customKey", "customValue")
+
+			expect(result).toBe(builder)
+			const config = builder.build() as { signal?: AbortSignal; customKey?: string }
+			expect(config?.signal).toBe(controller.signal)
+			expect(config?.customKey).toBe("customValue")
+		})
+	})
+
+	describe("addHeaders", () => {
+		test("should merge headers when provided", () => {
+			const builder = new RequestConfigBuilder()
+			const result = builder.addHeaders({ "X-Custom": "value1" })
+
+			expect(result).toBe(builder) // chainable
+			const config = builder.build() as { headers?: Record<string, string> }
+			expect(config?.headers).toEqual({ "X-Custom": "value1" })
+		})
+
+		test("should do nothing when headers object is empty", () => {
+			const builder = new RequestConfigBuilder({ initial: "value" })
+			const result = builder.addHeaders({})
+
+			expect(result).toBe(builder) // chainable
+			const config = builder.build() as Record<string, any>
+			expect(config.headers).toBeUndefined()
+		})
+
+		test("should override existing header values", () => {
+			const builder = new RequestConfigBuilder({ headers: { "X-Existing": "old" } })
+			builder.addHeaders({ "X-Existing": "new" })
+
+			const config = builder.build() as { headers?: Record<string, string> }
+			expect(config?.headers?.["X-Existing"]).toBe("new")
+		})
+
+		test("should merge with existing headers without overwriting unrelated keys", () => {
+			const builder = new RequestConfigBuilder({ headers: { "X-Existing": "value" } })
+			builder.addHeaders({ "X-New": "newValue" })
+
+			const config = builder.build() as { headers?: Record<string, string> }
+			expect(config?.headers).toEqual({ "X-Existing": "value", "X-New": "newValue" })
+		})
+
+		test("should create headers object if none exists", () => {
+			const builder = new RequestConfigBuilder()
+			builder.addHeaders({ "X-Custom": "value" })
+
+			const config = builder.build() as { headers?: Record<string, string> }
+			expect(config?.headers).toEqual({ "X-Custom": "value" })
+		})
+
+		test("should support chaining with other methods", () => {
+			const builder = new RequestConfigBuilder()
+			builder.addHeaders({ "X-First": "1" }).addHeaders({ "X-Second": "2" })
+
+			const config = builder.build() as { headers?: Record<string, string> }
+			expect(config?.headers).toEqual({ "X-First": "1", "X-Second": "2" })
+		})
+	})
+
+	describe("setOption", () => {
+		test("should set option when value is defined", () => {
+			const builder = new RequestConfigBuilder()
+			const result = builder.setOption("modelId", "test-model")
+
+			expect(result).toBe(builder) // chainable
+			const config = builder.build() as { modelId?: string }
+			expect(config?.modelId).toBe("test-model")
+		})
+
+		test("should do nothing when value is undefined", () => {
+			const builder = new RequestConfigBuilder({ initial: "value" })
+			builder.setOption("initial", undefined as any)
+
+			const config = builder.build() as Record<string, any>
+			// When setOption receives undefined, it should NOT modify the existing value
+			expect(config.initial).toBe("value")
+		})
+
+		test("should replace existing option value", () => {
+			const builder = new RequestConfigBuilder({ modelId: "old-model" })
+			builder.setOption("modelId", "new-model")
+
+			const config = builder.build() as { modelId?: string }
+			expect(config?.modelId).toBe("new-model")
+		})
+
+		test("should support different value types", () => {
+			const builder = new RequestConfigBuilder()
+
+			builder.setOption("stringKey", "stringValue")
+			builder.setOption("numberKey", 42)
+			builder.setOption("booleanKey", true)
+			builder.setOption("objectKey", { nested: true })
+
+			const config = builder.build() as Record<string, any>
+			expect(config.stringKey).toBe("stringValue")
+			expect(config.numberKey).toBe(42)
+			expect(config.booleanKey).toBe(true)
+			expect(config.objectKey).toEqual({ nested: true })
+		})
+
+		test("should support chaining", () => {
+			const builder = new RequestConfigBuilder()
+			const result = builder.setOption("key1", "value1").setOption("key2", "value2")
+
+			expect(result).toBe(builder)
+			const config = builder.build() as Record<string, any>
+			expect(config.key1).toBe("value1")
+			expect(config.key2).toBe("value2")
+		})
+	})
+
+	describe("getOption", () => {
+		test("should return existing option value", () => {
+			const builder = new RequestConfigBuilder({ modelId: "test-model" })
+			expect(builder.getOption("modelId")).toBe("test-model")
+		})
+
+		test("should return undefined for non-existent key", () => {
+			const builder = new RequestConfigBuilder()
+			expect(builder.getOption("nonExistent" as any)).toBeUndefined()
+		})
+	})
+
+	describe("build", () => {
+		test("should return shallow copy of options", () => {
+			const builder = new RequestConfigBuilder({ key: "value" })
+			const result1 = builder.build()
+			const result2 = builder.build()
+
+			expect(result1).toEqual(result2)
+			expect(result1).not.toBe(result2) // different references
+		})
+
+		test("should return undefined when options are empty", () => {
+			const builder = new RequestConfigBuilder()
+			expect(builder.build()).toBeUndefined()
+		})
+
+		test("modifying build result should not affect internal state", () => {
+			const builder = new RequestConfigBuilder({ key: "value" })
+			const result = builder.build() as Record<string, any>
+
+			result.key = "modified"
+			expect(builder.getOption("key")).toBe("value")
+		})
+
+		test("should return all set options", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+
+			const builder = new RequestConfigBuilder()
+			builder.addAbortSignal(metadata).addHeaders({ "X-Custom": "value" }).setOption("modelId", "test-model")
+
+			const config = builder.build() as Record<string, any>
+			expect(config.signal).toBe(controller.signal)
+			expect(config.headers).toEqual({ "X-Custom": "value" })
+			expect(config.modelId).toBe("test-model")
+		})
+	})
+
+	describe("static fromMetadata", () => {
+		test("should return undefined when both metadata and extraOptions are undefined", () => {
+			const result = RequestConfigBuilder.fromMetadata()
+			expect(result).toBeUndefined()
+		})
+
+		test("should set signal from metadata.abortSignal", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+
+			const result = RequestConfigBuilder.fromMetadata(metadata) as Record<string, any>
+			expect(result.signal).toBe(controller.signal)
+		})
+
+		test("should merge extraOptions with metadata signal", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+			const extraOptions = { modelId: "test-model", customKey: "customValue" }
+
+			const result = RequestConfigBuilder.fromMetadata(metadata, extraOptions) as Record<string, any>
+			expect(result.signal).toBe(controller.signal)
+			expect(result.modelId).toBe("test-model")
+			expect(result.customKey).toBe("customValue")
+		})
+
+		test("should return only extraOptions when metadata is undefined", () => {
+			const extraOptions = { modelId: "test-model" }
+			const result = RequestConfigBuilder.fromMetadata(undefined, extraOptions) as Record<string, any>
+			expect(result.modelId).toBe("test-model")
+		})
+
+		test("should not set signal when metadata.abortSignal is undefined", () => {
+			const metadata: ApiHandlerCreateMessageMetadata = { taskId: "test-task" }
+			const extraOptions = { modelId: "test-model" }
+
+			const result = RequestConfigBuilder.fromMetadata(metadata, extraOptions) as Record<string, any>
+			expect(result.signal).toBeUndefined()
+			expect(result.modelId).toBe("test-model")
+		})
+	})
+
+	describe("static mergeAbortSignals", () => {
+		test("should return primarySignal when secondarySignal is undefined", () => {
+			const controller = new AbortController()
+			const result = RequestConfigBuilder.mergeAbortSignals(controller.signal)
+			expect(result).toBe(controller.signal)
+		})
+
+		test("should return primarySignal when secondarySignal is already aborted", () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+			secondaryController.abort()
+
+			const result = RequestConfigBuilder.mergeAbortSignals(primaryController.signal, secondaryController.signal)
+			expect(result).toBe(primaryController.signal)
+		})
+
+		test("should return merged signal when both signals are active", () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+
+			const result = RequestConfigBuilder.mergeAbortSignals(primaryController.signal, secondaryController.signal)
+			expect(result).not.toBe(primaryController.signal)
+			expect(result).not.toBe(secondaryController.signal)
+		})
+
+		test("should abort merged signal when primarySignal is aborted", async () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+
+			const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+				primaryController.signal,
+				secondaryController.signal,
+			)
+
+			let aborted = false
+			mergedSignal.addEventListener(
+				"abort",
+				() => {
+					aborted = true
+				},
+				{ once: true },
+			)
+
+			primaryController.abort()
+
+			// Wait for event to propagate
+			await new Promise((resolve) => setTimeout(resolve, 10))
+			expect(aborted).toBe(true)
+		})
+
+		test("should abort merged signal when secondarySignal is aborted", async () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+
+			const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+				primaryController.signal,
+				secondaryController.signal,
+			)
+
+			let aborted = false
+			mergedSignal.addEventListener(
+				"abort",
+				() => {
+					aborted = true
+				},
+				{ once: true },
+			)
+
+			secondaryController.abort()
+
+			// Wait for event to propagate
+			await new Promise((resolve) => setTimeout(resolve, 10))
+			expect(aborted).toBe(true)
+		})
+
+		test("should not abort merged signal when neither signal is aborted", async () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+
+			const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+				primaryController.signal,
+				secondaryController.signal,
+			)
+
+			let aborted = false
+			mergedSignal.addEventListener(
+				"abort",
+				() => {
+					aborted = true
+				},
+				{ once: true },
+			)
+
+			await new Promise((resolve) => setTimeout(resolve, 10))
+			expect(aborted).toBe(false)
+		})
+
+		test("should handle primary already aborted before merge", () => {
+			const primaryController = new AbortController()
+			const secondaryController = new AbortController()
+
+			primaryController.abort()
+
+			const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+				primaryController.signal,
+				secondaryController.signal,
+			)
+			expect(mergedSignal.aborted).toBe(true)
+		})
+	})
+
+	describe("integration tests", () => {
+		test("should support full chain of operations", () => {
+			const controller = new AbortController()
+			const metadata: ApiHandlerCreateMessageMetadata = {
+				taskId: "test-task",
+				abortSignal: controller.signal,
+			}
+
+			type TestOptions = {
+				modelId?: string
+				signal?: AbortSignal
+				headers?: Record<string, string>
+				maxTokens?: number
+			}
+
+			const builder = new RequestConfigBuilder<TestOptions>({ modelId: "default-model" })
+			builder.addAbortSignal(metadata)
+			builder.addHeaders({ "X-API-Key": "secret" })
+			builder.setOption("maxTokens", 2000)
+
+			const config = builder.build() as TestOptions
+			expect(config.modelId).toBe("default-model")
+			expect(config.signal).toBe(controller.signal)
+			expect(config.headers).toEqual({ "X-API-Key": "secret" })
+			expect(config.maxTokens).toBe(2000)
+		})
+
+		test("should handle empty builder through full lifecycle", () => {
+			const builder = new RequestConfigBuilder()
+			expect(builder.build()).toBeUndefined()
+			expect(builder.getOption("anyKey" as any)).toBeUndefined()
+		})
+
+		test("should work with custom default options type", () => {
+			type CustomOptions = { apiUrl: string; timeout: number; retryCount?: number }
+
+			const defaults: Partial<CustomOptions> = {
+				apiUrl: "https://api.example.com",
+				timeout: 30000,
+			}
+
+			const builder = new RequestConfigBuilder<CustomOptions>(defaults)
+			builder.setOption("retryCount", 3)
+
+			const config = builder.build() as CustomOptions
+			expect(config.apiUrl).toBe("https://api.example.com")
+			expect(config.timeout).toBe(30000)
+			expect(config.retryCount).toBe(3)
+		})
+	})
+})

--- a/src/api/providers/__tests__/requesty.spec.ts
+++ b/src/api/providers/__tests__/requesty.spec.ts
@@ -498,12 +498,15 @@ describe("RequestyHandler", () => {
 
 			expect(result).toBe("test completion")
 
-			expect(mockCreate).toHaveBeenCalledWith({
-				model: mockOptions.requestyModelId,
-				max_tokens: 8192,
-				messages: [{ role: "system", content: "test prompt" }],
-				temperature: 0,
-			})
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: mockOptions.requestyModelId,
+					max_tokens: 8192,
+					messages: [{ role: "system", content: "test prompt" }],
+					temperature: 0,
+				},
+				{},
+			)
 		})
 
 		it("omits temperature for Claude Fable 5 in completePrompt", async () => {
@@ -515,12 +518,15 @@ describe("RequestyHandler", () => {
 
 			await handler.completePrompt("test prompt")
 
-			expect(mockCreate).toHaveBeenCalledWith({
-				model: "anthropic/claude-fable-5",
-				max_tokens: 8192,
-				messages: [{ role: "system", content: "test prompt" }],
-				temperature: undefined,
-			})
+			expect(mockCreate).toHaveBeenCalledWith(
+				{
+					model: "anthropic/claude-fable-5",
+					max_tokens: 8192,
+					messages: [{ role: "system", content: "test prompt" }],
+					temperature: undefined,
+				},
+				{},
+			)
 		})
 
 		it("handles API errors", async () => {
@@ -536,6 +542,35 @@ describe("RequestyHandler", () => {
 			mockCreate.mockRejectedValue(new Error("Unexpected error"))
 
 			await expect(handler.completePrompt("test prompt")).rejects.toThrow("Unexpected error")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const handler = new RequestyHandler(mockOptions)
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+				signal: controller.signal,
+			})
+		})
+
+		it("should pass timeout through to client", async () => {
+			const handler = new RequestyHandler(mockOptions)
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+				timeout: 5000,
+			})
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			const handler = new RequestyHandler(mockOptions)
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
 		})
 	})
 })

--- a/src/api/providers/__tests__/sambanova.spec.ts
+++ b/src/api/providers/__tests__/sambanova.spec.ts
@@ -69,6 +69,31 @@ describe("SambaNovaHandler", () => {
 		)
 	})
 
+	it("completePrompt should pass abort signal through to client", async () => {
+		const controller = new AbortController()
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		await handler.completePrompt("test prompt", { signal: controller.signal })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ signal: controller.signal }),
+		)
+	})
+
+	it("completePrompt should pass timeout through to client", async () => {
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ timeout: 5000 }),
+		)
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+		const result = await handler.completePrompt("test prompt")
+		expect(result).toBe("response")
+	})
+
 	it("createMessage should yield text content from stream", async () => {
 		const testContent = "This is test content from SambaNova stream"
 

--- a/src/api/providers/__tests__/unbound.spec.ts
+++ b/src/api/providers/__tests__/unbound.spec.ts
@@ -199,6 +199,59 @@ describe("UnboundHandler", () => {
 			expect.objectContaining({
 				messages: [{ role: "system", content: "Write a haiku" }],
 			}),
+			{},
 		)
+	})
+
+	it("completePrompt should pass abort signal through to client", async () => {
+		const mockCreate = (OpenAI as unknown as any)().chat.completions.create
+		const controller = new AbortController()
+		mockCreate.mockResolvedValue({
+			choices: [{ message: { content: "completed text" } }],
+		})
+
+		const handler = new UnboundHandler({
+			unboundApiKey: "test-key",
+			unboundModelId: "openai/gpt-4o",
+		})
+
+		await handler.completePrompt("Write a haiku", { signal: controller.signal })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ signal: controller.signal }),
+		)
+	})
+
+	it("completePrompt should pass timeout through to client", async () => {
+		const mockCreate = (OpenAI as unknown as any)().chat.completions.create
+		mockCreate.mockResolvedValue({
+			choices: [{ message: { content: "completed text" } }],
+		})
+
+		const handler = new UnboundHandler({
+			unboundApiKey: "test-key",
+			unboundModelId: "openai/gpt-4o",
+		})
+
+		await handler.completePrompt("Write a haiku", { timeoutMs: 5000 })
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			expect.objectContaining({ timeout: 5000 }),
+		)
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		const mockCreate = (OpenAI as unknown as any)().chat.completions.create
+		mockCreate.mockResolvedValue({
+			choices: [{ message: { content: "completed text" } }],
+		})
+
+		const handler = new UnboundHandler({
+			unboundApiKey: "test-key",
+			unboundModelId: "openai/gpt-4o",
+		})
+
+		const result = await handler.completePrompt("Write a haiku")
+		expect(result).toBe("completed text")
 	})
 })

--- a/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
+++ b/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
@@ -598,6 +598,7 @@ describe("VercelAiGatewayHandler", () => {
 					temperature: VERCEL_AI_GATEWAY_DEFAULT_TEMPERATURE,
 					max_completion_tokens: 64000,
 				}),
+				{},
 			)
 		})
 
@@ -614,6 +615,7 @@ describe("VercelAiGatewayHandler", () => {
 				expect.objectContaining({
 					temperature: customTemp,
 				}),
+				{},
 			)
 		})
 
@@ -645,6 +647,61 @@ describe("VercelAiGatewayHandler", () => {
 
 			const result = await handler.completePrompt("Test")
 			expect(result).toBe("")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const handler = new VercelAiGatewayHandler(mockOptions)
+			const controller = new AbortController()
+			mockCreate.mockImplementation(async () => ({
+				choices: [
+					{
+						message: { role: "assistant", content: "response" },
+						finish_reason: "stop",
+						index: 0,
+					},
+				],
+			}))
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			const handler = new VercelAiGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(async () => ({
+				choices: [
+					{
+						message: { role: "assistant", content: "response" },
+						finish_reason: "stop",
+						index: 0,
+					},
+				],
+			}))
+
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			const handler = new VercelAiGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(async () => ({
+				choices: [
+					{
+						message: { role: "assistant", content: "response" },
+						finish_reason: "stop",
+						index: 0,
+					},
+				],
+			}))
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
 		})
 	})
 

--- a/src/api/providers/__tests__/vertex.spec.ts
+++ b/src/api/providers/__tests__/vertex.spec.ts
@@ -137,6 +137,34 @@ describe("VertexHandler", () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
 		})
+
+		it("should pass abort signal through to client via httpOptions", async () => {
+			const controller = new AbortController()
+			;(handler["client"].models.generateContent as any).mockResolvedValue({
+				text: "response",
+			})
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(handler["client"].models.generateContent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: expect.any(String),
+					contents: [{ role: "user", parts: [{ text: "test prompt" }] }],
+					config: expect.objectContaining({
+						httpOptions: { signal: controller.signal },
+						temperature: 1,
+					}),
+				}),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			;(handler["client"].models.generateContent as any).mockResolvedValue({
+				text: "response",
+			})
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
 	})
 
 	describe("getModel", () => {

--- a/src/api/providers/__tests__/vscode-lm.spec.ts
+++ b/src/api/providers/__tests__/vscode-lm.spec.ts
@@ -538,7 +538,81 @@ describe("VsCodeLmHandler", () => {
 			handler["client"] = mockLanguageModelChat
 
 			const promise = handler.completePrompt("Test prompt")
-			await expect(promise).rejects.toThrow("VSCode LM completion error: Completion failed")
+			await expect(promise).rejects.toThrow("Completion failed")
+		})
+
+		it("should bridge abort signal to CancellationToken", async () => {
+			const mockModel = { ...mockLanguageModelChat }
+			;(vscode.lm.selectChatModels as Mock).mockResolvedValueOnce([mockModel])
+
+			const responseText = "Completed text"
+			mockLanguageModelChat.sendRequest.mockResolvedValueOnce({
+				stream: (async function* () {
+					yield new vscode.LanguageModelTextPart(responseText)
+					return
+				})(),
+				text: (async function* () {
+					yield responseText
+					return
+				})(),
+			})
+
+			handler["client"] = mockLanguageModelChat
+
+			const controller = new AbortController()
+			await handler.completePrompt("Test prompt", { signal: controller.signal })
+
+			// Verify that tokenSource.dispose was called (via the mock)
+			const TokenSourceInstance = (vscode.CancellationTokenSource as any).mock.results[0].value
+			expect(TokenSourceInstance.dispose).toHaveBeenCalled()
+		})
+
+		it("should cancel token when signal is already aborted", async () => {
+			const mockModel = { ...mockLanguageModelChat }
+			;(vscode.lm.selectChatModels as Mock).mockResolvedValueOnce([mockModel])
+
+			const responseText = "Completed text"
+			mockLanguageModelChat.sendRequest.mockResolvedValueOnce({
+				stream: (async function* () {
+					yield new vscode.LanguageModelTextPart(responseText)
+					return
+				})(),
+				text: (async function* () {
+					yield responseText
+					return
+				})(),
+			})
+
+			handler["client"] = mockLanguageModelChat
+
+			const controller = new AbortController()
+			controller.abort()
+			await handler.completePrompt("Test prompt", { signal: controller.signal })
+
+			const TokenSourceInstance = (vscode.CancellationTokenSource as any).mock.results[0].value
+			expect(TokenSourceInstance.cancel).toHaveBeenCalled()
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			const mockModel = { ...mockLanguageModelChat }
+			;(vscode.lm.selectChatModels as Mock).mockResolvedValueOnce([mockModel])
+
+			const responseText = "Completed text"
+			mockLanguageModelChat.sendRequest.mockResolvedValueOnce({
+				stream: (async function* () {
+					yield new vscode.LanguageModelTextPart(responseText)
+					return
+				})(),
+				text: (async function* () {
+					yield responseText
+					return
+				})(),
+			})
+
+			handler["client"] = mockLanguageModelChat
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe(responseText)
 		})
 	})
 })

--- a/src/api/providers/__tests__/xai.spec.ts
+++ b/src/api/providers/__tests__/xai.spec.ts
@@ -255,6 +255,27 @@ describe("XAIHandler", () => {
 		await expect(handler.completePrompt("test prompt")).rejects.toThrow(`xAI completion error: ${errorMessage}`)
 	})
 
+	it("completePrompt should pass abort signal through to client", async () => {
+		const controller = new AbortController()
+		mockResponsesCreate.mockResolvedValueOnce({ output_text: "response" })
+
+		await handler.completePrompt("test prompt", { signal: controller.signal })
+		expect(mockResponsesCreate).toHaveBeenCalledWith(expect.objectContaining({ model: expect.any(String) }), {
+			signal: controller.signal,
+		})
+	})
+
+	it("completePrompt should work without options (backward compatible)", async () => {
+		mockResponsesCreate.mockResolvedValueOnce({ output_text: "response" })
+
+		const result = await handler.completePrompt("test prompt")
+		expect(result).toBe("response")
+		expect(mockResponsesCreate).toHaveBeenCalledWith(
+			expect.objectContaining({ model: expect.any(String) }),
+			undefined,
+		)
+	})
+
 	it("should include reasoning_effort for mini models", async () => {
 		const miniModelHandler = new XAIHandler({
 			apiModelId: "grok-3-mini",

--- a/src/api/providers/__tests__/zai.spec.ts
+++ b/src/api/providers/__tests__/zai.spec.ts
@@ -427,6 +427,31 @@ describe("ZAiHandler", () => {
 			)
 		})
 
+		it("completePrompt should pass abort signal through to client", async () => {
+			const controller = new AbortController()
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("completePrompt should pass timeout through to client", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("completePrompt should work without options (backward compatible)", async () => {
+			mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: "response" } }] })
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
+		})
+
 		it("createMessage should yield text content from stream", async () => {
 			const testContent = "This is test content from Z AI stream"
 

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -445,6 +445,7 @@ describe("ZooGatewayHandler", () => {
 					temperature: ZOO_GATEWAY_DEFAULT_TEMPERATURE,
 					max_completion_tokens: 64000,
 				}),
+				{},
 			)
 		})
 
@@ -466,6 +467,43 @@ describe("ZooGatewayHandler", () => {
 			}))
 
 			await expect(handler.completePrompt("Test")).resolves.toBe("")
+		})
+
+		it("should pass abort signal through to client", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			const controller = new AbortController()
+			mockCreate.mockImplementation(async () => ({
+				choices: [{ message: { role: "assistant", content: "response" } }],
+			}))
+
+			await handler.completePrompt("test prompt", { signal: controller.signal })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ signal: controller.signal }),
+			)
+		})
+
+		it("should pass timeout through to client", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(async () => ({
+				choices: [{ message: { role: "assistant", content: "response" } }],
+			}))
+
+			await handler.completePrompt("test prompt", { timeoutMs: 5000 })
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({ model: expect.any(String) }),
+				expect.objectContaining({ timeout: 5000 }),
+			)
+		})
+
+		it("should work without options (backward compatible)", async () => {
+			const handler = new ZooGatewayHandler(mockOptions)
+			mockCreate.mockImplementation(async () => ({
+				choices: [{ message: { role: "assistant", content: "response" } }],
+			}))
+
+			const result = await handler.completePrompt("test prompt")
+			expect(result).toBe("response")
 		})
 	})
 

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -270,7 +270,7 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions) {
 		try {
 			const {
 				id,
@@ -296,7 +296,10 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 				stream: false,
 			} as Anthropic.Messages.MessageCreateParamsNonStreaming
 
-			const response = await this.client.messages.create(params)
+			const response = await this.client.messages.create(
+				params,
+				options?.signal ? { signal: options.signal } : undefined,
+			)
 			const content = response.content[0]
 
 			if (content.type === "text") {

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -398,19 +398,22 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions) {
 		const { id: model, temperature } = this.getModel()
 
 		let message
 		try {
-			message = await this.client.messages.create({
-				model,
-				max_tokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
-				thinking: undefined,
-				temperature,
-				messages: [{ role: "user", content: prompt }],
-				stream: false,
-			})
+			message = await this.client.messages.create(
+				{
+					model,
+					max_tokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+					thinking: undefined,
+					temperature,
+					messages: [{ role: "user", content: prompt }],
+					stream: false,
+				},
+				options?.signal ? { signal: options.signal } : undefined,
+			)
 		} catch (error) {
 			TelemetryService.instance.captureException(
 				new ApiProviderError(

--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -8,7 +8,7 @@ import { TagMatcher } from "../../utils/tag-matcher"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
 import { handleOpenAIError } from "./utils/openai-error-handler"
@@ -212,7 +212,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, info: modelInfo } = this.getModel()
 
 		const params: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
@@ -226,7 +226,16 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 		}
 
 		try {
-			const response = await this.client.chat.completions.create(params)
+			// Build request options with signal and/or timeout using RequestConfigBuilder
+			const requestOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				requestOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				requestOptions.timeout = options.timeoutMs
+			}
+
+			const response = await this.client.chat.completions.create(params, requestOptions || undefined)
 
 			// Check for provider-specific error responses (e.g., MiniMax base_resp)
 			const responseAny = response as any

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -796,7 +796,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		try {
 			const modelConfig = this.getModel()
 
@@ -838,7 +838,10 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 			}
 
 			const command = new ConverseCommand(payload)
-			const response = await this.client.send(command)
+			const response = await this.client.send(
+				command,
+				options?.signal ? { abortSignal: options.signal } : undefined,
+			)
 
 			if (
 				response?.output?.message?.content &&

--- a/src/api/providers/config-builder/README.md
+++ b/src/api/providers/config-builder/README.md
@@ -15,7 +15,7 @@ A generic, SDK-agnostic request configuration builder that provides a fluent API
 - [Deep Dive: Abort Signal Handling](#deep-dive-abort-signal-handling)
     - [Why Abort Signals Matter](#why-abort-signals-matter)
     - [How `addAbortSignal` Works](#how-addabortsignal-works)
-    - [How `mergeAbortSignals` Works](#how-mergesignals-works)
+    - [How `mergeAbortSignals` Works](#how-mergeabortsignals-works)
 - [Generic Design](#generic-design)
 - [Multi-SDK Usage Examples](#multi-sdk-usage-examples)
 - [Extending for Your SDK](#extending-for-your-sdk)

--- a/src/api/providers/config-builder/README.md
+++ b/src/api/providers/config-builder/README.md
@@ -1,0 +1,503 @@
+# RequestConfigBuilder
+
+A generic, SDK-agnostic request configuration builder that provides a fluent API for building type-safe request configurations. Designed to work with any HTTP client SDK (OpenAI, AWS Bedrock, Anthropic, Vertex AI, etc.) through TypeScript generics and inheritance.
+
+## Table of Contents
+
+- [Overview](#overview)
+    - [Multi-SDK Usage Matrix](#multi-sdk-usage-matrix)
+    - [Generic Methods vs SDK-Specific Methods](#generic-methods-vs-sdk-specific-methods)
+- [Architecture Diagram](#architecture-diagram)
+- [Quick Start](#quick-start)
+    - [Scenario 1: Basic Usage from Metadata](#scenario-1-basic-usage-from-metadata)
+    - [Scenario 2: Chainable Configuration](#scenario-2-chainable-configuration)
+    - [Scenario 3: Merging Multiple Abort Signals](#scenario-3-merging-multiple-abort-signals)
+- [Deep Dive: Abort Signal Handling](#deep-dive-abort-signal-handling)
+    - [Why Abort Signals Matter](#why-abort-signals-matter)
+    - [How `addAbortSignal` Works](#how-addabortsignal-works)
+    - [How `mergeAbortSignals` Works](#how-mergesignals-works)
+- [Generic Design](#generic-design)
+- [Multi-SDK Usage Examples](#multi-sdk-usage-examples)
+- [Extending for Your SDK](#extending-for-your-sdk)
+- [Test Strategy](#test-strategy)
+- [API Reference](#api-reference)
+    - [Instance Methods](#instance-methods)
+    - [Static Methods](#static-methods)
+- [Breaking Changes Analysis](#breaking-changes-analysis)
+- [Design Principles](#design-principles)
+
+---
+
+## Overview
+
+`RequestConfigBuilder` is a **generic, SDK-agnostic request configuration builder** that provides:
+
+1. **Unified Interface** - Consistent request configuration building across all SDKs (OpenAI, AWS Bedrock, Anthropic, Vertex AI, etc.)
+2. **Chainable Calls** - Fluent API style for concise, readable code
+3. **Generic Type Support** - TypeScript generics (`TOptions`) for type-safe SDK adaptation
+4. **Extensibility** - Easily add support for new SDKs by creating extended classes with SDK-specific methods
+
+### Multi-SDK Usage Matrix
+
+| SDK         | Usage Pattern                                                                          | Options Type               | Extended Class                           |
+| ----------- | -------------------------------------------------------------------------------------- | -------------------------- | ---------------------------------------- |
+| OpenAI      | `OpenAiRequestConfigBuilder extends RequestConfigBuilder<OpenAI.RequestOptions>`       | `OpenAI.RequestOptions`    | `OpenAiRequestConfigBuilder` (example)   |
+| AWS Bedrock | `BedrockRequestConfigBuilder extends RequestConfigBuilder<BedrockInvokeOptions>`       | SDK-specific type          | `BedrockRequestConfigBuilder` (future)   |
+| Anthropic   | `AnthropicRequestConfigBuilder extends RequestConfigBuilder<Anthropic.RequestOptions>` | `Anthropic.RequestOptions` | `AnthropicRequestConfigBuilder` (future) |
+| Vertex AI   | `VertexAiRequestConfigBuilder extends RequestConfigBuilder<VertexAiOptions>`           | Custom interface           | `VertexAiRequestConfigBuilder` (future)  |
+
+### Generic Methods vs SDK-Specific Methods
+
+| Category                         | Methods                                                           | Scope             | Implementation Location                                    |
+| -------------------------------- | ----------------------------------------------------------------- | ----------------- | ---------------------------------------------------------- |
+| **Generic Methods** (Base Class) | `addAbortSignal`, `addHeaders`, `setOption`, `getOption`, `build` | All SDKs          | [`RequestConfigBuilder`](../request-config-builder.ts:13)  |
+| **Static Methods**               | `fromMetadata`, `mergeAbortSignals`                               | All SDKs          | [`RequestConfigBuilder`](../request-config-builder.ts:101) |
+| **SDK-Specific Methods**         | `addPath`, `addQueryParams` (OpenAI), `addModelId` (Bedrock)      | Specific SDK only | Extended classes                                           |
+
+---
+
+## Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph Consumer_Providers
+        OpenAiHandler[OpenAI Handler]
+        AnthropicHandler[Anthropic Handler]
+        BedrockHandler[Bedrock Handler - Future]
+    end
+
+    subgraph Builder_Layer
+        BaseClass[RequestConfigBuilder\nGeneric Base Class]
+        OpenAiBuilder[OpenAiRequestConfigBuilder\nSDK-specific methods]
+        AnthropicBuilder[AnthropicRequestConfigBuilder\nFuture SDK extension]
+        BedrockBuilder[BedrockRequestConfigBuilder\nFuture SDK extension]
+    end
+
+    subgraph Test_Layer
+        BaseTests[request-config-builder.spec.ts\n461 lines, 50+ tests]
+        SdkTests[sdk-request-config-builder.spec.ts\nFuture SDK-specific tests]
+    end
+
+    BaseClass -.->|extends| OpenAiBuilder
+    BaseClass -.->|extends| AnthropicBuilder
+    BaseClass -.->|extends| BedrockBuilder
+
+    OpenAiHandler -->|uses| OpenAiBuilder
+    AnthropicHandler -->|uses| BaseClass
+    BedrockHandler -->|uses| BedrockBuilder
+
+    BaseTests -.->|tests| BaseClass
+    SdkTests -.->|tests| OpenAiBuilder
+
+    style BaseClass fill:f9f,stroke:#333,stroke-width:4px
+    style OpenAiBuilder fill:bbf,stroke:#333
+```
+
+---
+
+## Quick Start
+
+### Scenario 1: Basic Usage from Metadata
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+// Create a configuration quickly from metadata with extra options
+const config = RequestConfigBuilder.fromMetadata(metadata, { timeout: 5000 })
+```
+
+This is equivalent to the following manual process:
+
+```typescript
+const builder = new RequestConfigBuilder<{ timeout: number; signal?: AbortSignal }>({ timeout: 5000 })
+builder.addAbortSignal(metadata)
+const config = builder.build()
+```
+
+### Scenario 2: Chainable Configuration
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+const builder = new RequestConfigBuilder<{ url: string; headers?: Record<string, string>; signal?: AbortSignal }>()
+const config = builder.addHeaders({ "X-Custom-Header": "value" }).setOption("url", "https://api.example.com").build()
+```
+
+All `add*` and `setOption` methods return `this`, enabling fluent chainable calls.
+
+### Scenario 3: Merging Multiple Abort Signals
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+const mergedSignal = RequestConfigBuilder.mergeAbortSignals(primarySignal, secondarySignal)
+```
+
+When either signal is aborted, the returned signal will also be aborted.
+
+---
+
+## Deep Dive: Abort Signal Handling
+
+Abort signals are a core feature of `RequestConfigBuilder`. This section explains how they work in detail.
+
+### Why Abort Signals Matter
+
+In HTTP requests, abort signals allow you to cancel in-flight requests. This is essential for:
+
+- **User experience**: Cancel long-running requests when the user navigates away
+- **Resource management**: Free up network connections and memory
+- **Race condition prevention**: Cancel stale requests when a new one is triggered
+
+### How `addAbortSignal` Works
+
+The `addAbortSignal` method extracts an abort signal from metadata and adds it to the configuration:
+
+```typescript
+// Usage
+builder.addAbortSignal(metadata)
+```
+
+**Behavior breakdown:**
+
+1. If `metadata` is `undefined`, do nothing and return `this`
+2. If `metadata.abortSignal` is `undefined`, do nothing and return `this`
+3. Otherwise, set `options.signal = metadata.abortSignal`
+
+**Internal implementation:**
+
+```typescript
+addAbortSignal(metadata?: ApiHandlerCreateMessageMetadata): this {
+    if (!metadata?.abortSignal) {
+        return this  // Early exit: no signal to add
+    }
+
+    // Add the signal to options (returns new object for immutability)
+    this.options = { ...this.options, signal: metadata.abortSignal } as TOptions
+    return this  // Enable chaining
+}
+```
+
+**Example with real metadata:**
+
+```typescript
+// Metadata from API handler creation
+const metadata: ApiHandlerCreateMessageMetadata = {
+	abortSignal: new AbortController().signal,
+	// ... other properties
+}
+
+// Add the signal to configuration
+const config = new RequestConfigBuilder()
+	.addAbortSignal(metadata) // Signal is now in options.signal
+	.build()
+```
+
+### How `mergeAbortSignals` Works
+
+The static `mergeAbortSignals` method combines two abort signals into one. When **either** signal is aborted, the returned signal will be aborted:
+
+```typescript
+static mergeAbortSignals(primarySignal: AbortSignal, secondarySignal?: AbortSignal): AbortSignal {
+    // If no secondary signal or it's already aborted, just return primary
+    if (!secondarySignal || secondarySignal.aborted) {
+        return primarySignal
+    }
+
+    const controller = new AbortController()
+
+    // If primary is already aborted, abort immediately
+    if (primarySignal.aborted) {
+        controller.abort()
+        return controller.signal
+    }
+
+    // Listen for abort events on both signals
+    primarySignal.addEventListener("abort", () => controller.abort(), { once: true })
+    secondarySignal.addEventListener("abort", () => controller.abort(), { once: true })
+
+    return controller.signal
+}
+```
+
+**Behavior breakdown:**
+
+| Condition                            | Result                                          |
+| ------------------------------------ | ----------------------------------------------- |
+| `secondarySignal` is `undefined`     | Return `primarySignal` unchanged                |
+| `secondarySignal` is already aborted | Return `primarySignal` unchanged                |
+| `primarySignal` is already aborted   | Return new aborted signal                       |
+| Both signals are active              | Return new signal that aborts when either fires |
+
+**Usage example:**
+
+```typescript
+// Create two independent signals
+const userAbortController = new AbortController()
+const timeoutController = new AbortController()
+
+// Merge them into one
+const mergedSignal = RequestConfigBuilder.mergeAbortSignals(userAbortController.signal, timeoutController.signal)
+
+// Now aborting either controller will trigger the merged signal
+userAbortController.abort() // mergedSignal.aborted === true
+```
+
+---
+
+## Generic Design
+
+### Type Parameter
+
+```typescript
+export class RequestConfigBuilder<
+    TOptions extends Record<string, any> = Record<string, any>
+>
+```
+
+| Parameter  | Type                  | Default               | Description                          |
+| ---------- | --------------------- | --------------------- | ------------------------------------ |
+| `TOptions` | `Record<string, any>` | `Record<string, any>` | SDK-specific options type constraint |
+
+### Design Rationale
+
+The generic design enables:
+
+1. **Type Safety** - TypeScript enforces correct option types at compile time
+2. **SDK Isolation** - Each SDK's specific options are encapsulated in their own type
+3. **Code Reuse** - Common logic (signal handling, header merging) lives in the base class
+4. **Zero Runtime Overhead** - Generics are erased at compile time, no runtime cost
+
+---
+
+## Multi-SDK Usage Examples
+
+### Scenario A: OpenAI SDK - Using Extended Class
+
+```typescript
+import { OpenAiRequestConfigBuilder } from "./openai-request-config-builder"
+
+const config = new OpenAiRequestConfigBuilder()
+	.addAbortSignal(metadata)
+	.addPath("/v1/chat/completions")
+	.addQueryParams({ stream: true })
+	.addHeaders({ "X-API-Key": "secret" })
+	.build()
+
+await client.chat.completions.create(requestOptions, config)
+```
+
+### Scenario B: AWS Bedrock SDK - Using Generic Base Class with setOption
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+type BedrockOptions = {
+	modelId?: string
+	maxTokens?: number
+	body?: string
+	signal?: AbortSignal
+}
+
+const config = new RequestConfigBuilder<BedrockOptions>()
+	.addAbortSignal(metadata)
+	.setOption("modelId", "anthropic.claude-3-opus-20240229-v1:0")
+	.setOption("maxTokens", 2000)
+	.build()
+
+await bedrockClient.invoke(config)
+```
+
+### Scenario C: Anthropic SDK - Using Extended Class (Future)
+
+```typescript
+import { AnthropicRequestConfigBuilder } from "./anthropic-request-config-builder"
+
+const config = new AnthropicRequestConfigBuilder()
+	.addAbortSignal(metadata)
+	.setApiVersion("2023-06-01")
+	.addHeaders({ "X-Anthropic-Beta": "prompt-caching-20240715" })
+	.build()
+
+await anthropic.messages.create(requestOptions, config)
+```
+
+### Scenario D: Quick Factory Method (All SDKs)
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+// Simplest usage - just add signal + extra options
+const config = RequestConfigBuilder.fromMetadata(metadata, {
+	timeout: 5000,
+	retryCount: 3,
+})
+```
+
+### Scenario E: Merging External Signals (All SDKs)
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+
+// Provider creates internal AbortController
+this.abortController = new AbortController()
+
+// Merge external signal - works with all SDKs
+const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+    this.abortController.signal,
+    metadata?.abortSignal,
+)
+
+// Use with any SDK
+await client.request({ signal: mergedSignal, ... })
+```
+
+---
+
+## Extending for Your SDK
+
+`RequestConfigBuilder` supports SDK-specific extensions via inheritance. Follow these steps to add support for a new SDK:
+
+### Step 1: Define SDK-Specific Options Type
+
+```typescript
+// my-sdk-options.ts
+export interface MySdkOptions {
+	signal?: AbortSignal
+	headers?: Record<string, string>
+	modelId?: string
+	maxTokens?: number
+}
+```
+
+### Step 2: Create Extended Builder Class
+
+Here's an example for the OpenAI SDK:
+
+```typescript
+import { RequestConfigBuilder } from "./request-config-builder"
+import type * as OpenAI from "openai"
+
+export class OpenAiRequestConfigBuilder extends RequestConfigBuilder<OpenAI.RequestOptions> {
+	constructor(defaultOptions?: Partial<OpenAI.RequestOptions>) {
+		super(defaultOptions)
+	}
+
+	addPath(path: string | undefined): this {
+		if (path) {
+			this.options = { ...this.options, path } as OpenAI.RequestOptions
+		}
+		return this
+	}
+
+	addQueryParams(params: Record<string, any>): this {
+		if (Object.keys(params).length > 0) {
+			this.options = { ...this.options, queryParams: params } as OpenAI.RequestOptions
+		}
+		return this
+	}
+}
+```
+
+### Step 3: Add SDK-Specific Tests
+
+```typescript
+// my-sdk-request-config-builder.spec.ts
+import { describe, test, expect } from "vitest"
+import { MySdkRequestConfigBuilder } from "./my-sdk-request-config-builder"
+
+describe("MySdkRequestConfigBuilder", () => {
+	test("addModelId sets model ID", () => {
+		const builder = new MySdkRequestConfigBuilder()
+		const result = builder.addModelId("my-model-123")
+
+		expect(result).toBe(builder) // chainable
+		const config = builder.build()
+		expect(config?.modelId).toBe("my-model-123")
+	})
+})
+```
+
+### Step 4: Update Documentation
+
+Add usage examples in this document's Multi-SDK section.
+
+### Key Extension Patterns
+
+| Pattern                    | Description                                                                                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Generic type parameter** | Pass your SDK's options type (e.g., `OpenAI.RequestOptions`) to `RequestConfigBuilder<TOptions>` |
+| **SDK-specific methods**   | Add methods like `addPath`, `addModelId`, `setApiVersion` for SDK-specific configuration         |
+| **Type casting**           | Use `as YourSdkOptionsType` when assigning merged objects back to `this.options`                 |
+| **Delegation to base**     | Use `this.setOption()` for simple options, direct `this.options` assignment for complex merges   |
+
+---
+
+## Test Strategy
+
+### Test Coverage Overview
+
+| Test File                                                                       | Lines | Test Category            | Test Count |
+| ------------------------------------------------------------------------------- | ----- | ------------------------ | ---------- |
+| [`request-config-builder.spec.ts`](../__tests__/request-config-builder.spec.ts) | 461   | Generic + Static Methods | ~50+       |
+
+### Test Categories
+
+| Category          | Test Count | Coverage                                            |
+| ----------------- | ---------- | --------------------------------------------------- |
+| constructor       | 3          | Empty init, default options, shallow copy           |
+| addAbortSignal    | 5          | Normal case, undefined metadata, signal replacement |
+| addHeaders        | 6          | Merge, override, create new object                  |
+| setOption         | 5          | Type safety, undefined handling                     |
+| getOption         | 2          | Get value, non-existent key                         |
+| build             | 4          | Shallow copy, empty options, immutability           |
+| fromMetadata      | 5          | Various combination scenarios                       |
+| mergeAbortSignals | 8          | Primary only, merged, abort events                  |
+| integration       | 3          | Full lifecycle, custom types                        |
+
+### Running Tests
+
+```bash
+cd src && npx vitest run api/providers/__tests__/request-config-builder.spec.ts
+```
+
+---
+
+## Breaking Changes Analysis
+
+| Change Type                                   | Breaking | Description                                                          |
+| --------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| Adding generic parameter TOptions             | No       | Default value `Record<string, any>` maintains backward compatibility |
+| Adding setOption method                       | No       | Existing code unaffected                                             |
+| Modifying fromMetadata to be generic          | No       | TypeScript type inference remains compatible                         |
+| options access modifier (private → protected) | Partial  | Only affects extended classes, not direct users                      |
+
+---
+
+## API Reference
+
+### Instance Methods
+
+| Method           | Parameters                                   | Returns                    | Description                                                                                                       |
+| ---------------- | -------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `addAbortSignal` | `metadata?: ApiHandlerCreateMessageMetadata` | `this`                     | Add an abort signal from metadata. Skips if metadata or abortSignal is undefined.                                 |
+| `addHeaders`     | `headers: Record<string, string>`            | `this`                     | Add or merge custom headers. Empty objects are skipped. Headers are merged (not replaced).                        |
+| `setOption`      | `key: K, value: TOptions[K]`                 | `this`                     | Set a single option in a type-safe way. Skips if value is undefined.                                              |
+| `getOption`      | `key: K`                                     | `TOptions[K] \| undefined` | Get an option value by key. Returns undefined if not set.                                                         |
+| `build`          | —                                            | `TOptions \| undefined`    | Build the final configuration. Returns a shallow copy for immutability. Returns undefined if no options were set. |
+
+### Static Methods
+
+| Method              | Parameters                                                                     | Returns                 | Description                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------ | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fromMetadata`      | `metadata?: ApiHandlerCreateMessageMetadata, extraOptions?: Partial<TOptions>` | `TOptions \| undefined` | Factory method that creates a builder from metadata and optional extra options. Combines `new RequestConfigBuilder(extraOptions)` + `addAbortSignal(metadata)` + `build()`. |
+| `mergeAbortSignals` | `primarySignal: AbortSignal, secondarySignal?: AbortSignal`                    | `AbortSignal`           | Merge two abort signals into one. The returned signal aborts when either input signal aborts.                                                                               |
+
+---
+
+## Design Principles
+
+1. **Immutability**: `build()` returns a shallow copy of internal options
+2. **Defensive programming**: Empty/undefined values are skipped (not added to config)
+3. **Chainable interface**: All mutation methods return `this` for fluent API style
+4. **Generic type safety**: TypeScript generics ensure SDK-specific types are enforced at compile time

--- a/src/api/providers/config-builder/request-config-builder.ts
+++ b/src/api/providers/config-builder/request-config-builder.ts
@@ -124,8 +124,7 @@ export class RequestConfigBuilder<TOptions extends Record<string, any> = Record<
 		const controller = new AbortController()
 
 		if (primarySignal.aborted) {
-			controller.abort()
-			return controller.signal
+			return primarySignal
 		}
 
 		primarySignal.addEventListener("abort", () => controller.abort(), { once: true })

--- a/src/api/providers/config-builder/request-config-builder.ts
+++ b/src/api/providers/config-builder/request-config-builder.ts
@@ -1,0 +1,136 @@
+import type { ApiHandlerCreateMessageMetadata } from "../../index"
+
+/**
+ * A generic, SDK-agnostic request configuration builder.
+ *
+ * Provides a fluent API for building request configurations with:
+ * - Chainable method calls
+ * - Generic type support (TOptions)
+ * - Abort signal handling
+ * - Header merging
+ * - Static factory methods
+ */
+export class RequestConfigBuilder<TOptions extends Record<string, any> = Record<string, any>> {
+	protected options: TOptions
+
+	constructor(defaultOptions?: Partial<TOptions>) {
+		this.options = (defaultOptions ? { ...defaultOptions } : {}) as TOptions
+	}
+
+	/**
+	 * Add an abort signal from metadata.
+	 *
+	 * @param metadata - Optional metadata containing an abortSignal
+	 * @returns this for chainable calls
+	 */
+	addAbortSignal(metadata?: ApiHandlerCreateMessageMetadata): this {
+		if (!metadata?.abortSignal) {
+			return this
+		}
+
+		this.options = { ...this.options, signal: metadata.abortSignal } as TOptions
+		return this
+	}
+
+	/**
+	 * Add or merge custom headers.
+	 *
+	 * @param headers - Key-value pairs of header names and values
+	 * @returns this for chainable calls
+	 */
+	addHeaders(headers: Record<string, string>): this {
+		if (Object.keys(headers).length === 0) {
+			return this
+		}
+
+		const existingHeaders = (this.options as any).headers ?? {}
+		this.options = { ...this.options, headers: { ...existingHeaders, ...headers } } as TOptions
+		return this
+	}
+
+	/**
+	 * Set a single option by key (type-safe).
+	 *
+	 * @param key - Option key
+	 * @param value - Option value
+	 * @returns this for chainable calls
+	 */
+	setOption<K extends keyof TOptions>(key: K, value: TOptions[K]): this {
+		if (value === undefined) {
+			return this
+		}
+
+		this.options = { ...this.options, [key]: value } as TOptions
+		return this
+	}
+
+	/**
+	 * Get an option by key.
+	 *
+	 * @param key - Option key
+	 * @returns The option value or undefined if not set
+	 */
+	getOption<K extends keyof TOptions>(key: K): TOptions[K] | undefined {
+		return this.options[key]
+	}
+
+	/**
+	 * Build the final configuration object.
+	 *
+	 * Returns a shallow copy of the internal options to ensure immutability.
+	 * Returns undefined if no options have been set.
+	 *
+	 * @returns The built configuration or undefined if empty
+	 */
+	build(): TOptions | undefined {
+		const keys = Object.keys(this.options as object)
+		if (keys.length === 0) {
+			return undefined
+		}
+
+		return { ...this.options } as TOptions
+	}
+
+	/**
+	 * Factory method to quickly create and configure a builder from metadata.
+	 *
+	 * @param metadata - Optional metadata containing an abortSignal
+	 * @param extraOptions - Additional options to merge
+	 * @returns The built configuration or undefined if empty
+	 */
+	static fromMetadata<TOptions extends Record<string, any> = Record<string, any>>(
+		metadata?: ApiHandlerCreateMessageMetadata,
+		extraOptions?: Partial<TOptions>,
+	): TOptions | undefined {
+		const builder = new RequestConfigBuilder<TOptions>(extraOptions)
+		builder.addAbortSignal(metadata)
+		return builder.build()
+	}
+
+	/**
+	 * Merge multiple abort signals.
+	 *
+	 * If any signal is aborted, the returned signal will be aborted.
+	 *
+	 * @param primarySignal - The primary abort signal
+	 * @param secondarySignal - Optional secondary abort signal
+	 * @returns A merged AbortSignal
+	 */
+	static mergeAbortSignals(primarySignal: AbortSignal, secondarySignal?: AbortSignal): AbortSignal {
+		if (!secondarySignal || secondarySignal.aborted) {
+			return primarySignal
+		}
+
+		const controller = new AbortController()
+
+		if (primarySignal.aborted) {
+			controller.abort()
+			return controller.signal
+		}
+
+		primarySignal.addEventListener("abort", () => controller.abort(), { once: true })
+		secondarySignal.addEventListener("abort", () => controller.abort(), { once: true })
+
+		return controller.signal
+	}
+}

--- a/src/api/providers/fake-ai.ts
+++ b/src/api/providers/fake-ai.ts
@@ -28,7 +28,7 @@ interface FakeAI {
 	): ApiStream
 	getModel(): { id: string; info: ModelInfo }
 	countTokens(content: Array<Anthropic.Messages.ContentBlockParam>): Promise<number>
-	completePrompt(prompt: string): Promise<string>
+	completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string>
 }
 
 /**
@@ -75,7 +75,7 @@ export class FakeAIHandler implements ApiHandler, SingleCompletionHandler {
 		return this.ai.countTokens(content)
 	}
 
-	completePrompt(prompt: string): Promise<string> {
-		return this.ai.completePrompt(prompt)
+	completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
+		return (this.ai as any).completePrompt(prompt, options)
 	}
 }

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -576,7 +576,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		return citationLinks.join(", ")
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: model, info } = this.getModel()
 
 		try {
@@ -585,10 +585,16 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 				? (this.options.modelTemperature ?? info.defaultTemperature ?? 1)
 				: info.defaultTemperature
 
+			const httpOpts: Record<string, any> = {}
+			if (options?.signal) {
+				httpOpts.signal = options.signal
+			}
+			if (this.options.googleGeminiBaseUrl) {
+				httpOpts.baseUrl = this.options.googleGeminiBaseUrl
+			}
+
 			const promptConfig: GenerateContentConfig = {
-				httpOptions: this.options.googleGeminiBaseUrl
-					? { baseUrl: this.options.googleGeminiBaseUrl }
-					: undefined,
+				httpOptions: Object.keys(httpOpts).length > 0 ? httpOpts : undefined,
 				temperature: temperatureConfig,
 			}
 

--- a/src/api/providers/index.ts
+++ b/src/api/providers/index.ts
@@ -1,3 +1,4 @@
+export { RequestConfigBuilder } from "./config-builder/request-config-builder"
 export { AnthropicVertexHandler } from "./anthropic-vertex"
 export { AnthropicHandler } from "./anthropic"
 export { AwsBedrockHandler } from "./bedrock"

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -311,7 +311,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: modelId, info } = await this.fetchModel()
 
 		// Check if this is a GPT-5 model that requires max_completion_tokens instead of max_tokens
@@ -334,7 +334,16 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 				requestOptions.max_tokens = info.maxTokens
 			}
 
-			const response = await this.client.chat.completions.create(requestOptions)
+			// Build request options with signal and/or timeout
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
+			const response = await this.client.chat.completions.create(requestOptions, createOptions || undefined)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			if (error instanceof Error) {

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -184,7 +184,7 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		try {
 			// Create params object with optional draft model
 			const params: any = {
@@ -199,9 +199,18 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 				params.draft_model = this.options.lmStudioDraftModelId
 			}
 
+			// Build request options with signal and/or timeout
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
 			let response
 			try {
-				response = await this.client.chat.completions.create(params)
+				response = await this.client.chat.completions.create(params, createOptions || undefined)
 			} catch (error) {
 				throw handleOpenAIError(error, this.providerName)
 			}

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -289,16 +289,19 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions) {
 		const { id: model, temperature } = this.getModel()
 
-		const message = await this.client.messages.create({
-			model,
-			max_tokens: 16_384,
-			temperature: temperature ?? 1.0,
-			messages: [{ role: "user", content: prompt }],
-			stream: false,
-		})
+		const message = await this.client.messages.create(
+			{
+				model,
+				max_tokens: 16_384,
+				temperature: temperature ?? 1.0,
+				messages: [{ role: "user", content: prompt }],
+				stream: false,
+			},
+			options?.signal ? { signal: options.signal } : undefined,
+		)
 
 		const content = message.content.find(({ type }) => type === "text")
 		return content?.type === "text" ? content.text : ""

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -193,15 +193,18 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 		return { id, info, maxTokens, temperature }
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: model, temperature } = this.getModel()
 
 		try {
-			const response = await this.client.chat.complete({
-				model,
-				messages: [{ role: "user", content: prompt }],
-				temperature,
-			})
+			const response = await this.client.chat.complete(
+				{
+					model,
+					messages: [{ role: "user", content: prompt }],
+					temperature,
+				},
+				(options?.signal ? { signal: options.signal } : undefined) as any,
+			)
 
 			const content = response.choices?.[0]?.message.content
 

--- a/src/api/providers/native-ollama.ts
+++ b/src/api/providers/native-ollama.ts
@@ -344,7 +344,8 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, _options?: import("../index").CompletePromptOptions): Promise<string> {
+		// Ollama native client doesn't support abort signals at all — accept param but ignore
 		try {
 			const client = this.ensureClient()
 			const { id: modelId } = await this.fetchModel()

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -26,6 +26,7 @@ import { isMcpTool } from "../../utils/mcp-name"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 import { openAiCodexOAuthManager } from "../../integrations/openai-codex/oauth"
 import { t } from "../../i18n"
+import { RequestConfigBuilder } from "./config-builder/request-config-builder"
 
 export type OpenAiCodexModel = ReturnType<OpenAiCodexHandler["getModel"]>
 
@@ -1152,8 +1153,17 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		return this.lastResponseId
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
+		// Merge incoming signal with existing class-level controller if needed
+		const defaultSignal = new AbortController().signal
+		const mergedSignal = RequestConfigBuilder.mergeAbortSignals(defaultSignal, options?.signal)
 		this.abortController = new AbortController()
+		// Link the merged signal to our abort controller
+		if (mergedSignal.aborted) {
+			this.abortController.abort()
+		} else {
+			mergedSignal.addEventListener("abort", () => this.abortController?.abort(), { once: true })
+		}
 
 		try {
 			const model = this.getModel()
@@ -1214,7 +1224,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				method: "POST",
 				headers,
 				body: JSON.stringify(requestBody),
-				signal: this.abortController.signal,
+				signal: mergedSignal,
 			})
 
 			if (!response.ok) {

--- a/src/api/providers/openai-compatible.ts
+++ b/src/api/providers/openai-compatible.ts
@@ -197,7 +197,7 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 	/**
 	 * Complete a prompt using the AI SDK generateText.
 	 */
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const languageModel = this.getLanguageModel()
 
 		const { text } = await generateText({
@@ -205,6 +205,7 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 			prompt,
 			maxOutputTokens: this.getMaxOutputTokens(),
 			temperature: this.config.temperature ?? 0,
+			...(options?.signal && { signal: options.signal }),
 		})
 
 		return text

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -29,6 +29,7 @@ import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { isMcpTool } from "../../utils/mcp-name"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
+import { RequestConfigBuilder } from "./config-builder/request-config-builder"
 
 export type OpenAiNativeModel = ReturnType<OpenAiNativeHandler["getModel"]>
 
@@ -1483,9 +1484,21 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 		return this.lastResponseId
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
-		// Create AbortController for cancellation
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
+		// Merge incoming signal with existing class-level controller if needed
+		const mergedSignal = RequestConfigBuilder.mergeAbortSignals(
+			this.abortController?.signal ?? new AbortController().signal,
+			options?.signal,
+		)
+
+		// Create AbortController for cancellation (keep for cleanup tracking)
 		this.abortController = new AbortController()
+		// Link the merged signal to our abort controller
+		if (mergedSignal.aborted) {
+			this.abortController.abort()
+		} else {
+			mergedSignal.addEventListener("abort", () => this.abortController?.abort(), { once: true })
+		}
 
 		try {
 			const model = this.getModel()
@@ -1547,7 +1560,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 
 			// Make the non-streaming request
 			const response = await (this.client as any).responses.create(requestBody, {
-				signal: this.abortController.signal,
+				signal: mergedSignal,
 			})
 
 			// Extract text from the response

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -296,7 +296,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		return { id, info, ...params }
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../../api").CompletePromptOptions): Promise<string> {
 		try {
 			const isAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 			const model = this.getModel()
@@ -310,11 +310,20 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			// Add max_tokens if needed
 			this.addMaxTokensIfNeeded(requestOptions, modelInfo)
 
+			// Build request options with signal and/or timeout
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
 			let response
 			try {
 				response = await this.client.chat.completions.create(
 					requestOptions,
-					isAzureAiInference ? { path: OPENAI_AZURE_AI_INFERENCE_PATH } : {},
+					isAzureAiInference ? { path: OPENAI_AZURE_AI_INFERENCE_PATH, ...createOptions } : createOptions,
 				)
 			} catch (error) {
 				throw handleOpenAIError(error, this.providerName)

--- a/src/api/providers/opencode-go.ts
+++ b/src/api/providers/opencode-go.ts
@@ -485,25 +485,28 @@ export class OpencodeGoHandler extends RouterProvider implements SingleCompletio
 	 * @returns The model's reply text, or an empty string if no content is returned.
 	 * @throws Error with an Opencode Go-specific prefix if the request fails.
 	 */
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: modelId, format, temperature, reasoningEffort, maxTokens } = await this.resolveModel()
 
 		if (format === "anthropic") {
 			try {
-				const message = await this.anthropicClient.messages.create({
-					model: modelId,
-					// Honour the same includeMaxTokens/modelMaxTokens override
-					// logic as the streaming path so non-streaming completions
-					// respect the user's max-output slider instead of always
-					// falling back to the model default.
-					max_tokens:
-						this.options.includeMaxTokens === true
-							? this.options.modelMaxTokens || maxTokens || 16_384
-							: (maxTokens ?? 16_384),
-					temperature: this.supportsTemperature(modelId) ? (temperature ?? 1.0) : undefined,
-					messages: [{ role: "user", content: prompt }],
-					stream: false,
-				})
+				const message = await this.anthropicClient.messages.create(
+					{
+						model: modelId,
+						// Honour the same includeMaxTokens/modelMaxTokens override
+						// logic as the streaming path so non-streaming completions
+						// respect the user's max-output slider instead of always
+						// falling back to the model default.
+						max_tokens:
+							this.options.includeMaxTokens === true
+								? this.options.modelMaxTokens || maxTokens || 16_384
+								: (maxTokens ?? 16_384),
+						temperature: this.supportsTemperature(modelId) ? (temperature ?? 1.0) : undefined,
+						messages: [{ role: "user", content: prompt }],
+						stream: false,
+					},
+					options?.signal ? { signal: options.signal } : undefined,
+				)
 
 				const content = message.content.find(({ type }) => type === "text")
 				return content?.type === "text" ? content.text : ""
@@ -534,7 +537,16 @@ export class OpencodeGoHandler extends RouterProvider implements SingleCompletio
 					reasoningEffort as OpenAI.Chat.ChatCompletionCreateParams["reasoning_effort"]
 			}
 
-			const response = await this.client.chat.completions.create(requestOptions)
+			// Build request options with signal and/or timeout for OpenAI path
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
+			const response = await this.client.chat.completions.create(requestOptions, createOptions || undefined)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			if (error instanceof Error) {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -574,7 +574,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		return { id, info, topP: isDeepSeekR1 ? 0.95 : undefined, ...params }
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions) {
 		const { id: modelId, maxTokens, temperature, reasoning } = await this.fetchModel()
 
 		const completionParams: OpenRouterChatCompletionParams = {
@@ -596,9 +596,14 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		}
 
 		// Add Anthropic beta header for fine-grained tool streaming when using Anthropic models
-		const requestOptions = modelId.startsWith("anthropic/")
-			? { headers: { "x-anthropic-beta": "fine-grained-tool-streaming-2025-05-14" } }
-			: undefined
+		// Merge signal + timeout with existing headers
+		const requestOptions: OpenAI.RequestOptions = {
+			...(modelId.startsWith("anthropic/")
+				? { headers: { "x-anthropic-beta": "fine-grained-tool-streaming-2025-05-14" } }
+				: undefined),
+			...(options?.signal && { signal: options.signal }),
+			...(options?.timeoutMs && { timeout: options.timeoutMs }),
+		}
 
 		let response
 

--- a/src/api/providers/poe.ts
+++ b/src/api/providers/poe.ts
@@ -134,12 +134,13 @@ export class PoeHandler extends BaseProvider implements SingleCompletionHandler 
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id } = this.getModel()
 		try {
 			const { text } = await generateText({
 				model: this.poe(id),
 				prompt,
+				...(options?.signal && { signal: options.signal }),
 			})
 			return text
 		} catch (error) {

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -204,7 +204,7 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: model, maxTokens: max_tokens, temperature } = await this.fetchModel()
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [{ role: "system", content: prompt }]
@@ -216,9 +216,17 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 			temperature: temperature,
 		}
 
+		const createOptions: OpenAI.RequestOptions = {}
+		if (options?.signal) {
+			createOptions.signal = options.signal
+		}
+		if (options?.timeoutMs) {
+			createOptions.timeout = options.timeoutMs
+		}
+
 		let response: OpenAI.Chat.ChatCompletion
 		try {
-			response = await this.client.chat.completions.create(completionParams)
+			response = await this.client.chat.completions.create(completionParams, createOptions || undefined)
 		} catch (error) {
 			throw handleOpenAIError(error, this.providerName)
 		}

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -192,7 +192,7 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: model, maxTokens: max_tokens, temperature } = await this.fetchModel()
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [{ role: "system", content: prompt }]
@@ -204,9 +204,18 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 			temperature: temperature,
 		}
 
+		// Build request options with signal and/or timeout
+		const createOptions: OpenAI.RequestOptions = {}
+		if (options?.signal) {
+			createOptions.signal = options.signal
+		}
+		if (options?.timeoutMs) {
+			createOptions.timeout = options.timeoutMs
+		}
+
 		let response: OpenAI.Chat.ChatCompletion
 		try {
-			response = await this.client.chat.completions.create(completionParams)
+			response = await this.client.chat.completions.create(completionParams, createOptions || undefined)
 		} catch (error) {
 			throw handleOpenAIError(error, this.providerName)
 		}

--- a/src/api/providers/vercel-ai-gateway.ts
+++ b/src/api/providers/vercel-ai-gateway.ts
@@ -117,7 +117,7 @@ export class VercelAiGatewayHandler extends RouterProvider implements SingleComp
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const { id: modelId, info } = await this.fetchModel()
 
 		try {
@@ -133,7 +133,16 @@ export class VercelAiGatewayHandler extends RouterProvider implements SingleComp
 
 			requestOptions.max_completion_tokens = info.maxTokens
 
-			const response = await this.client.chat.completions.create(requestOptions)
+			// Build request options with signal and/or timeout
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
+			const response = await this.client.chat.completions.create(requestOptions, createOptions || undefined)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			if (error instanceof Error) {

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -562,13 +562,24 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
+		const client = await this.getClient()
+
+		// Bridge external AbortSignal to VSCode CancellationToken
+		const tokenSource = new vscode.CancellationTokenSource()
+		if (options?.signal) {
+			if (options.signal.aborted) {
+				tokenSource.cancel()
+			} else {
+				options.signal.addEventListener("abort", () => tokenSource.cancel(), { once: true })
+			}
+		}
+
 		try {
-			const client = await this.getClient()
 			const response = await client.sendRequest(
 				[vscode.LanguageModelChatMessage.User(prompt)],
 				{},
-				new vscode.CancellationTokenSource().token,
+				tokenSource.token,
 			)
 			let result = ""
 			for await (const chunk of response.stream) {
@@ -577,12 +588,15 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 				}
 			}
 			return result
-		} catch (error) {
-			if (error instanceof Error) {
-				throw new Error(`VSCode LM completion error: ${error.message}`)
-			}
-			throw error
+		} finally {
+			tokenSource.dispose()
 		}
+	}
+	catch(error: any) {
+		if (error instanceof Error) {
+			throw new Error(`VSCode LM completion error: ${error.message}`)
+		}
+		throw error
 	}
 }
 

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -142,15 +142,18 @@ export class XAIHandler extends BaseProvider implements SingleCompletionHandler 
 		yield* processResponsesApiStream(stream, normalizeUsage)
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		const model = this.getModel()
 
 		try {
-			const response = await this.client.responses.create({
-				model: model.id,
-				input: [{ role: "user", content: [{ type: "input_text", text: prompt }] }],
-				store: false,
-			})
+			const response = await this.client.responses.create(
+				{
+					model: model.id,
+					input: [{ role: "user", content: [{ type: "input_text", text: prompt }] }],
+					store: false,
+				},
+				options?.signal ? { signal: options.signal } : undefined,
+			)
 
 			// output_text is a convenience field on the Responses API response
 			return response.output_text || ""

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -276,7 +276,7 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../index").CompletePromptOptions): Promise<string> {
 		this.ensureAuthenticated()
 
 		const { id: modelId, info } = await this.fetchModel()
@@ -294,7 +294,16 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 
 			requestOptions.max_completion_tokens = info.maxTokens
 
-			const response = await this.client.chat.completions.create(requestOptions)
+			// Build request options with signal and/or timeout
+			const createOptions: OpenAI.RequestOptions = {}
+			if (options?.signal) {
+				createOptions.signal = options.signal
+			}
+			if (options?.timeoutMs) {
+				createOptions.timeout = options.timeoutMs
+			}
+
+			const response = await this.client.chat.completions.create(requestOptions, createOptions || undefined)
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			try {

--- a/src/utils/single-completion-handler.ts
+++ b/src/utils/single-completion-handler.ts
@@ -1,12 +1,16 @@
 import type { ProviderSettings } from "@roo-code/types"
 
-import { buildApiHandler, SingleCompletionHandler } from "../api"
+import { buildApiHandler, SingleCompletionHandler, type CompletePromptOptions } from "../api"
 
 /**
  * Enhances a prompt using the configured API without creating a full Cline instance or task history.
  * This is a lightweight alternative that only uses the API's completion functionality.
  */
-export async function singleCompletionHandler(apiConfiguration: ProviderSettings, promptText: string): Promise<string> {
+export async function singleCompletionHandler(
+	apiConfiguration: ProviderSettings,
+	promptText: string,
+	options?: CompletePromptOptions,
+): Promise<string> {
 	if (!promptText) {
 		throw new Error("No prompt text provided")
 	}
@@ -21,5 +25,5 @@ export async function singleCompletionHandler(apiConfiguration: ProviderSettings
 		throw new Error("The selected API provider does not support prompt enhancement")
 	}
 
-	return (handler as SingleCompletionHandler).completePrompt(promptText)
+	return (handler as SingleCompletionHandler).completePrompt(promptText, options)
 }


### PR DESCRIPTION
## Summary

This PR builds on top of the abort signal core plumbing (#674) and adds:

- **RequestConfigBuilder** — A new SDK-agnostic request configuration class that unifies timeout, signal, and provider-specific options across all API providers.
- **Complete prompt signal/timeout tests** — Comprehensive test coverage for all 25 providers verifying `completePrompt` signal passing and timeout behavior.
- **Config builder documentation** — Enhanced README with generic architecture design and multi-SDK usage examples.

## Changes

| Area | Description |
|------|-------------|
| `src/api/providers/config-builder/` | New RequestConfigBuilder class + README |
| `src/api/providers/*.ts` | Updated all 25 providers to use the new config builder |
| `src/api/providers/__tests__/` | Added completePrompt signal/timeout tests for every provider |

## Test Plan

- [x] All unit tests pass (25 provider test files updated)
- [x] Config builder README validates correctly
- [ ] CI checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-prompt completion now supports optional cancellation and timeout settings.
  * Added a reusable request configuration builder for composing request options.
  * Expanded provider support so more completion flows can accept the same optional settings.

* **Bug Fixes**
  * Completed requests now consistently handle omitted options without breaking existing behavior.
  * Improved request cancellation handling across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->