### PR TITLE
Improve Anthropic Vertex Claude content block handling

### DIFF
--- a/src/api/providers/__tests__/anthropic-vertex.spec.ts
+++ b/src/api/providers/__tests__/anthropic-vertex.spec.ts
@@ -895,6 +895,41 @@ describe("VertexHandler", () => {
 			const result = await handler.completePrompt("Test prompt")
 			expect(result).toBe("")
 		})
+
+		it("should handle empty content array for Claude", async () => {
+			handler = new AnthropicVertexHandler({
+				apiModelId: "claude-3-5-sonnet-v2@20241022",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const mockCreate = vitest.fn().mockResolvedValue({
+				content: [],
+			})
+			;(handler["client"].messages as any).create = mockCreate
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("")
+		})
+
+		it("should return text from first text block when mixed content for Claude", async () => {
+			handler = new AnthropicVertexHandler({
+				apiModelId: "claude-3-5-sonnet-v2@20241022",
+				vertexProjectId: "test-project",
+				vertexRegion: "us-central1",
+			})
+
+			const mockCreate = vitest.fn().mockResolvedValue({
+				content: [
+					{ type: "thinking", thinking: "internal reasoning" },
+					{ type: "text", text: "visible response" },
+				],
+			})
+			;(handler["client"].messages as any).create = mockCreate
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("visible response")
+		})
 	})
 
 	describe("getModel", () => {
@@ -1342,7 +1377,9 @@ describe("VertexHandler", () => {
 			}))
 			;(sonnetHandler["client"].messages as any).create = mockCreate
 
-			await sonnetHandler.createMessage("You are a helpful assistant", [{ role: "user", content: "Hello" }]).next()
+			await sonnetHandler
+				.createMessage("You are a helpful assistant", [{ role: "user", content: "Hello" }])
+				.next()
 
 			expect(mockCreate).toHaveBeenCalledWith(
 				expect.objectContaining({

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -297,13 +297,9 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 			} as Anthropic.Messages.MessageCreateParamsNonStreaming
 
 			const response = await this.client.messages.create(params)
-			const content = response.content[0]
+			const content = response.content.find(({ type }) => type === "text")
 
-			if (content.type === "text") {
-				return content.text
-			}
-
-			return ""
+			return content?.type === "text" ? content.text : ""
 		} catch (error) {
 			if (error instanceof Error) {
 				throw new Error(`Vertex completion error: ${error.message}`)


### PR DESCRIPTION
<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #788  <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

This PR improves how completion response content blocks are handled when using Claude models through Anthropic Vertex.

The previous implementation only checked `response.content[0]`, assuming that the first content block would always be a `text` block. This works for common text-only responses, but it is less defensive when Claude returns an empty content array or includes non-text blocks, such as `thinking`, before the actual text response.

This change updates the logic to search for the first available `text` block in the response content array. If no text block exists, it safely returns an empty string, preserving the existing fallback behavior.

Main changes:

* Updated Anthropic Vertex `completePrompt` to find the first `text` block instead of only checking `response.content[0]`.
* Safely handles empty content arrays.
* Added test coverage for empty Claude content responses.
* Added test coverage for mixed Claude content responses where a non-text block appears before a text block.

### Test Procedure

Added unit tests for the following cases:

1. Claude returns an empty `content` array and `completePrompt` returns an empty string.
2. Claude returns mixed content blocks and `completePrompt` returns the first text block.

Test command:

```bash
pnpm test src/api/providers/__tests__/anthropic-vertex.spec.ts
```

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->
N/A

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->
- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->
This change aligns Anthropic Vertex completion handling with other providers by extracting the first available text block instead of assuming the first content block is always text.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
hehegwk_23849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt completion handling for Claude/Vertex responses so text is extracted correctly even when non-text content appears first.
  * Empty responses now return an empty string instead of failing or returning unexpected output.
  * Added test coverage for empty content and mixed content responses to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->