### PR TITLE
fix(gemini): base64-encode thoughtSignature bypass token to fix Vertex AI empty-response loop

### DIFF
--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -54,6 +54,215 @@ describe("GeminiHandler", () => {
 		})
 	})
 
+	describe("thoughtSignature round-trip (issue #536)", () => {
+		const systemPrompt = "You are a helpful assistant"
+		const toolMetadata = { tools: [{ function: { name: "read_file", description: "", parameters: {} } }] } as any
+
+		// Helper: build a mock async-iterable stream from chunks
+		function makeStream(chunks: unknown[]) {
+			return {
+				[Symbol.asyncIterator]: async function* () {
+					for (const chunk of chunks) yield chunk
+				},
+			}
+		}
+
+		// Simulate a Gemini 3.x response: thoughtSignature arrives on its own part,
+		// alongside a functionCall part (the way the real Gemini 3 API returns it).
+		const turn1Response = makeStream([
+			{
+				candidates: [
+					{
+						content: {
+							parts: [
+								{ thought: true, text: "thinking…" },
+								{ functionCall: { name: "read_file", args: { path: "foo.ts" } } },
+								{ thoughtSignature: "sig-abc123" },
+							],
+						},
+					},
+				],
+			},
+			{ usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 } },
+		])
+
+		it("captures thoughtSignature from the stream after turn 1", async () => {
+			;(handler["client"].models.generateContentStream as any).mockResolvedValue(turn1Response)
+
+			const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "Read foo.ts" }]
+
+			for await (const _chunk of handler.createMessage(systemPrompt, messages, toolMetadata)) {
+				// drain
+			}
+
+			expect(handler.getThoughtSignature()).toBe("sig-abc123")
+		})
+
+		it("sends thoughtSignature from history on turn 2 (core regression)", async () => {
+			// This is the bug from issue #536: after turn 1 the thoughtSignature block is
+			// persisted into apiConversationHistory. On turn 2 the handler must include it
+			// in the outgoing request, otherwise Gemini 3.x returns an empty response.
+			const historyAfterTurn1: Anthropic.Messages.MessageParam[] = [
+				{ role: "user", content: "Read foo.ts" },
+				{
+					role: "assistant",
+					// assistant turn as stored by prepareApiConversationMessage:
+					// tool_use block + appended thoughtSignature block
+					content: [
+						{ type: "tool_use", id: "call-1", name: "read_file", input: { path: "foo.ts" } },
+						{ type: "thoughtSignature", thoughtSignature: "sig-abc123" } as any,
+					],
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "call-1", content: "file contents here" }],
+				},
+			]
+
+			;(handler["client"].models.generateContentStream as any).mockResolvedValue(
+				makeStream([
+					{ candidates: [{ content: { parts: [{ text: "Done." }] } }] },
+					{ usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 5 } },
+				]),
+			)
+
+			for await (const _chunk of handler.createMessage(systemPrompt, historyAfterTurn1, toolMetadata)) {
+				// drain
+			}
+
+			const callArgs = (handler["client"].models.generateContentStream as any).mock.calls[0][0]
+			const contents: any[] = callArgs.contents
+
+			// The model turn in the outgoing request must carry the thoughtSignature on its functionCall part
+			const modelTurn = contents.find((c: any) => c.role === "model")
+			expect(modelTurn).toBeDefined()
+			const fnPart = modelTurn.parts.find((p: any) => p.functionCall)
+			expect(fnPart).toBeDefined()
+			expect(fnPart.thoughtSignature).toBe("sig-abc123")
+		})
+
+		it("falls back to base64-encoded skip_thought_signature_validator when history has no signature", async () => {
+			// Cross-model history scenario: prior session used a non-Gemini model, no signature stored.
+			// The fallback bypass token must be base64-encoded because Part.thoughtSignature is
+			// documented as a base64 field. Vertex AI validates this strictly.
+			const historyNoSig: Anthropic.Messages.MessageParam[] = [
+				{ role: "user", content: "Read foo.ts" },
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "call-1", name: "read_file", input: { path: "foo.ts" } }],
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "call-1", content: "file contents" }],
+				},
+			]
+
+			;(handler["client"].models.generateContentStream as any).mockResolvedValue(
+				makeStream([
+					{ candidates: [{ content: { parts: [{ text: "Done." }] } }] },
+					{ usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 5 } },
+				]),
+			)
+
+			for await (const _chunk of handler.createMessage(systemPrompt, historyNoSig, toolMetadata)) {
+				// drain
+			}
+
+			const callArgs = (handler["client"].models.generateContentStream as any).mock.calls[0][0]
+			const contents: any[] = callArgs.contents
+			const modelTurn = contents.find((c: any) => c.role === "model")
+			const fnPart = modelTurn?.parts.find((p: any) => p.functionCall)
+			expect(fnPart).toBeDefined()
+			const expectedBypass = Buffer.from("skip_thought_signature_validator").toString("base64")
+			expect(fnPart.thoughtSignature).toBe(expectedBypass)
+		})
+
+		it("sends thoughtSignature even when reasoningEffort is disabled", async () => {
+			// If the user disables reasoning effort, thinkingConfig=undefined.
+			// The old code: includeThoughtSignatures = Boolean(thinkingConfig) || Boolean(metadata?.tools?.length)
+			// With tools present this is still true — but if called with no tools it would be false.
+			// Verify the signature is sent regardless when tools are in the metadata.
+			const handlerNoReasoning = new GeminiHandler({
+				apiKey: "test-key",
+				geminiApiKey: "test-key",
+				apiModelId: GEMINI_MODEL_NAME,
+				reasoningEffort: "disable" as any,
+			})
+			handlerNoReasoning["client"] = handler["client"] as any
+
+			const historyWithSig: Anthropic.Messages.MessageParam[] = [
+				{ role: "user", content: "Read foo.ts" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "call-1", name: "read_file", input: { path: "foo.ts" } },
+						{ type: "thoughtSignature", thoughtSignature: "sig-xyz" } as any,
+					],
+				},
+				{
+					role: "user",
+					content: [{ type: "tool_result", tool_use_id: "call-1", content: "file contents" }],
+				},
+			]
+
+			;(handler["client"].models.generateContentStream as any).mockResolvedValue(
+				makeStream([
+					{ candidates: [{ content: { parts: [{ text: "Done." }] } }] },
+					{ usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 5 } },
+				]),
+			)
+
+			for await (const _chunk of handlerNoReasoning.createMessage(systemPrompt, historyWithSig, toolMetadata)) {
+				// drain
+			}
+
+			const callArgs = (handler["client"].models.generateContentStream as any).mock.calls[0][0]
+			const contents: any[] = callArgs.contents
+			const modelTurn = contents.find((c: any) => c.role === "model")
+			const fnPart = modelTurn?.parts.find((p: any) => p.functionCall)
+			expect(fnPart).toBeDefined()
+			expect(fnPart.thoughtSignature).toBe("sig-xyz")
+		})
+
+		it("does NOT capture thoughtSignature when there are no tools in metadata", async () => {
+			// Without tools, includeThoughtSignatures=false when thinkingConfig is also absent.
+			// This tests the boundary so we don't over-eagerly store signatures for non-tool calls.
+			const handlerNoReasoning = new GeminiHandler({
+				apiKey: "test-key",
+				geminiApiKey: "test-key",
+				apiModelId: GEMINI_MODEL_NAME,
+				reasoningEffort: "disable" as any,
+			})
+			handlerNoReasoning["client"] = handler["client"] as any
+			;(handler["client"].models.generateContentStream as any).mockResolvedValue(
+				makeStream([
+					{
+						candidates: [
+							{
+								content: {
+									parts: [
+										{ functionCall: { name: "read_file", args: { path: "foo.ts" } } },
+										{ thoughtSignature: "sig-should-not-be-captured" },
+									],
+								},
+							},
+						],
+					},
+					{ usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 } },
+				]),
+			)
+
+			// No tools in metadata, no thinkingConfig → includeThoughtSignatures=false
+			for await (const _chunk of handlerNoReasoning.createMessage(systemPrompt, [
+				{ role: "user", content: "hi" },
+			])) {
+				// drain
+			}
+
+			expect(handlerNoReasoning.getThoughtSignature()).toBeUndefined()
+		})
+	})
+
 	describe("createMessage", () => {
 		const mockMessages: Anthropic.Messages.MessageParam[] = [
 			{

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -9,6 +9,7 @@ import { ApiHandlerOptions } from "../../shared/api"
 
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
+import { GEMINI_THOUGHT_SIGNATURE_BYPASS } from "../transform/gemini-format"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
@@ -72,7 +73,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 	 *
 	 * Per LiteLLM documentation:
 	 * - Thought signatures are stored in provider_specific_fields.thought_signature of tool calls
-	 * - The dummy signature base64("skip_thought_signature_validator") bypasses validation
+	 * - The bypass token (GEMINI_THOUGHT_SIGNATURE_BYPASS) skips signature validation
 	 *
 	 * We inject the dummy signature on EVERY tool call unconditionally to ensure Gemini
 	 * doesn't complain about missing/corrupted signatures when conversation history
@@ -81,8 +82,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 	private injectThoughtSignatureForGemini(
 		openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[],
 	): OpenAI.Chat.ChatCompletionMessageParam[] {
-		// Base64 encoded "skip_thought_signature_validator" as per LiteLLM docs
-		const dummySignature = Buffer.from("skip_thought_signature_validator").toString("base64")
+		const dummySignature = GEMINI_THOUGHT_SIGNATURE_BYPASS
 
 		return openAiMessages.map((msg) => {
 			if (msg.role === "assistant") {

--- a/src/api/transform/__tests__/gemini-format.spec.ts
+++ b/src/api/transform/__tests__/gemini-format.spec.ts
@@ -123,6 +123,11 @@ describe("convertAnthropicMessageToGemini", () => {
 
 		const result = convertAnthropicMessageToGemini(anthropicMessage)
 
+		// thoughtSignature must be base64-encoded: the Gemini API documents Part.thoughtSignature
+		// as "Encoded as base64 string". Sending the raw bypass token without base64 encoding fails
+		// on Vertex AI (Gemini 3.1/3.5 strict validation), causing empty-response loops on turn 2+.
+		const expectedBypassToken = Buffer.from("skip_thought_signature_validator").toString("base64")
+
 		expect(result).toEqual([
 			{
 				role: "model",
@@ -133,7 +138,7 @@ describe("convertAnthropicMessageToGemini", () => {
 							name: "calculator",
 							args: { operation: "add", numbers: [2, 3] },
 						},
-						thoughtSignature: "skip_thought_signature_validator",
+						thoughtSignature: expectedBypassToken,
 					},
 				],
 			},

--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -1,6 +1,11 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { Content, Part } from "@google/genai"
 
+// Gemini documents Part.thoughtSignature as "Encoded as base64 string". Vertex AI enforces
+// this strictly — sending the plain string causes empty responses after the first tool call.
+// This bypass token tells Gemini to skip signature validation for cross-model history entries.
+export const GEMINI_THOUGHT_SIGNATURE_BYPASS = Buffer.from("skip_thought_signature_validator").toString("base64")
+
 type ThoughtSignatureContentBlock = {
 	type: "thoughtSignature"
 	thoughtSignature?: string
@@ -42,10 +47,12 @@ export function convertAnthropicContentToGemini(
 	// Determine the signature to attach to function calls.
 	// If we're in a mode that expects signatures (includeThoughtSignatures is true):
 	// 1. Use the actual signature if we found one in the history/content.
-	// 2. Fallback to "skip_thought_signature_validator" if missing (e.g. cross-model history).
+	// 2. Fallback to a base64-encoded bypass token if missing (e.g. cross-model history).
+	//    Part.thoughtSignature is documented as "Encoded as base64 string" — Vertex AI validates
+	//    this strictly and returns empty responses when a non-base64 value is sent.
 	let functionCallSignature: string | undefined
 	if (includeThoughtSignatures) {
-		functionCallSignature = activeThoughtSignature || "skip_thought_signature_validator"
+		functionCallSignature = activeThoughtSignature || GEMINI_THOUGHT_SIGNATURE_BYPASS
 	}
 
 	if (typeof content === "string") {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #536

### Description

Gemini 3.x (including `gemini-3.1-pro-preview` and `gemini-3.5-flash`) validates `Part.thoughtSignature` strictly on Vertex AI. The field is documented by the Google GenAI SDK as **"Encoded as base64 string"**. The fallback bypass token in `gemini-format.ts` was being sent as a plain string (`"skip_thought_signature_validator"`), while the same token in `lite-llm.ts` was already correctly base64-encoded.

Vertex AI enforces base64 validation more strictly than the direct Gemini API. When the plain string was sent on turn 2+ (after a tool call), Vertex returned an empty response, triggering the infinite retry loop reported in #536.

**How:**
- Added `GEMINI_THOUGHT_SIGNATURE_BYPASS` as a named export in `src/api/transform/gemini-format.ts` — the single source of truth for the base64-encoded bypass token.
- Updated `gemini-format.ts` to use the constant instead of the inline plain string.
- Updated `lite-llm.ts` to import and use the same constant, eliminating the duplicate `Buffer.from(...)` computation.

**Reviewers should note:**
- The direct Gemini API accepts both plain and base64 forms (confirmed via live API test), but Vertex AI requires base64. The fix is safe for both paths.
- `thoughtSignature` round-trip from real API responses is unaffected — only the fallback/bypass path changed.

### Test Procedure

TDD approach: failing tests written first, then fix applied.

- `src/api/transform/__tests__/gemini-format.spec.ts` — updated existing tool-use test to assert base64-encoded bypass token; added assertion documents the exact Vertex AI failure mode.
- `src/api/providers/__tests__/gemini.spec.ts` — added `thoughtSignature round-trip (issue #536)` suite covering: capture from stream, round-trip through history on turn 2, base64 fallback for cross-model history, disabled-reasoning edge case, and no-tools boundary.
- `src/api/providers/__tests__/lite-llm.spec.ts` — existing tests continue to pass unchanged (they already asserted the base64 value).

```
pnpm exec vitest run api/transform/__tests__/gemini-format.spec.ts api/providers/__tests__/gemini.spec.ts api/providers/__tests__/lite-llm.spec.ts
# 3 files, 74 tests, all pass
```

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [ ] No documentation updates are required.

### Get in Touch

edelauna@gmail.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Gemini tool calls by preserving and reusing required reasoning metadata across streamed turns.
  * Added a safe fallback for cases where no prior signature is available, helping avoid validation issues in Gemini responses.
  * Ensured tool-related behavior remains consistent even when reasoning settings are disabled.

* **Tests**
  * Expanded coverage for Gemini streaming and tool-call scenarios, including edge cases around missing signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->