### PR TITLE
feat: Add Anthropic Custom provider with configurable model parameters

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -85,7 +85,7 @@ export const isInternalProvider = (key: string): key is InternalProvider =>
  * Custom providers are completely configurable within Roo Code settings.
  */
 
-export const customProviders = ["openai"] as const
+export const customProviders = ["openai", "anthropic-custom"] as const
 
 export type CustomProvider = (typeof customProviders)[number]
 
@@ -262,6 +262,15 @@ const openAiSchema = baseProviderSettingsSchema.extend({
 	openAiHeaders: z.record(z.string(), z.string()).optional(),
 })
 
+const anthropicCustomSchema = baseProviderSettingsSchema.extend({
+	anthropicCustomBaseUrl: z.string().optional(),
+	anthropicCustomApiKey: z.string().optional(),
+	anthropicCustomModelId: z.string().optional(),
+	anthropicCustomModelInfo: modelInfoSchema.nullish(),
+	anthropicCustomStreamingEnabled: z.boolean().optional(),
+	anthropicCustomHeaders: z.record(z.string(), z.string()).optional(),
+})
+
 const ollamaSchema = baseProviderSettingsSchema.extend({
 	ollamaModelId: z.string().optional(),
 	ollamaBaseUrl: z.string().optional(),
@@ -427,6 +436,7 @@ export const providerSettingsSchemaDiscriminated = z.discriminatedUnion("apiProv
 	bedrockSchema.merge(z.object({ apiProvider: z.literal("bedrock") })),
 	vertexSchema.merge(z.object({ apiProvider: z.literal("vertex") })),
 	openAiSchema.merge(z.object({ apiProvider: z.literal("openai") })),
+	anthropicCustomSchema.merge(z.object({ apiProvider: z.literal("anthropic-custom") })),
 	ollamaSchema.merge(z.object({ apiProvider: z.literal("ollama") })),
 	vsCodeLmSchema.merge(z.object({ apiProvider: z.literal("vscode-lm") })),
 	lmStudioSchema.merge(z.object({ apiProvider: z.literal("lmstudio") })),
@@ -463,6 +473,7 @@ export const providerSettingsSchema = z.object({
 	...bedrockSchema.shape,
 	...vertexSchema.shape,
 	...openAiSchema.shape,
+	...anthropicCustomSchema.shape,
 	...ollamaSchema.shape,
 	...vsCodeLmSchema.shape,
 	...lmStudioSchema.shape,
@@ -512,6 +523,7 @@ export const modelIdKeys = [
 	"apiModelId",
 	"openRouterModelId",
 	"openAiModelId",
+	"anthropicCustomModelId",
 	"ollamaModelId",
 	"lmStudioModelId",
 	"lmStudioDraftModelId",
@@ -575,7 +587,7 @@ export const modelIdKeysByProvider: Record<TypicalProvider, ModelIdKey> = {
  */
 
 // Providers that use Anthropic-style API protocol.
-export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "bedrock", "minimax"]
+export const ANTHROPIC_STYLE_PROVIDERS: ProviderName[] = ["anthropic", "anthropic-custom", "bedrock", "minimax"]
 
 export const getApiProtocol = (provider: ProviderName | undefined, modelId?: string): "anthropic" | "openai" => {
 	if (provider && ANTHROPIC_STYLE_PROVIDERS.includes(provider)) {
@@ -615,7 +627,7 @@ export const getApiProtocol = (provider: ProviderName | undefined, modelId?: str
  */
 
 export const MODELS_BY_PROVIDER: Record<
-	Exclude<ProviderName, "fake-ai" | "gemini-cli" | "openai">,
+	Exclude<ProviderName, "fake-ai" | "gemini-cli" | "openai" | "anthropic-custom">,
 	{ id: ProviderName; label: string; models: string[] }
 > = {
 	anthropic: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -133,6 +133,7 @@ export function buildApiHandler(configuration: ProviderSettings): ApiHandler {
 
 	switch (apiProvider) {
 		case "anthropic":
+		case "anthropic-custom":
 			return new AnthropicHandler(options)
 		case "openrouter":
 			return new OpenRouterHandler(options)

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -8,6 +8,7 @@ import {
 	type AnthropicModelId,
 	anthropicDefaultModelId,
 	anthropicModels,
+	openAiModelInfoSaneDefaults,
 	ANTHROPIC_DEFAULT_MAX_TOKENS,
 	ApiProviderError,
 } from "@roo-code/types"
@@ -38,12 +39,17 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		super()
 		this.options = options
 
+		const baseURL = this.options.anthropicCustomBaseUrl || this.options.anthropicBaseUrl || undefined
+		const apiKey = this.options.anthropicCustomApiKey || this.options.apiKey
 		const apiKeyFieldName =
-			this.options.anthropicBaseUrl && this.options.anthropicUseAuthToken ? "authToken" : "apiKey"
+			baseURL && this.options.anthropicUseAuthToken && !this.options.anthropicCustomApiKey
+				? "authToken"
+				: "apiKey"
 
 		this.client = new Anthropic({
-			baseURL: this.options.anthropicBaseUrl || undefined,
-			[apiKeyFieldName]: this.options.apiKey,
+			baseURL,
+			[apiKeyFieldName]: apiKey,
+			defaultHeaders: this.options.anthropicCustomHeaders,
 			timeout: this.timeoutMs,
 		})
 	}
@@ -352,9 +358,14 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 	}
 
 	getModel() {
-		const modelId = this.options.apiModelId
-		const id = modelId && modelId in anthropicModels ? (modelId as AnthropicModelId) : anthropicDefaultModelId
-		let info: ModelInfo = anthropicModels[id]
+		const customModelId = this.options.anthropicCustomModelId
+		const modelId = customModelId || this.options.apiModelId
+		const id =
+			customModelId ||
+			(modelId && modelId in anthropicModels ? (modelId as AnthropicModelId) : anthropicDefaultModelId)
+		let info: ModelInfo = customModelId
+			? this.options.anthropicCustomModelInfo || openAiModelInfoSaneDefaults
+			: anthropicModels[id as AnthropicModelId]
 
 		// If 1M context beta is enabled for supported models, update the model info
 		if (

--- a/src/shared/ProfileValidator.ts
+++ b/src/shared/ProfileValidator.ts
@@ -53,6 +53,8 @@ export class ProfileValidator {
 		switch (profile.apiProvider) {
 			case "openai":
 				return profile.openAiModelId
+			case "anthropic-custom":
+				return profile.anthropicCustomModelId
 			case "anthropic":
 			case "openai-native":
 			case "bedrock":

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -48,6 +48,7 @@ import {
 
 import {
 	Anthropic,
+	AnthropicCustom,
 	Baseten,
 	Bedrock,
 	DeepSeek,
@@ -464,6 +465,16 @@ const ApiOptions = ({
 						<Anthropic
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
+							simplifySettings={fromWelcomeView}
+						/>
+					)}
+
+					{selectedProvider === "anthropic-custom" && (
+						<AnthropicCustom
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={modelValidationError}
 							simplifySettings={fromWelcomeView}
 						/>
 					)}

--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -32,6 +32,7 @@ type ModelIdKey = keyof Pick<
 	| "requestyModelId"
 	| "unboundModelId"
 	| "openAiModelId"
+	| "anthropicCustomModelId"
 	| "litellmModelId"
 	| "vercelAiGatewayModelId"
 	| "opencodeGoModelId"

--- a/webview-ui/src/components/settings/constants.ts
+++ b/webview-ui/src/components/settings/constants.ts
@@ -43,6 +43,7 @@ export const MODELS_BY_PROVIDER: Partial<Record<ProviderName, Record<string, Mod
 export const PROVIDERS = [
 	{ value: "openrouter", label: "OpenRouter", proxy: false },
 	{ value: "anthropic", label: "Anthropic", proxy: false },
+	{ value: "anthropic-custom", label: "Anthropic Custom", proxy: true },
 	{ value: "gemini", label: "Google Gemini", proxy: false },
 	{ value: "deepseek", label: "DeepSeek", proxy: false },
 	{ value: "moonshot", label: "Moonshot", proxy: false },

--- a/webview-ui/src/components/settings/providers/AnthropicCustom.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicCustom.tsx
@@ -1,14 +1,19 @@
-import { useState, useCallback, useEffect } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { Checkbox } from "vscrui"
-import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
-import { type ProviderSettings, type OrganizationAllowList, openAiModelInfoSaneDefaults } from "@roo-code/types"
+import {
+	type ProviderSettings,
+	type OrganizationAllowList,
+	anthropicModels,
+	openAiModelInfoSaneDefaults,
+} from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { Button, StandardTooltip } from "@src/components/ui"
+import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
 
-import { convertHeadersToObject } from "../utils/headers"
-import { inputEventTransform, noTransform } from "../transforms"
+import { inputEventTransform } from "../transforms"
 import { ModelPicker } from "../ModelPicker"
 
 type AnthropicCustomProps = {
@@ -23,6 +28,8 @@ type AnthropicCustomProps = {
 	simplifySettings?: boolean
 }
 
+const anthropicCustomDefaultModelId = "claude-sonnet-4-5"
+
 export const AnthropicCustom = ({
 	apiConfiguration,
 	setApiConfigurationField,
@@ -32,51 +39,20 @@ export const AnthropicCustom = ({
 }: AnthropicCustomProps) => {
 	const { t } = useAppTranslation()
 
-	const [customHeaders, setCustomHeaders] = useState<[string, string][]>(() => {
-		const headers = apiConfiguration?.anthropicCustomHeaders || {}
-		return Object.entries(headers)
-	})
-
-	const handleAddCustomHeader = useCallback(() => {
-		setCustomHeaders((prev) => [...prev, ["", ""]])
-	}, [])
-
-	const handleUpdateHeaderKey = useCallback((index: number, newKey: string) => {
-		setCustomHeaders((prev) => {
-			const updated = [...prev]
-
-			if (updated[index]) {
-				updated[index] = [newKey, updated[index][1]]
-			}
-
-			return updated
-		})
-	}, [])
-
-	const handleUpdateHeaderValue = useCallback((index: number, newValue: string) => {
-		setCustomHeaders((prev) => {
-			const updated = [...prev]
-
-			if (updated[index]) {
-				updated[index] = [updated[index][0], newValue]
-			}
-
-			return updated
-		})
-	}, [])
-
-	const handleRemoveCustomHeader = useCallback((index: number) => {
-		setCustomHeaders((prev) => prev.filter((_, i) => i !== index))
-	}, [])
+	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicCustomBaseUrl)
 
 	useEffect(() => {
-		const timer = setTimeout(() => {
-			const headerObject = convertHeadersToObject(customHeaders)
-			setApiConfigurationField("anthropicCustomHeaders", headerObject, false)
-		}, 300)
-
-		return () => clearTimeout(timer)
-	}, [customHeaders, setApiConfigurationField])
+		if (!apiConfiguration.anthropicCustomModelInfo) {
+			setApiConfigurationField(
+				"anthropicCustomModelInfo",
+				{
+					...openAiModelInfoSaneDefaults,
+					...(anthropicModels[anthropicCustomDefaultModelId] || {}),
+				},
+				false,
+			)
+		}
+	}, [apiConfiguration.anthropicCustomModelInfo, setApiConfigurationField])
 
 	const handleInputChange = useCallback(
 		<K extends keyof ProviderSettings, E>(
@@ -89,80 +65,74 @@ export const AnthropicCustom = ({
 		[setApiConfigurationField],
 	)
 
+	const getCustomModelInfo = () => apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults
+
 	return (
 		<>
-			<VSCodeTextField
-				value={apiConfiguration?.anthropicCustomBaseUrl || ""}
-				type="url"
-				onInput={handleInputChange("anthropicCustomBaseUrl")}
-				placeholder="https://api.anthropic.com"
-				className="w-full">
-				<label className="block font-medium mb-1">{t("settings:providers.openAiBaseUrl")}</label>
-			</VSCodeTextField>
 			<VSCodeTextField
 				value={apiConfiguration?.anthropicCustomApiKey || ""}
 				type="password"
 				onInput={handleInputChange("anthropicCustomApiKey")}
 				placeholder={t("settings:placeholders.apiKey")}
 				className="w-full">
-				<label className="block font-medium mb-1">{t("settings:providers.apiKey")}</label>
+				<label className="block font-medium mb-1">{t("settings:providers.anthropicApiKey")}</label>
 			</VSCodeTextField>
+			<div className="text-sm text-vscode-descriptionForeground -mt-2">
+				{t("settings:providers.apiKeyStorageNotice")}
+			</div>
+			{!apiConfiguration?.anthropicCustomApiKey && (
+				<VSCodeButtonLink href="https://console.anthropic.com/settings/keys" appearance="secondary">
+					{t("settings:providers.getAnthropicApiKey")}
+				</VSCodeButtonLink>
+			)}
+			<div>
+				<Checkbox
+					checked={anthropicBaseUrlSelected}
+					onChange={(checked: boolean) => {
+						setAnthropicBaseUrlSelected(checked)
+
+						if (!checked) {
+							setApiConfigurationField("anthropicCustomBaseUrl", "")
+						}
+					}}>
+					{t("settings:providers.useCustomBaseUrl")}
+				</Checkbox>
+				{anthropicBaseUrlSelected && (
+					<VSCodeTextField
+						value={apiConfiguration?.anthropicCustomBaseUrl || ""}
+						type="url"
+						onInput={handleInputChange("anthropicCustomBaseUrl")}
+						placeholder="https://api.anthropic.com"
+						className="w-full mt-1">
+						<label className="block font-medium mb-1">Base URL</label>
+					</VSCodeTextField>
+				)}
+			</div>
 			<ModelPicker
 				apiConfiguration={apiConfiguration}
-				setApiConfigurationField={setApiConfigurationField}
-				defaultModelId="claude-3-5-sonnet-20241022"
-				models={null}
+				setApiConfigurationField={(field, value, isUserAction) => {
+					setApiConfigurationField(field, value, isUserAction)
+
+					if (field === "anthropicCustomModelId") {
+						setApiConfigurationField(
+							"anthropicCustomModelInfo",
+							{
+								...openAiModelInfoSaneDefaults,
+								...(anthropicModels[value as keyof typeof anthropicModels] || {}),
+							},
+							false,
+						)
+					}
+				}}
+				defaultModelId={anthropicCustomDefaultModelId}
+				models={anthropicModels}
 				modelIdKey="anthropicCustomModelId"
-				serviceName="Anthropic Custom"
+				serviceName="Anthropic"
 				serviceUrl="https://docs.anthropic.com"
 				organizationAllowList={organizationAllowList}
 				errorMessage={modelValidationError}
 				simplifySettings={simplifySettings}
 			/>
-			<Checkbox
-				checked={apiConfiguration?.anthropicCustomStreamingEnabled ?? true}
-				onChange={handleInputChange("anthropicCustomStreamingEnabled", noTransform)}>
-				{t("settings:modelInfo.enableStreaming")}
-			</Checkbox>
-
-			{/* Custom Headers UI */}
-			<div className="mb-4">
-				<div className="flex justify-between items-center mb-2">
-					<label className="block font-medium">{t("settings:providers.customHeaders")}</label>
-					<StandardTooltip content={t("settings:common.add")}>
-						<VSCodeButton appearance="icon" onClick={handleAddCustomHeader}>
-							<span className="codicon codicon-add"></span>
-						</VSCodeButton>
-					</StandardTooltip>
-				</div>
-				{!customHeaders.length ? (
-					<div className="text-sm text-vscode-descriptionForeground">
-						{t("settings:providers.noCustomHeaders")}
-					</div>
-				) : (
-					customHeaders.map(([key, value], index) => (
-						<div key={index} className="flex items-center mb-2">
-							<VSCodeTextField
-								value={key}
-								className="flex-1 mr-2"
-								placeholder={t("settings:providers.headerName")}
-								onInput={(e: any) => handleUpdateHeaderKey(index, e.target.value)}
-							/>
-							<VSCodeTextField
-								value={value}
-								className="flex-1 mr-2"
-								placeholder={t("settings:providers.headerValue")}
-								onInput={(e: any) => handleUpdateHeaderValue(index, e.target.value)}
-							/>
-							<StandardTooltip content={t("settings:common.remove")}>
-								<VSCodeButton appearance="icon" onClick={() => handleRemoveCustomHeader(index)}>
-									<span className="codicon codicon-trash"></span>
-								</VSCodeButton>
-							</StandardTooltip>
-						</div>
-					))
-				)}
-			</div>
 
 			<div className="flex flex-col gap-3">
 				<div className="text-sm text-vscode-descriptionForeground whitespace-pre-line">
@@ -171,28 +141,13 @@ export const AnthropicCustom = ({
 
 				<div>
 					<VSCodeTextField
-						value={
-							apiConfiguration?.anthropicCustomModelInfo?.maxTokens?.toString() ||
-							openAiModelInfoSaneDefaults.maxTokens?.toString() ||
-							""
-						}
+						value={getCustomModelInfo().maxTokens?.toString() || ""}
 						type="text"
-						style={{
-							borderColor: (() => {
-								const value = apiConfiguration?.anthropicCustomModelInfo?.maxTokens
-
-								if (!value) {
-									return "var(--vscode-input-border)"
-								}
-
-								return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
-							})(),
-						}}
 						onInput={handleInputChange("anthropicCustomModelInfo", (e) => {
 							const value = parseInt((e.target as HTMLInputElement).value)
 
 							return {
-								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+								...getCustomModelInfo(),
 								maxTokens: isNaN(value) ? undefined : value,
 							}
 						})}
@@ -209,30 +164,14 @@ export const AnthropicCustom = ({
 
 				<div>
 					<VSCodeTextField
-						value={
-							apiConfiguration?.anthropicCustomModelInfo?.contextWindow?.toString() ||
-							openAiModelInfoSaneDefaults.contextWindow?.toString() ||
-							""
-						}
+						value={getCustomModelInfo().contextWindow?.toString() || ""}
 						type="text"
-						style={{
-							borderColor: (() => {
-								const value = apiConfiguration?.anthropicCustomModelInfo?.contextWindow
-
-								if (!value) {
-									return "var(--vscode-input-border)"
-								}
-
-								return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
-							})(),
-						}}
 						onInput={handleInputChange("anthropicCustomModelInfo", (e) => {
-							const value = (e.target as HTMLInputElement).value
-							const parsed = parseInt(value)
+							const value = parseInt((e.target as HTMLInputElement).value)
 
 							return {
-								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
-								contextWindow: isNaN(parsed) ? openAiModelInfoSaneDefaults.contextWindow : parsed,
+								...getCustomModelInfo(),
+								contextWindow: isNaN(value) ? openAiModelInfoSaneDefaults.contextWindow : value,
 							}
 						})}
 						placeholder={t("settings:placeholders.numbers.contextWindow")}
@@ -249,16 +188,11 @@ export const AnthropicCustom = ({
 				<div>
 					<div className="flex items-center gap-1">
 						<Checkbox
-							checked={
-								apiConfiguration?.anthropicCustomModelInfo?.supportsImages ??
-								openAiModelInfoSaneDefaults.supportsImages
-							}
-							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => {
-								return {
-									...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
-									supportsImages: checked,
-								}
-							})}>
+							checked={getCustomModelInfo().supportsImages ?? false}
+							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => ({
+								...getCustomModelInfo(),
+								supportsImages: checked,
+							}))}>
 							<span className="font-medium">
 								{t("settings:providers.customModel.imageSupport.label")}
 							</span>
@@ -270,21 +204,16 @@ export const AnthropicCustom = ({
 							/>
 						</StandardTooltip>
 					</div>
-					<div className="text-sm text-vscode-descriptionForeground pt-1">
-						{t("settings:providers.customModel.imageSupport.description")}
-					</div>
 				</div>
 
 				<div>
 					<div className="flex items-center gap-1">
 						<Checkbox
-							checked={apiConfiguration?.anthropicCustomModelInfo?.supportsPromptCache ?? false}
-							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => {
-								return {
-									...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
-									supportsPromptCache: checked,
-								}
-							})}>
+							checked={getCustomModelInfo().supportsPromptCache ?? false}
+							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => ({
+								...getCustomModelInfo(),
+								supportsPromptCache: checked,
+							}))}>
 							<span className="font-medium">{t("settings:providers.customModel.promptCache.label")}</span>
 						</Checkbox>
 						<StandardTooltip content={t("settings:providers.customModel.promptCache.description")}>
@@ -294,36 +223,17 @@ export const AnthropicCustom = ({
 							/>
 						</StandardTooltip>
 					</div>
-					<div className="text-sm text-vscode-descriptionForeground pt-1">
-						{t("settings:providers.customModel.promptCache.description")}
-					</div>
 				</div>
 
 				<div>
 					<VSCodeTextField
-						value={
-							apiConfiguration?.anthropicCustomModelInfo?.inputPrice?.toString() ??
-							openAiModelInfoSaneDefaults.inputPrice?.toString() ??
-							""
-						}
+						value={getCustomModelInfo().inputPrice?.toString() ?? ""}
 						type="text"
-						style={{
-							borderColor: (() => {
-								const value = apiConfiguration?.anthropicCustomModelInfo?.inputPrice
-
-								if (!value && value !== 0) {
-									return "var(--vscode-input-border)"
-								}
-
-								return value >= 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
-							})(),
-						}}
 						onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
-							const value = (e.target as HTMLInputElement).value
-							const parsed = parseFloat(value)
+							const parsed = parseFloat((e.target as HTMLInputElement).value)
 
 							return {
-								...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+								...getCustomModelInfo(),
 								inputPrice: isNaN(parsed) ? openAiModelInfoSaneDefaults.inputPrice : parsed,
 							}
 						})}
@@ -345,29 +255,13 @@ export const AnthropicCustom = ({
 
 				<div>
 					<VSCodeTextField
-						value={
-							apiConfiguration?.anthropicCustomModelInfo?.outputPrice?.toString() ||
-							openAiModelInfoSaneDefaults.outputPrice?.toString() ||
-							""
-						}
+						value={getCustomModelInfo().outputPrice?.toString() ?? ""}
 						type="text"
-						style={{
-							borderColor: (() => {
-								const value = apiConfiguration?.anthropicCustomModelInfo?.outputPrice
-
-								if (!value && value !== 0) {
-									return "var(--vscode-input-border)"
-								}
-
-								return value >= 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
-							})(),
-						}}
 						onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
-							const value = (e.target as HTMLInputElement).value
-							const parsed = parseFloat(value)
+							const parsed = parseFloat((e.target as HTMLInputElement).value)
 
 							return {
-								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+								...getCustomModelInfo(),
 								outputPrice: isNaN(parsed) ? openAiModelInfoSaneDefaults.outputPrice : parsed,
 							}
 						})}
@@ -387,90 +281,44 @@ export const AnthropicCustom = ({
 					</VSCodeTextField>
 				</div>
 
-				{apiConfiguration?.anthropicCustomModelInfo?.supportsPromptCache && (
+				{getCustomModelInfo().supportsPromptCache && (
 					<>
 						<div>
 							<VSCodeTextField
-								value={apiConfiguration?.anthropicCustomModelInfo?.cacheReadsPrice?.toString() ?? "0"}
+								value={getCustomModelInfo().cacheReadsPrice?.toString() ?? "0"}
 								type="text"
-								style={{
-									borderColor: (() => {
-										const value = apiConfiguration?.anthropicCustomModelInfo?.cacheReadsPrice
-
-										if (!value && value !== 0) {
-											return "var(--vscode-input-border)"
-										}
-
-										return value >= 0
-											? "var(--vscode-charts-green)"
-											: "var(--vscode-errorForeground)"
-									})(),
-								}}
 								onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
-									const value = (e.target as HTMLInputElement).value
-									const parsed = parseFloat(value)
+									const parsed = parseFloat((e.target as HTMLInputElement).value)
 
 									return {
-										...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+										...getCustomModelInfo(),
 										cacheReadsPrice: isNaN(parsed) ? 0 : parsed,
 									}
 								})}
 								placeholder={t("settings:placeholders.numbers.inputPrice")}
 								className="w-full">
-								<div className="flex items-center gap-1">
-									<span className="font-medium">
-										{t("settings:providers.customModel.pricing.cacheReads.label")}
-									</span>
-									<StandardTooltip
-										content={t("settings:providers.customModel.pricing.cacheReads.description")}>
-										<i
-											className="codicon codicon-info text-vscode-descriptionForeground"
-											style={{ fontSize: "12px" }}
-										/>
-									</StandardTooltip>
-								</div>
+								<span className="font-medium">
+									{t("settings:providers.customModel.pricing.cacheReads.label")}
+								</span>
 							</VSCodeTextField>
 						</div>
 						<div>
 							<VSCodeTextField
-								value={apiConfiguration?.anthropicCustomModelInfo?.cacheWritesPrice?.toString() ?? "0"}
+								value={getCustomModelInfo().cacheWritesPrice?.toString() ?? "0"}
 								type="text"
-								style={{
-									borderColor: (() => {
-										const value = apiConfiguration?.anthropicCustomModelInfo?.cacheWritesPrice
-
-										if (!value && value !== 0) {
-											return "var(--vscode-input-border)"
-										}
-
-										return value >= 0
-											? "var(--vscode-charts-green)"
-											: "var(--vscode-errorForeground)"
-									})(),
-								}}
 								onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
-									const value = (e.target as HTMLInputElement).value
-									const parsed = parseFloat(value)
+									const parsed = parseFloat((e.target as HTMLInputElement).value)
 
 									return {
-										...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+										...getCustomModelInfo(),
 										cacheWritesPrice: isNaN(parsed) ? 0 : parsed,
 									}
 								})}
 								placeholder={t("settings:placeholders.numbers.cacheWritePrice")}
 								className="w-full">
-								<div className="flex items-center gap-1">
-									<label className="block font-medium mb-1">
-										{t("settings:providers.customModel.pricing.cacheWrites.label")}
-									</label>
-									<StandardTooltip
-										content={t("settings:providers.customModel.pricing.cacheWrites.description")}>
-										<i
-											className="codicon codicon-info text-vscode-descriptionForeground"
-											style={{ fontSize: "12px" }}
-										/>
-									</StandardTooltip>
-								</div>
+								<label className="block font-medium mb-1">
+									{t("settings:providers.customModel.pricing.cacheWrites.label")}
+								</label>
 							</VSCodeTextField>
 						</div>
 					</>
@@ -478,7 +326,14 @@ export const AnthropicCustom = ({
 
 				<Button
 					variant="secondary"
-					onClick={() => setApiConfigurationField("anthropicCustomModelInfo", openAiModelInfoSaneDefaults)}>
+					onClick={() =>
+						setApiConfigurationField("anthropicCustomModelInfo", {
+							...openAiModelInfoSaneDefaults,
+							...(anthropicModels[
+								apiConfiguration.anthropicCustomModelId as keyof typeof anthropicModels
+							] || {}),
+						})
+					}>
 					{t("settings:providers.customModel.resetDefaults")}
 				</Button>
 			</div>

--- a/webview-ui/src/components/settings/providers/AnthropicCustom.tsx
+++ b/webview-ui/src/components/settings/providers/AnthropicCustom.tsx
@@ -1,0 +1,487 @@
+import { useState, useCallback, useEffect } from "react"
+import { Checkbox } from "vscrui"
+import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
+
+import { type ProviderSettings, type OrganizationAllowList, openAiModelInfoSaneDefaults } from "@roo-code/types"
+
+import { useAppTranslation } from "@src/i18n/TranslationContext"
+import { Button, StandardTooltip } from "@src/components/ui"
+
+import { convertHeadersToObject } from "../utils/headers"
+import { inputEventTransform, noTransform } from "../transforms"
+import { ModelPicker } from "../ModelPicker"
+
+type AnthropicCustomProps = {
+	apiConfiguration: ProviderSettings
+	setApiConfigurationField: <K extends keyof ProviderSettings>(
+		field: K,
+		value: ProviderSettings[K],
+		isUserAction?: boolean,
+	) => void
+	organizationAllowList: OrganizationAllowList
+	modelValidationError?: string
+	simplifySettings?: boolean
+}
+
+export const AnthropicCustom = ({
+	apiConfiguration,
+	setApiConfigurationField,
+	organizationAllowList,
+	modelValidationError,
+	simplifySettings,
+}: AnthropicCustomProps) => {
+	const { t } = useAppTranslation()
+
+	const [customHeaders, setCustomHeaders] = useState<[string, string][]>(() => {
+		const headers = apiConfiguration?.anthropicCustomHeaders || {}
+		return Object.entries(headers)
+	})
+
+	const handleAddCustomHeader = useCallback(() => {
+		setCustomHeaders((prev) => [...prev, ["", ""]])
+	}, [])
+
+	const handleUpdateHeaderKey = useCallback((index: number, newKey: string) => {
+		setCustomHeaders((prev) => {
+			const updated = [...prev]
+
+			if (updated[index]) {
+				updated[index] = [newKey, updated[index][1]]
+			}
+
+			return updated
+		})
+	}, [])
+
+	const handleUpdateHeaderValue = useCallback((index: number, newValue: string) => {
+		setCustomHeaders((prev) => {
+			const updated = [...prev]
+
+			if (updated[index]) {
+				updated[index] = [updated[index][0], newValue]
+			}
+
+			return updated
+		})
+	}, [])
+
+	const handleRemoveCustomHeader = useCallback((index: number) => {
+		setCustomHeaders((prev) => prev.filter((_, i) => i !== index))
+	}, [])
+
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			const headerObject = convertHeadersToObject(customHeaders)
+			setApiConfigurationField("anthropicCustomHeaders", headerObject, false)
+		}, 300)
+
+		return () => clearTimeout(timer)
+	}, [customHeaders, setApiConfigurationField])
+
+	const handleInputChange = useCallback(
+		<K extends keyof ProviderSettings, E>(
+			field: K,
+			transform: (event: E) => ProviderSettings[K] = inputEventTransform,
+		) =>
+			(event: E | Event) => {
+				setApiConfigurationField(field, transform(event as E))
+			},
+		[setApiConfigurationField],
+	)
+
+	return (
+		<>
+			<VSCodeTextField
+				value={apiConfiguration?.anthropicCustomBaseUrl || ""}
+				type="url"
+				onInput={handleInputChange("anthropicCustomBaseUrl")}
+				placeholder="https://api.anthropic.com"
+				className="w-full">
+				<label className="block font-medium mb-1">{t("settings:providers.openAiBaseUrl")}</label>
+			</VSCodeTextField>
+			<VSCodeTextField
+				value={apiConfiguration?.anthropicCustomApiKey || ""}
+				type="password"
+				onInput={handleInputChange("anthropicCustomApiKey")}
+				placeholder={t("settings:placeholders.apiKey")}
+				className="w-full">
+				<label className="block font-medium mb-1">{t("settings:providers.apiKey")}</label>
+			</VSCodeTextField>
+			<ModelPicker
+				apiConfiguration={apiConfiguration}
+				setApiConfigurationField={setApiConfigurationField}
+				defaultModelId="claude-3-5-sonnet-20241022"
+				models={null}
+				modelIdKey="anthropicCustomModelId"
+				serviceName="Anthropic Custom"
+				serviceUrl="https://docs.anthropic.com"
+				organizationAllowList={organizationAllowList}
+				errorMessage={modelValidationError}
+				simplifySettings={simplifySettings}
+			/>
+			<Checkbox
+				checked={apiConfiguration?.anthropicCustomStreamingEnabled ?? true}
+				onChange={handleInputChange("anthropicCustomStreamingEnabled", noTransform)}>
+				{t("settings:modelInfo.enableStreaming")}
+			</Checkbox>
+
+			{/* Custom Headers UI */}
+			<div className="mb-4">
+				<div className="flex justify-between items-center mb-2">
+					<label className="block font-medium">{t("settings:providers.customHeaders")}</label>
+					<StandardTooltip content={t("settings:common.add")}>
+						<VSCodeButton appearance="icon" onClick={handleAddCustomHeader}>
+							<span className="codicon codicon-add"></span>
+						</VSCodeButton>
+					</StandardTooltip>
+				</div>
+				{!customHeaders.length ? (
+					<div className="text-sm text-vscode-descriptionForeground">
+						{t("settings:providers.noCustomHeaders")}
+					</div>
+				) : (
+					customHeaders.map(([key, value], index) => (
+						<div key={index} className="flex items-center mb-2">
+							<VSCodeTextField
+								value={key}
+								className="flex-1 mr-2"
+								placeholder={t("settings:providers.headerName")}
+								onInput={(e: any) => handleUpdateHeaderKey(index, e.target.value)}
+							/>
+							<VSCodeTextField
+								value={value}
+								className="flex-1 mr-2"
+								placeholder={t("settings:providers.headerValue")}
+								onInput={(e: any) => handleUpdateHeaderValue(index, e.target.value)}
+							/>
+							<StandardTooltip content={t("settings:common.remove")}>
+								<VSCodeButton appearance="icon" onClick={() => handleRemoveCustomHeader(index)}>
+									<span className="codicon codicon-trash"></span>
+								</VSCodeButton>
+							</StandardTooltip>
+						</div>
+					))
+				)}
+			</div>
+
+			<div className="flex flex-col gap-3">
+				<div className="text-sm text-vscode-descriptionForeground whitespace-pre-line">
+					{t("settings:providers.customModel.capabilities")}
+				</div>
+
+				<div>
+					<VSCodeTextField
+						value={
+							apiConfiguration?.anthropicCustomModelInfo?.maxTokens?.toString() ||
+							openAiModelInfoSaneDefaults.maxTokens?.toString() ||
+							""
+						}
+						type="text"
+						style={{
+							borderColor: (() => {
+								const value = apiConfiguration?.anthropicCustomModelInfo?.maxTokens
+
+								if (!value) {
+									return "var(--vscode-input-border)"
+								}
+
+								return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+							})(),
+						}}
+						onInput={handleInputChange("anthropicCustomModelInfo", (e) => {
+							const value = parseInt((e.target as HTMLInputElement).value)
+
+							return {
+								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+								maxTokens: isNaN(value) ? undefined : value,
+							}
+						})}
+						placeholder={t("settings:placeholders.numbers.maxTokens")}
+						className="w-full">
+						<label className="block font-medium mb-1">
+							{t("settings:providers.customModel.maxTokens.label")}
+						</label>
+					</VSCodeTextField>
+					<div className="text-sm text-vscode-descriptionForeground">
+						{t("settings:providers.customModel.maxTokens.description")}
+					</div>
+				</div>
+
+				<div>
+					<VSCodeTextField
+						value={
+							apiConfiguration?.anthropicCustomModelInfo?.contextWindow?.toString() ||
+							openAiModelInfoSaneDefaults.contextWindow?.toString() ||
+							""
+						}
+						type="text"
+						style={{
+							borderColor: (() => {
+								const value = apiConfiguration?.anthropicCustomModelInfo?.contextWindow
+
+								if (!value) {
+									return "var(--vscode-input-border)"
+								}
+
+								return value > 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+							})(),
+						}}
+						onInput={handleInputChange("anthropicCustomModelInfo", (e) => {
+							const value = (e.target as HTMLInputElement).value
+							const parsed = parseInt(value)
+
+							return {
+								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+								contextWindow: isNaN(parsed) ? openAiModelInfoSaneDefaults.contextWindow : parsed,
+							}
+						})}
+						placeholder={t("settings:placeholders.numbers.contextWindow")}
+						className="w-full">
+						<label className="block font-medium mb-1">
+							{t("settings:providers.customModel.contextWindow.label")}
+						</label>
+					</VSCodeTextField>
+					<div className="text-sm text-vscode-descriptionForeground">
+						{t("settings:providers.customModel.contextWindow.description")}
+					</div>
+				</div>
+
+				<div>
+					<div className="flex items-center gap-1">
+						<Checkbox
+							checked={
+								apiConfiguration?.anthropicCustomModelInfo?.supportsImages ??
+								openAiModelInfoSaneDefaults.supportsImages
+							}
+							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => {
+								return {
+									...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+									supportsImages: checked,
+								}
+							})}>
+							<span className="font-medium">
+								{t("settings:providers.customModel.imageSupport.label")}
+							</span>
+						</Checkbox>
+						<StandardTooltip content={t("settings:providers.customModel.imageSupport.description")}>
+							<i
+								className="codicon codicon-info text-vscode-descriptionForeground"
+								style={{ fontSize: "12px" }}
+							/>
+						</StandardTooltip>
+					</div>
+					<div className="text-sm text-vscode-descriptionForeground pt-1">
+						{t("settings:providers.customModel.imageSupport.description")}
+					</div>
+				</div>
+
+				<div>
+					<div className="flex items-center gap-1">
+						<Checkbox
+							checked={apiConfiguration?.anthropicCustomModelInfo?.supportsPromptCache ?? false}
+							onChange={handleInputChange("anthropicCustomModelInfo", (checked) => {
+								return {
+									...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+									supportsPromptCache: checked,
+								}
+							})}>
+							<span className="font-medium">{t("settings:providers.customModel.promptCache.label")}</span>
+						</Checkbox>
+						<StandardTooltip content={t("settings:providers.customModel.promptCache.description")}>
+							<i
+								className="codicon codicon-info text-vscode-descriptionForeground"
+								style={{ fontSize: "12px" }}
+							/>
+						</StandardTooltip>
+					</div>
+					<div className="text-sm text-vscode-descriptionForeground pt-1">
+						{t("settings:providers.customModel.promptCache.description")}
+					</div>
+				</div>
+
+				<div>
+					<VSCodeTextField
+						value={
+							apiConfiguration?.anthropicCustomModelInfo?.inputPrice?.toString() ??
+							openAiModelInfoSaneDefaults.inputPrice?.toString() ??
+							""
+						}
+						type="text"
+						style={{
+							borderColor: (() => {
+								const value = apiConfiguration?.anthropicCustomModelInfo?.inputPrice
+
+								if (!value && value !== 0) {
+									return "var(--vscode-input-border)"
+								}
+
+								return value >= 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+							})(),
+						}}
+						onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
+							const value = (e.target as HTMLInputElement).value
+							const parsed = parseFloat(value)
+
+							return {
+								...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+								inputPrice: isNaN(parsed) ? openAiModelInfoSaneDefaults.inputPrice : parsed,
+							}
+						})}
+						placeholder={t("settings:placeholders.numbers.inputPrice")}
+						className="w-full">
+						<div className="flex items-center gap-1">
+							<label className="block font-medium mb-1">
+								{t("settings:providers.customModel.pricing.input.label")}
+							</label>
+							<StandardTooltip content={t("settings:providers.customModel.pricing.input.description")}>
+								<i
+									className="codicon codicon-info text-vscode-descriptionForeground"
+									style={{ fontSize: "12px" }}
+								/>
+							</StandardTooltip>
+						</div>
+					</VSCodeTextField>
+				</div>
+
+				<div>
+					<VSCodeTextField
+						value={
+							apiConfiguration?.anthropicCustomModelInfo?.outputPrice?.toString() ||
+							openAiModelInfoSaneDefaults.outputPrice?.toString() ||
+							""
+						}
+						type="text"
+						style={{
+							borderColor: (() => {
+								const value = apiConfiguration?.anthropicCustomModelInfo?.outputPrice
+
+								if (!value && value !== 0) {
+									return "var(--vscode-input-border)"
+								}
+
+								return value >= 0 ? "var(--vscode-charts-green)" : "var(--vscode-errorForeground)"
+							})(),
+						}}
+						onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
+							const value = (e.target as HTMLInputElement).value
+							const parsed = parseFloat(value)
+
+							return {
+								...(apiConfiguration?.anthropicCustomModelInfo || openAiModelInfoSaneDefaults),
+								outputPrice: isNaN(parsed) ? openAiModelInfoSaneDefaults.outputPrice : parsed,
+							}
+						})}
+						placeholder={t("settings:placeholders.numbers.outputPrice")}
+						className="w-full">
+						<div className="flex items-center gap-1">
+							<label className="block font-medium mb-1">
+								{t("settings:providers.customModel.pricing.output.label")}
+							</label>
+							<StandardTooltip content={t("settings:providers.customModel.pricing.output.description")}>
+								<i
+									className="codicon codicon-info text-vscode-descriptionForeground"
+									style={{ fontSize: "12px" }}
+								/>
+							</StandardTooltip>
+						</div>
+					</VSCodeTextField>
+				</div>
+
+				{apiConfiguration?.anthropicCustomModelInfo?.supportsPromptCache && (
+					<>
+						<div>
+							<VSCodeTextField
+								value={apiConfiguration?.anthropicCustomModelInfo?.cacheReadsPrice?.toString() ?? "0"}
+								type="text"
+								style={{
+									borderColor: (() => {
+										const value = apiConfiguration?.anthropicCustomModelInfo?.cacheReadsPrice
+
+										if (!value && value !== 0) {
+											return "var(--vscode-input-border)"
+										}
+
+										return value >= 0
+											? "var(--vscode-charts-green)"
+											: "var(--vscode-errorForeground)"
+									})(),
+								}}
+								onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
+									const value = (e.target as HTMLInputElement).value
+									const parsed = parseFloat(value)
+
+									return {
+										...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+										cacheReadsPrice: isNaN(parsed) ? 0 : parsed,
+									}
+								})}
+								placeholder={t("settings:placeholders.numbers.inputPrice")}
+								className="w-full">
+								<div className="flex items-center gap-1">
+									<span className="font-medium">
+										{t("settings:providers.customModel.pricing.cacheReads.label")}
+									</span>
+									<StandardTooltip
+										content={t("settings:providers.customModel.pricing.cacheReads.description")}>
+										<i
+											className="codicon codicon-info text-vscode-descriptionForeground"
+											style={{ fontSize: "12px" }}
+										/>
+									</StandardTooltip>
+								</div>
+							</VSCodeTextField>
+						</div>
+						<div>
+							<VSCodeTextField
+								value={apiConfiguration?.anthropicCustomModelInfo?.cacheWritesPrice?.toString() ?? "0"}
+								type="text"
+								style={{
+									borderColor: (() => {
+										const value = apiConfiguration?.anthropicCustomModelInfo?.cacheWritesPrice
+
+										if (!value && value !== 0) {
+											return "var(--vscode-input-border)"
+										}
+
+										return value >= 0
+											? "var(--vscode-charts-green)"
+											: "var(--vscode-errorForeground)"
+									})(),
+								}}
+								onChange={handleInputChange("anthropicCustomModelInfo", (e) => {
+									const value = (e.target as HTMLInputElement).value
+									const parsed = parseFloat(value)
+
+									return {
+										...(apiConfiguration?.anthropicCustomModelInfo ?? openAiModelInfoSaneDefaults),
+										cacheWritesPrice: isNaN(parsed) ? 0 : parsed,
+									}
+								})}
+								placeholder={t("settings:placeholders.numbers.cacheWritePrice")}
+								className="w-full">
+								<div className="flex items-center gap-1">
+									<label className="block font-medium mb-1">
+										{t("settings:providers.customModel.pricing.cacheWrites.label")}
+									</label>
+									<StandardTooltip
+										content={t("settings:providers.customModel.pricing.cacheWrites.description")}>
+										<i
+											className="codicon codicon-info text-vscode-descriptionForeground"
+											style={{ fontSize: "12px" }}
+										/>
+									</StandardTooltip>
+								</div>
+							</VSCodeTextField>
+						</div>
+					</>
+				)}
+
+				<Button
+					variant="secondary"
+					onClick={() => setApiConfigurationField("anthropicCustomModelInfo", openAiModelInfoSaneDefaults)}>
+					{t("settings:providers.customModel.resetDefaults")}
+				</Button>
+			</div>
+		</>
+	)
+}

--- a/webview-ui/src/components/settings/providers/index.ts
+++ b/webview-ui/src/components/settings/providers/index.ts
@@ -1,4 +1,5 @@
 export { Anthropic } from "./Anthropic"
+export { AnthropicCustom } from "./AnthropicCustom"
 export { Bedrock } from "./Bedrock"
 export { DeepSeek } from "./DeepSeek"
 export { Gemini } from "./Gemini"

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -370,8 +370,15 @@ function getSelectedModel({
 		// case "anthropic":
 		// case "fake-ai":
 		default: {
-			provider satisfies "anthropic" | "gemini-cli" | "fake-ai"
-			const id = apiConfiguration.apiModelId ?? defaultModelId
+			provider satisfies "anthropic" | "anthropic-custom" | "gemini-cli" | "fake-ai"
+			const id = apiConfiguration.apiModelId ?? apiConfiguration.anthropicCustomModelId ?? defaultModelId
+
+			// For anthropic-custom, use custom model info if available
+			if (provider === "anthropic-custom") {
+				const info = apiConfiguration.anthropicCustomModelInfo || undefined
+				return { id, info }
+			}
+
 			const baseInfo = anthropicModels[id as keyof typeof anthropicModels]
 
 			// Apply 1M context beta tier pricing for supported Claude 4 models

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -98,12 +98,11 @@ function validateModelsAndKeysProvided(
 			}
 			break
 		case "anthropic-custom":
-			if (
-				!apiConfiguration.anthropicCustomBaseUrl ||
-				!apiConfiguration.anthropicCustomApiKey ||
-				!apiConfiguration.anthropicCustomModelId
-			) {
-				return i18next.t("settings:validation.openAi")
+			if (!apiConfiguration.anthropicCustomApiKey) {
+				return i18next.t("settings:validation.apiKey")
+			}
+			if (!apiConfiguration.anthropicCustomModelId) {
+				return i18next.t("settings:validation.modelId")
 			}
 			break
 		case "ollama":

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -97,6 +97,15 @@ function validateModelsAndKeysProvided(
 				return i18next.t("settings:validation.openAi")
 			}
 			break
+		case "anthropic-custom":
+			if (
+				!apiConfiguration.anthropicCustomBaseUrl ||
+				!apiConfiguration.anthropicCustomApiKey ||
+				!apiConfiguration.anthropicCustomModelId
+			) {
+				return i18next.t("settings:validation.openAi")
+			}
+			break
 		case "ollama":
 			if (!apiConfiguration.ollamaModelId) {
 				return i18next.t("settings:validation.modelId")
@@ -193,6 +202,10 @@ function validateProviderAgainstOrganizationSettings(
 function getModelIdForProvider(apiConfiguration: ProviderSettings, provider: ProviderName): string | undefined {
 	if (provider === "vscode-lm") {
 		return apiConfiguration.vsCodeLmModelSelector?.id
+	}
+
+	if (provider === "anthropic-custom") {
+		return apiConfiguration.anthropicCustomModelId
 	}
 
 	if (isCustomProvider(provider) || isFauxProvider(provider)) {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #753

### Description

This PR adds a new **Anthropic Custom** provider that allows users to customize model parameters while using the Anthropic Messages API protocol. This addresses the limitation that the standard Anthropic provider doesn't allow customization of context window size and pricing.

**Key implementation details:**
- Added `anthropic-custom` to the provider list
- Reuses the existing `AnthropicHandler` with custom configuration fields
- Settings UI is simplified based on the Anthropic provider with additional customization options
- Base URL is optional (defaults to official Anthropic API endpoint when unchecked)
- Model picker uses the standard `anthropicModels` list
- Auto-populates model capabilities from selected model, allowing user overrides

**Changes made:**
1. Added new provider type `anthropic-custom` to provider settings
2. Added configuration fields: `anthropicCustomBaseUrl`, `anthropicCustomApiKey`, `anthropicCustomModelId`, `anthropicCustomModelInfo`, `anthropicCustomHeaders`
3. Modified `AnthropicHandler` to use custom fields when provider is `anthropic-custom`
4. Created `AnthropicCustom.tsx` settings component
5. Updated validation to only require API key and model ID
6. Updated `ModelPicker`, `ProfileValidator`, and routing logic

### Test Procedure

**Manual testing steps:**
1. Open Zoo Code settings
2. Select "Anthropic Custom" as the provider
3. Enter a valid Anthropic API key
4. Select a model from the dropdown (e.g., claude-3-5-sonnet-20241022)
5. Observe that model capabilities are auto-populated
6. Optionally check "Use custom Base URL" and enter a custom endpoint
7. Modify context window, max tokens, pricing as needed
8. Click "Save" - validation should pass with just API key and model ID
9. Start a conversation to verify the provider works correctly

**Testing environment:**
- Windows 11, VSCode
- Tested with real Anthropic API key
- Verified compilation and VSIX packaging

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (#753).
- [x] **Scope**: My changes are focused on the linked issue (adding Anthropic Custom provider).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: Manually tested the new provider with real API credentials.
- [x] **Documentation Impact**: No documentation updates required (feature is self-explanatory in UI).
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshots / Videos

_Settings UI showing Anthropic Custom provider with customizable options_
<img width="332" height="707" alt="image" src="https://github.com/user-attachments/assets/aaf80d76-8239-4a21-bff9-1704f8b793f7" />
<img width="342" height="729" alt="image" src="https://github.com/user-attachments/assets/5736c711-4480-488d-83b8-4ae5507949cf" />

### Documentation Updates

- [x] No documentation updates are required.

The feature is self-documenting through the UI with tooltips explaining each field.

### Additional Notes

This implementation intentionally reuses the existing `AnthropicHandler` to minimize code duplication and ensure consistency with the standard Anthropic provider. The custom headers field was added to the type definitions but the UI for it was removed in the final version to keep the interface simple.

### Get in Touch

Discord: g_avery114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new custom Anthropic provider option in settings.
  * Users can now configure a custom Anthropic API key, optional base URL, model, and advanced model details.

* **Bug Fixes**
  * Improved model selection and validation so the custom Anthropic provider uses the correct saved model and required credentials.
  * Fixed provider handling so the new option works throughout configuration, model picking, and API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->