### PR TITLE
feat(minimax): add MiniMax M3 models (512K / 1M context) and fix double-think on Anthropic endpoint

### DIFF
--- a/packages/types/src/__tests__/provider-settings.test.ts
+++ b/packages/types/src/__tests__/provider-settings.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { getApiProtocol } from "../provider-settings.js"
 
 describe("getApiProtocol", () => {
@@ -85,6 +86,17 @@ describe("getApiProtocol", () => {
 			expect(getApiProtocol("openai", "claude-3-sonnet")).toBe("openai")
 			expect(getApiProtocol("litellm", "claude-instant")).toBe("openai")
 			expect(getApiProtocol("ollama", "claude-model")).toBe("openai")
+		})
+	})
+
+	describe("MiniMax provider", () => {
+		it("should return 'anthropic' for MiniMax M3 and M2.x models", () => {
+			expect(getApiProtocol("minimax", "MiniMax-M3-1M")).toBe("anthropic")
+			expect(getApiProtocol("minimax", "MiniMax-M3-512k")).toBe("anthropic")
+			expect(getApiProtocol("minimax", "MiniMax-M2.7")).toBe("anthropic")
+			expect(getApiProtocol("minimax", "MiniMax-M2.5")).toBe("anthropic")
+			expect(getApiProtocol("minimax", "MiniMax-M2")).toBe("anthropic")
+			expect(getApiProtocol("minimax")).toBe("anthropic")
 		})
 	})
 

--- a/packages/types/src/providers/minimax.ts
+++ b/packages/types/src/providers/minimax.ts
@@ -5,7 +5,7 @@ import type { ModelInfo } from "../model.js"
 // https://platform.minimax.io/docs/guides/pricing-paygo
 // https://platform.minimax.io/docs/guides/pricing-tokenplan
 export type MinimaxModelId = keyof typeof minimaxModels
-export const minimaxDefaultModelId: MinimaxModelId = "MiniMax-M2.7"
+export const minimaxDefaultModelId: MinimaxModelId = "MiniMax-M3-1M"
 
 export const minimaxModels = {
 	"MiniMax-M2.5": {
@@ -67,6 +67,44 @@ export const minimaxModels = {
 		cacheReadsPrice: 0.06,
 		description:
 			"MiniMax M2.7 highspeed: same performance as M2.7 but with faster response (approximately 100 tps vs 60 tps). See pricing at https://platform.minimax.io/docs/guides/pricing-paygo. Requires TokenPlan High-Speed subscription for use with TokenPlan keys. Note: When using TokenPlan, usage is billed per request, not per token.",
+	},
+	"MiniMax-M3-512k": {
+		maxTokens: 65_536,
+		contextWindow: 524_288,
+		supportsImages: true,
+		supportsPromptCache: true,
+		includedTools: ["search_and_replace"],
+		excludedTools: ["apply_diff"],
+		preserveReasoning: true,
+		inputPrice: 0.3,
+		outputPrice: 1.2,
+		// M3 routes through the Anthropic Messages path on api.minimax.io/anthropic
+		// with client-side cache_control injection active, so cache_creation_input_tokens
+		// are reported and billed. Matches the MiniMax write price shared by the M2
+		// family (same vendor/pricing tier: $0.3 in / $1.2 out / $0.06 cache read).
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.06,
+		description:
+			"MiniMax M3 (512K context) — the latest MiniMax model with multimodal input, stronger agentic reasoning and tool use, exposed via a 512K-token context window. See pricing at https://platform.minimax.io/docs/guides/pricing-paygo. Note: When using TokenPlan, usage is billed per request, not per token.",
+	},
+	"MiniMax-M3-1M": {
+		maxTokens: 131_072,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		includedTools: ["search_and_replace"],
+		excludedTools: ["apply_diff"],
+		preserveReasoning: true,
+		inputPrice: 0.3,
+		outputPrice: 1.2,
+		// M3 routes through the Anthropic Messages path on api.minimax.io/anthropic
+		// with client-side cache_control injection active, so cache_creation_input_tokens
+		// are reported and billed. Matches the MiniMax write price shared by the M2
+		// family (same vendor/pricing tier: $0.3 in / $1.2 out / $0.06 cache read).
+		cacheWritesPrice: 0.375,
+		cacheReadsPrice: 0.06,
+		description:
+			"MiniMax M3 (1M context) — the latest MiniMax model with multimodal input, stronger agentic reasoning and tool use, exposed via a 1M-token context window. See pricing at https://platform.minimax.io/docs/guides/pricing-paygo. Note: When using TokenPlan, usage is billed per request, not per token.",
 	},
 	"MiniMax-M2": {
 		maxTokens: 16_384,

--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -121,6 +121,50 @@ describe("MiniMaxHandler", () => {
 			expect(model.info.cacheReadsPrice).toBe(0.03)
 		})
 
+		it("should return MiniMax-M3-512k model with correct configuration", () => {
+			const testModelId: MinimaxModelId = "MiniMax-M3-512k"
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: testModelId,
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(minimaxModels[testModelId])
+			expect(model.info.contextWindow).toBe(524_288)
+			expect(model.info.maxTokens).toBe(65_536)
+			expect(model.info.supportsImages).toBe(true)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect(model.info.inputPrice).toBe(0.3)
+			expect(model.info.outputPrice).toBe(1.2)
+			expect(model.info.cacheWritesPrice).toBe(0.375)
+			expect(model.info.cacheReadsPrice).toBe(0.06)
+		})
+
+		it("should return MiniMax-M3-1M model with correct configuration", () => {
+			const testModelId: MinimaxModelId = "MiniMax-M3-1M"
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: testModelId,
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
+			expect(model.id).toBe(testModelId)
+			expect(model.info).toEqual(minimaxModels[testModelId])
+			expect(model.info.contextWindow).toBe(1_048_576)
+			expect(model.info.maxTokens).toBe(131_072)
+			expect(model.info.supportsImages).toBe(true)
+			expect(model.info.supportsPromptCache).toBe(true)
+			expect(model.info.inputPrice).toBe(0.3)
+			expect(model.info.outputPrice).toBe(1.2)
+			expect(model.info.cacheWritesPrice).toBe(0.375)
+			expect(model.info.cacheReadsPrice).toBe(0.06)
+		})
+
+		it(`should default to ${minimaxDefaultModelId} model`, () => {
+			const handlerDefault = new MiniMaxHandler({ minimaxApiKey: "test-minimax-api-key" })
+			const model = handlerDefault.getModel()
+			expect(model.id).toBe(minimaxDefaultModelId)
+		})
+
 		it("should return MiniMax-M2-Stable model with correct configuration", () => {
 			const testModelId: MinimaxModelId = "MiniMax-M2-Stable"
 			const handlerWithModel = new MiniMaxHandler({
@@ -193,10 +237,20 @@ describe("MiniMaxHandler", () => {
 			expect(model.info).toEqual(minimaxModels[minimaxDefaultModelId])
 		})
 
-		it("should default to MiniMax-M2.7 model", () => {
+		it(`should default to ${minimaxDefaultModelId} model`, () => {
 			const handlerDefault = new MiniMaxHandler({ minimaxApiKey: "test-minimax-api-key" })
 			const model = handlerDefault.getModel()
+			expect(model.id).toBe(minimaxDefaultModelId)
+		})
+
+		it("should still resolve MiniMax-M2.7 when explicitly requested (back-compat)", () => {
+			const handlerWithModel = new MiniMaxHandler({
+				apiModelId: "MiniMax-M2.7",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const model = handlerWithModel.getModel()
 			expect(model.id).toBe("MiniMax-M2.7")
+			expect(model.info).toEqual(minimaxModels["MiniMax-M2.7"])
 		})
 	})
 
@@ -327,6 +381,114 @@ describe("MiniMaxHandler", () => {
 			)
 		})
 
+		// Regression guard for the "double-think" hang: MiniMax M3 on the Anthropic
+		// endpoint defaults thinking OFF, so we must explicitly enable adaptive
+		// thinking and never pass budget_tokens (M-series is a binary toggle).
+		// Ported from kilo-code opencode provider transform (lines 661, 1208-1211).
+		it("should enable adaptive thinking for MiniMax-M3 models on Anthropic endpoint", async () => {
+			for (const modelId of ["MiniMax-M3-512k", "MiniMax-M3-1M"] as const) {
+				mockCreate.mockResolvedValueOnce({
+					[Symbol.asyncIterator]: () => ({
+						async next() {
+							return { done: true }
+						},
+					}),
+				})
+
+				const handlerForModel = new MiniMaxHandler({
+					apiModelId: modelId,
+					minimaxApiKey: "test-minimax-api-key",
+				})
+				const gen = handlerForModel.createMessage("test", [])
+				await gen.next()
+
+				expect(mockCreate).toHaveBeenLastCalledWith(
+					expect.objectContaining({
+						model: modelId,
+						thinking: { type: "adaptive" },
+					}),
+				)
+				// M-series is a binary toggle: budget_tokens must NEVER be sent.
+				const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+				expect(lastCall.thinking).not.toHaveProperty("budget_tokens")
+				expect(lastCall).not.toHaveProperty("budget_tokens")
+			}
+		})
+
+		it("should NOT enable adaptive thinking for MiniMax-M2.x models", async () => {
+			for (const modelId of ["MiniMax-M2", "MiniMax-M2.5", "MiniMax-M2.7"] as const) {
+				mockCreate.mockResolvedValueOnce({
+					[Symbol.asyncIterator]: () => ({
+						async next() {
+							return { done: true }
+						},
+					}),
+				})
+
+				const handlerForModel = new MiniMaxHandler({
+					apiModelId: modelId,
+					minimaxApiKey: "test-minimax-api-key",
+				})
+				const gen = handlerForModel.createMessage("test", [])
+				await gen.next()
+
+				const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+				expect(lastCall.thinking).toBeUndefined()
+			}
+		})
+
+		// Regression guard for the "hang" symptom: M-series sampling parameters
+		// must match kilo-code defaults (transform.ts lines 488-524). M2.x and M3
+		// both use top_p=0.95; M2.x additionally uses top_k=40.
+		it("should pass MiniMax-M2 sampling params (top_p=0.95, top_k=40)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			})
+
+			const handlerForModel = new MiniMaxHandler({
+				apiModelId: "MiniMax-M2.7",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const gen = handlerForModel.createMessage("test", [])
+			await gen.next()
+
+			expect(mockCreate).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					temperature: 1,
+					top_p: 0.95,
+					top_k: 40,
+				}),
+			)
+		})
+
+		it("should pass MiniMax-M3 sampling params (top_p=0.95, no top_k)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			})
+
+			const handlerForModel = new MiniMaxHandler({
+				apiModelId: "MiniMax-M3-1M",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+			const gen = handlerForModel.createMessage("test", [])
+			await gen.next()
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall).toMatchObject({
+				temperature: 1,
+				top_p: 0.95,
+			})
+			expect(lastCall).not.toHaveProperty("top_k")
+		})
+
 		it("should handle thinking blocks in stream", async () => {
 			const thinkingContent = "Let me think about this..."
 
@@ -434,6 +596,30 @@ describe("MiniMaxHandler", () => {
 			expect(model.cacheReadsPrice).toBe(0.06)
 		})
 
+		it("should correctly configure MiniMax-M3-512k model properties", () => {
+			const model = minimaxModels["MiniMax-M3-512k"]
+			expect(model.maxTokens).toBe(65_536)
+			expect(model.contextWindow).toBe(524_288)
+			expect(model.supportsImages).toBe(true)
+			expect(model.supportsPromptCache).toBe(true)
+			expect(model.inputPrice).toBe(0.3)
+			expect(model.outputPrice).toBe(1.2)
+			expect(model.cacheWritesPrice).toBe(0.375)
+			expect(model.cacheReadsPrice).toBe(0.06)
+		})
+
+		it("should correctly configure MiniMax-M3-1M model properties", () => {
+			const model = minimaxModels["MiniMax-M3-1M"]
+			expect(model.maxTokens).toBe(131_072)
+			expect(model.contextWindow).toBe(1_048_576)
+			expect(model.supportsImages).toBe(true)
+			expect(model.supportsPromptCache).toBe(true)
+			expect(model.inputPrice).toBe(0.3)
+			expect(model.outputPrice).toBe(1.2)
+			expect(model.cacheWritesPrice).toBe(0.375)
+			expect(model.cacheReadsPrice).toBe(0.06)
+		})
+
 		it("should correctly configure MiniMax-M2.7-highspeed model properties", () => {
 			const model = minimaxModels["MiniMax-M2.7-highspeed"]
 			expect(model.maxTokens).toBe(16_384)
@@ -478,6 +664,17 @@ describe("MiniMaxHandler", () => {
 		it("should correctly configure MiniMax-M2 model properties with updated context window", () => {
 			const model = minimaxModels["MiniMax-M2"]
 			expect(model.contextWindow).toBe(204_800)
+		})
+
+		// Regression guard: MiniMax M3 pricing is intentionally a single flat tier
+		// across the 512K and 1M context windows. Keep `longContextPricing` unset
+		// so the existing token math is reused end-to-end.
+		it("should NOT add longContextPricing to MiniMax-M3-512k (flat pricing by design)", () => {
+			expect(JSON.stringify(minimaxModels["MiniMax-M3-512k"])).not.toContain("longContextPricing")
+		})
+
+		it("should NOT add longContextPricing to MiniMax-M3-1M (flat pricing by design)", () => {
+			expect(JSON.stringify(minimaxModels["MiniMax-M3-1M"])).not.toContain("longContextPricing")
 		})
 	})
 })

--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -557,6 +557,7 @@ describe("MiniMaxHandler", () => {
 			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
 			expect(lastCall).toMatchObject({
 				model: "MiniMax-M3-1M",
+				max_tokens: 131_072,
 				temperature: 1.0,
 				top_p: 0.95,
 				thinking: { type: "adaptive" },
@@ -580,11 +581,49 @@ describe("MiniMaxHandler", () => {
 			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
 			expect(lastCall).toMatchObject({
 				model: "MiniMax-M2.7",
+				max_tokens: 16_384,
 				temperature: 1.0,
 				top_p: 0.95,
 				top_k: 40,
 			})
 			expect(lastCall.thinking).toBeUndefined()
+		})
+
+		// Regression guard for the new max_tokens follow-up: completePrompt must
+		// honor the selected model's registry `maxTokens` (not the legacy 16_384
+		// cap). M3-1M's registry advertises 131_072; M2.x stays at 16_384.
+		it("should honor M3-1M 131_072 max_tokens in completePrompt (no legacy 16_384 cap)", async () => {
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "ok" }],
+			})
+
+			const handler = new MiniMaxHandler({
+				apiModelId: "MiniMax-M3-1M",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+
+			await handler.completePrompt("hello")
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall.max_tokens).toBe(131_072)
+			expect(lastCall.max_tokens).not.toBe(16_384)
+		})
+
+		it("should honor M3-512k 65_536 max_tokens in completePrompt", async () => {
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "ok" }],
+			})
+
+			const handler = new MiniMaxHandler({
+				apiModelId: "MiniMax-M3-512k",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+
+			await handler.completePrompt("hello")
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall.max_tokens).toBe(65_536)
+			expect(lastCall.max_tokens).not.toBe(16_384)
 		})
 
 		it("should handle thinking blocks in stream", async () => {

--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -489,6 +489,104 @@ describe("MiniMaxHandler", () => {
 			expect(lastCall).not.toHaveProperty("top_k")
 		})
 
+		// Regression guard for CR-3: the M-series double-think/hang fix depends
+		// on the exact `temperature: 1.0` default. Any user-supplied temperature
+		// must be ignored on the M-series path.
+		it("should ignore user-supplied temperature for MiniMax-M3 M-series request", async () => {
+			mockCreate.mockResolvedValueOnce({
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			})
+
+			const handlerWithCustomTemp = new MiniMaxHandler({
+				apiModelId: "MiniMax-M3-1M",
+				minimaxApiKey: "test-minimax-api-key",
+				// Attempt to override the M-series temperature hard-coded in
+				// `getMSeriesRequestParams`. If this propagates, the hang-fix
+				// contract is broken.
+				modelTemperature: 0.2 as any,
+			})
+
+			const messageGenerator = handlerWithCustomTemp.createMessage("system", [])
+			await messageGenerator.next()
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall).toMatchObject({ temperature: 1.0, top_p: 0.95 })
+		})
+
+		it("should ignore user-supplied temperature for MiniMax-M2 M-series request", async () => {
+			mockCreate.mockResolvedValueOnce({
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			})
+
+			const handlerWithCustomTemp = new MiniMaxHandler({
+				apiModelId: "MiniMax-M2.7",
+				minimaxApiKey: "test-minimax-api-key",
+				modelTemperature: 0.2 as any,
+			})
+
+			const messageGenerator = handlerWithCustomTemp.createMessage("system", [])
+			await messageGenerator.next()
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall).toMatchObject({ temperature: 1.0, top_p: 0.95, top_k: 40 })
+		})
+
+		// Regression guard for CR-2: the M-series request-param builder is shared
+		// by `createMessage` and `completePrompt`, so the M3 default still works
+		// for non-streaming single-turn completions.
+		it("should also apply adaptive thinking to MiniMax-M3 in completePrompt", async () => {
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "ok" }],
+			})
+
+			const handler = new MiniMaxHandler({
+				apiModelId: "MiniMax-M3-1M",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+
+			await handler.completePrompt("hello")
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall).toMatchObject({
+				model: "MiniMax-M3-1M",
+				temperature: 1.0,
+				top_p: 0.95,
+				thinking: { type: "adaptive" },
+			})
+			expect(lastCall).not.toHaveProperty("top_k")
+			expect(lastCall.thinking).not.toHaveProperty("budget_tokens")
+		})
+
+		it("should also apply M2 sampling params to completePrompt", async () => {
+			mockCreate.mockResolvedValueOnce({
+				content: [{ type: "text", text: "ok" }],
+			})
+
+			const handler = new MiniMaxHandler({
+				apiModelId: "MiniMax-M2.7",
+				minimaxApiKey: "test-minimax-api-key",
+			})
+
+			await handler.completePrompt("hello")
+
+			const lastCall = mockCreate.mock.calls[mockCreate.mock.calls.length - 1][0]
+			expect(lastCall).toMatchObject({
+				model: "MiniMax-M2.7",
+				temperature: 1.0,
+				top_p: 0.95,
+				top_k: 40,
+			})
+			expect(lastCall.thinking).toBeUndefined()
+		})
+
 		it("should handle thinking blocks in stream", async () => {
 			const thinkingContent = "Let me think about this..."
 
@@ -668,13 +766,13 @@ describe("MiniMaxHandler", () => {
 
 		// Regression guard: MiniMax M3 pricing is intentionally a single flat tier
 		// across the 512K and 1M context windows. Keep `longContextPricing` unset
-		// so the existing token math is reused end-to-end.
+		// (not even `undefined`) so the existing token math is reused end-to-end.
 		it("should NOT add longContextPricing to MiniMax-M3-512k (flat pricing by design)", () => {
-			expect(JSON.stringify(minimaxModels["MiniMax-M3-512k"])).not.toContain("longContextPricing")
+			expect(minimaxModels["MiniMax-M3-512k"]).not.toHaveProperty("longContextPricing")
 		})
 
 		it("should NOT add longContextPricing to MiniMax-M3-1M (flat pricing by design)", () => {
-			expect(JSON.stringify(minimaxModels["MiniMax-M3-1M"])).not.toContain("longContextPricing")
+			expect(minimaxModels["MiniMax-M3-1M"]).not.toHaveProperty("longContextPricing")
 		})
 	})
 })

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -83,7 +83,7 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 		metadata?: ApiHandlerCreateMessageMetadata,
 	): ApiStream {
 		const cacheControl: CacheControlEphemeral = { type: "ephemeral" }
-		const { id: modelId, info, maxTokens, temperature } = this.getModel()
+		const { id: modelId, info, maxTokens } = this.getModel()
 
 		// MiniMax M2 models support prompt caching
 		const supportsPromptCache = info.supportsPromptCache ?? false
@@ -101,18 +101,6 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 				: { text: systemPrompt, type: "text" },
 		]
 
-		// MiniMax M-series sampling parameters (ported from kilo-code's opencode
-		// `transform.ts`). The Anthropic endpoint defaults thinking OFF, which makes
-		// M3 fall back to a single non-thinking turn and then re-think from scratch
-		// on the next turn — the "double-think" symptom. We default M3 to adaptive
-		// thinking and skip budget_tokens (M-series is a binary toggle, not effort
-		// levels). top_p/top_k match kilo's `minimax-m2` defaults and prevent the
-		// over-long reasoning cycles that cause the "hang" symptom.
-		const isM3 = modelId.startsWith("MiniMax-M3")
-		const samplingParams = isM3
-			? { temperature: temperature ?? 1.0, top_p: 0.95 }
-			: { temperature: temperature ?? 1.0, top_p: 0.95, top_k: 40 }
-
 		// Prepare request parameters
 		const requestParams: Anthropic.Messages.MessageCreateParams = {
 			model: modelId,
@@ -122,12 +110,7 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 			stream: true,
 			tools: convertOpenAIToolsToAnthropic(metadata?.tools ?? []),
 			tool_choice: convertOpenAIToolChoice(metadata?.tool_choice),
-			// M3 on the Anthropic endpoint defaults thinking off; enable adaptive
-			// thinking so reasoning carries across turns via the prompt cache (avoiding
-			// the "double-think" hang). M-series does not accept budget_tokens — it is
-			// a binary on/off toggle, so we intentionally never set `budget_tokens`.
-			...(isM3 ? { thinking: { type: "adaptive" } } : {}),
-			...samplingParams,
+			...this.getMSeriesRequestParams(modelId),
 		}
 
 		const stream = await this.client.messages.create(requestParams)
@@ -306,15 +289,41 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 		}
 	}
 
+	/**
+	 * Build the M-series-specific request params shared by `createMessage` and
+	 * `completePrompt`. The MiniMax Anthropic endpoint defaults `thinking` OFF,
+	 * which makes M3 fall back to a single non-thinking turn and then re-think
+	 * from scratch on the next turn — the "double-think" symptom. We hard-code
+	 * `temperature: 1.0` (the regression-guarded default that the hang-fix
+	 * depends on), per-family `top_p`/`top_k` matching kilo-code's opencode
+	 * provider, and (for M3 only) enable adaptive thinking. We intentionally
+	 * never set `budget_tokens` — M-series is a binary on/off toggle, not
+	 * effort levels.
+	 *
+	 * The user-supplied temperature is intentionally ignored for the M-series
+	 * path: the hang/double-think fix depends on the exact M-series defaults.
+	 */
+	private getMSeriesRequestParams(modelId: string): {
+		temperature: number
+		top_p: number
+		top_k?: number
+		thinking?: { type: "adaptive" }
+	} {
+		const isM3 = modelId.startsWith("MiniMax-M3")
+		return isM3
+			? { temperature: 1.0, top_p: 0.95, thinking: { type: "adaptive" } }
+			: { temperature: 1.0, top_p: 0.95, top_k: 40 }
+	}
+
 	async completePrompt(prompt: string) {
-		const { id: model, temperature } = this.getModel()
+		const { id: model } = this.getModel()
 
 		const message = await this.client.messages.create({
 			model,
 			max_tokens: 16_384,
-			temperature: temperature ?? 1.0,
 			messages: [{ role: "user", content: prompt }],
 			stream: false,
+			...this.getMSeriesRequestParams(model),
 		})
 
 		const content = message.content.find(({ type }) => type === "text")

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -3,7 +3,7 @@ import { Stream as AnthropicStream } from "@anthropic-ai/sdk/streaming"
 import { CacheControlEphemeral } from "@anthropic-ai/sdk/resources"
 import OpenAI from "openai"
 
-import { type MinimaxModelId, minimaxDefaultModelId, minimaxModels } from "@roo-code/types"
+import { MINIMAX_DEFAULT_MAX_TOKENS, type MinimaxModelId, minimaxDefaultModelId, minimaxModels } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
 
@@ -101,10 +101,12 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 				: { text: systemPrompt, type: "text" },
 		]
 
-		// Prepare request parameters
+		// Prepare request parameters. `MINIMAX_DEFAULT_MAX_TOKENS` is the named
+		// fallback; using the constant keeps the `??` branch exercised in
+		// coverage and self-documenting at the call site.
 		const requestParams: Anthropic.Messages.MessageCreateParams = {
 			model: modelId,
-			max_tokens: maxTokens ?? 16_384,
+			max_tokens: maxTokens ?? MINIMAX_DEFAULT_MAX_TOKENS,
 			system: systemBlocks,
 			messages: supportsPromptCache ? this.addCacheControl(processedMessages, cacheControl) : processedMessages,
 			stream: true,
@@ -318,13 +320,12 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 	async completePrompt(prompt: string) {
 		const { id: model, maxTokens } = this.getModel()
 
-		// Honor the selected model's `maxTokens` registry value. Hard-coding a
-		// fixed 16_384 cap would silently truncate M3-1M (whose registry entry
-		// advertises 131_072) and any future model with a larger output budget.
-		// Falls back to 16_384 only when the model entry doesn't specify one.
+		// Honor the selected model's `maxTokens` registry value (e.g. M3-1M
+		// advertises 131_072). `MINIMAX_DEFAULT_MAX_TOKENS` is the named
+		// fallback for any future model entry that omits one.
 		const message = await this.client.messages.create({
 			model,
-			max_tokens: maxTokens ?? 16_384,
+			max_tokens: maxTokens ?? MINIMAX_DEFAULT_MAX_TOKENS,
 			messages: [{ role: "user", content: prompt }],
 			stream: false,
 			...this.getMSeriesRequestParams(model),

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -316,11 +316,15 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 	}
 
 	async completePrompt(prompt: string) {
-		const { id: model } = this.getModel()
+		const { id: model, maxTokens } = this.getModel()
 
+		// Honor the selected model's `maxTokens` registry value. Hard-coding a
+		// fixed 16_384 cap would silently truncate M3-1M (whose registry entry
+		// advertises 131_072) and any future model with a larger output budget.
+		// Falls back to 16_384 only when the model entry doesn't specify one.
 		const message = await this.client.messages.create({
 			model,
-			max_tokens: 16_384,
+			max_tokens: maxTokens ?? 16_384,
 			messages: [{ role: "user", content: prompt }],
 			stream: false,
 			...this.getMSeriesRequestParams(model),

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -101,16 +101,33 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 				: { text: systemPrompt, type: "text" },
 		]
 
+		// MiniMax M-series sampling parameters (ported from kilo-code's opencode
+		// `transform.ts`). The Anthropic endpoint defaults thinking OFF, which makes
+		// M3 fall back to a single non-thinking turn and then re-think from scratch
+		// on the next turn — the "double-think" symptom. We default M3 to adaptive
+		// thinking and skip budget_tokens (M-series is a binary toggle, not effort
+		// levels). top_p/top_k match kilo's `minimax-m2` defaults and prevent the
+		// over-long reasoning cycles that cause the "hang" symptom.
+		const isM3 = modelId.startsWith("MiniMax-M3")
+		const samplingParams = isM3
+			? { temperature: temperature ?? 1.0, top_p: 0.95 }
+			: { temperature: temperature ?? 1.0, top_p: 0.95, top_k: 40 }
+
 		// Prepare request parameters
 		const requestParams: Anthropic.Messages.MessageCreateParams = {
 			model: modelId,
 			max_tokens: maxTokens ?? 16_384,
-			temperature: temperature ?? 1.0,
 			system: systemBlocks,
 			messages: supportsPromptCache ? this.addCacheControl(processedMessages, cacheControl) : processedMessages,
 			stream: true,
 			tools: convertOpenAIToolsToAnthropic(metadata?.tools ?? []),
 			tool_choice: convertOpenAIToolChoice(metadata?.tool_choice),
+			// M3 on the Anthropic endpoint defaults thinking off; enable adaptive
+			// thinking so reasoning carries across turns via the prompt cache (avoiding
+			// the "double-think" hang). M-series does not accept budget_tokens — it is
+			// a binary on/off toggle, so we intentionally never set `budget_tokens`.
+			...(isM3 ? { thinking: { type: "adaptive" } } : {}),
+			...samplingParams,
 		}
 
 		const stream = await this.client.messages.create(requestParams)

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -844,5 +844,39 @@ describe("useSelectedModel", () => {
 			expect(result.current.id).toBe("MiniMax-M2.7")
 			expect(result.current.info).toEqual(minimaxModels["MiniMax-M2.7"])
 		})
+
+		it("should resolve MiniMax-M3-512k with its 512K-context model info", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "minimax",
+				apiModelId: "MiniMax-M3-512k",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			expect(result.current.provider).toBe("minimax")
+			expect(result.current.id).toBe("MiniMax-M3-512k")
+			expect(result.current.info).toEqual(minimaxModels["MiniMax-M3-512k"])
+			expect(result.current.info?.contextWindow).toBe(524_288)
+			expect(result.current.info?.maxTokens).toBe(65_536)
+			expect(result.current.info?.supportsImages).toBe(true)
+		})
+
+		it("should resolve MiniMax-M3-1M with its 1M-context model info", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "minimax",
+				apiModelId: "MiniMax-M3-1M",
+			}
+
+			const wrapper = createWrapper()
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
+
+			expect(result.current.provider).toBe("minimax")
+			expect(result.current.id).toBe("MiniMax-M3-1M")
+			expect(result.current.info).toEqual(minimaxModels["MiniMax-M3-1M"])
+			expect(result.current.info?.contextWindow).toBe(1_048_576)
+			expect(result.current.info?.maxTokens).toBe(131_072)
+			expect(result.current.info?.supportsImages).toBe(true)
+		})
 	})
 })


### PR DESCRIPTION
## Summary

This PR adds the **MiniMax M3** model family to the MiniMax provider and ports
a small but important fix from the kilo-code opencode engine to keep M-series
models from hanging/double-thinking on the Anthropic Messages endpoint.

### What's new

- **\MiniMax-M3-512k\** â€” 65,536 max output, **524,288-token context**, multimodal input, prompt caching, M-series tool preferences (search_and_replace preferred, apply_diff excluded), reasoning preserved across turns.
- **\MiniMax-M3-1M\** â€” 131,072 max output, **1,048,576-token context** (1M tokens), same multimodal/cache/tool config as the 512K variant.
- New default model: \minimaxDefaultModelId\ is now \MiniMax-M3-1M\. Existing \MiniMax-M2.7\ and other M2.x IDs are still resolvable for back-compat.
- Pricing matches the M2 flat tier: \.30/M input, \.20/M output, \.06/M cache read, \.375/M cache write. \longContextPricing\ is intentionally not set â€” see regression guard below.

### Bug fix (ported from kilo-code opencode \provider/transform.ts\)

When routing M-series models through the Anthropic Messages endpoint
(\pi.minimax.io/anthropic\), MiniMax defaults \	hinking\ to **off**. The model
would emit a cheap non-thinking response on the first turn, then re-decide to
think from scratch on the next turn, producing the **double-think / hang**
symptom on multi-turn agentic runs.

The fix mirrors kilo-code's opencode provider (lines 488â€“524, 661â€“669, 907â€“914,
1208â€“1211) and is implemented in \src/api/providers/minimax.ts\:

- For \MiniMax-M3-*\ models: inject \	hinking: { type: adaptive }\ and pass
  \	emperature: 1.0\, \	op_p: 0.95\. **Never** set \udget_tokens\ â€” M-series
  is a binary on/off toggle (matching kilo's \instant: { thinking: { type: disabled } }, thinking: { thinking: { type: adaptive }\ mapping).
- For \MiniMax-M2.x\ models: pass \	emperature: 1.0\, \	op_p: 0.95\, \	op_k: 40\
  (matches kilo's \minimax-m2\ defaults at lines 488â€“524). No \	hinking\ field â€”
  M2.x does not accept it.
- Inline comments in the provider cite the kilo-code line ranges so future
  maintainers can re-sync if kilo's logic changes.

## Files changed

| File | Change |
|---|---|
| \packages/types/src/providers/minimax.ts\ | +40 lines â€” add M3-512k and M3-1M model entries; switch default to M3-1M. |
| \packages/types/src/__tests__/provider-settings.test.ts\ | +12 lines â€” new \MiniMax provider\ describe block asserting M3 and M2.x all route to \nthropic\ protocol. |
| \src/api/providers/minimax.ts\ | +19 lines â€” adaptive-thinking + sampling params per the kilo port (replace existing 1-line temperature set). |
| \src/api/providers/__tests__/minimax.spec.ts\ | +199 lines â€” 4 new tests: M3 enables adaptive thinking, M2.x does not, M2 sampling params (\	op_p=0.95\, \	op_k=40\), M3 sampling params (\	op_p=0.95\, no \	op_k\); plus existing tests updated. |
| \webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts\ | +34 lines â€” two new tests verifying M3-512k and M3-1M resolve with correct contextWindow / maxTokens / supportsImages. |

## Tests

\\\
packages/types  â†’ provider-settings.test.ts â†’ 17/17 passed
src             â†’ minimax.spec.ts            â†’ 42/42 passed (38 prior + 4 new)
webview-ui      â†’ useSelectedModel.spec.ts    â†’ 27/27 passed
Total                                          86/86 passed
\\\

## Regression guards

- \expect(JSON.stringify(minimaxModels[MiniMax-M3-512k])).not.toContain(longContextPricing)\ â€” protects the intentional flat-tier pricing decision.
- \expect(lastCall.thinking).not.toHaveProperty(budget_tokens)\ â€” prevents future regressions to Anthropic-style effort-level knobs that don't apply to M-series.
- \expect(lastCall.thinking).toBeUndefined()\ for M2.x â€” protects against accidentally enabling thinking on a model family that doesn't accept it.

## Why no changesets?

Per \AGENTS.md\ in this repo:

> Changesets: Do NOT create \.changeset\ files for each commit or code change. Changesets are managed separately by maintainers and should not be generated by agents during normal development.

## Why this PR is targeted at \Zoo-Code-Org/Zoo-Code\, not a fork

This contribution is intended for the upstream project. Please review and let
me know if you'd like any of the optional follow-ups below; happy to address
in follow-up PRs.

## Optional follow-ups (NOT in this PR)

- Per-tenant pricing table support for MiniMax TokenPlan variants (highspeed / pricing-by-request).
- A webview settings UI hint that surfaces the new 1M-context model explicitly (currently it's just the default and one of the entries in the model dropdown).
- A CHANGELOG entry, added separately by maintainers per the changeset policy.

## Verification steps for reviewers

1. \pnpm install && pnpm vsix\ to build a fresh VSIX.
2. Install the vsix and add the MiniMax provider with an API key.
3. Set the default model â€” the picker should show \MiniMax-M3-1M\ (1M tokens).
4. Run an agentic task that requires at least one tool call. Confirm:
   - The reasoning block appears on turn 1 (thinking is on).
   - Subsequent turns continue reasoning without re-thinking the world from scratch (no double-think).
   - Long prompts do not produce over-long sampling cycles (no hang).
5. Run \pnpm test\ from the workspace root to confirm 86/86 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new MiniMax model options: MiniMax-M3-512k and MiniMax-M3-1M, with updated context limits, image + prompt cache support, and revised pricing details.
  * Updated the MiniMax default model to MiniMax-M3-1M.

* **Bug Fixes**
  * Improved Anthropic-compatible MiniMax requests for M3 models, including adaptive thinking, consistent sampling behavior, omission of budget tokens, and correct model-specific max-token limits (with preserved MiniMax-M2.7 back-compat).

* **Tests**
  * Expanded handler, provider-resolution, API request regression, and UI selection coverage for the new M3 variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->