### PR TITLE
feat(nightly-publish): publish Open VSX pre-releases, skip on release merge

### DIFF
--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -41,7 +41,33 @@ jobs:
             exit 1
           fi
 
+      - name: Skip if this push is a release merge
+        id: release-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          package_version=$(node -p "require('./src/package.json').version")
+          commit_subject=$(git log -1 --format=%s)
+          skip=false
+
+          if [[ "$commit_subject" =~ ^chore:\ prepare\ v[0-9]+\.[0-9]+\.[0-9]+\ release ]]; then
+            echo "Commit '${commit_subject}' looks like a release-prep merge; skipping nightly pre-release."
+            skip=true
+          else
+            release_error=$(gh release view "v${package_version}" 2>&1 >/dev/null) && release_found=true || release_found=false
+            if [ "$release_found" = "true" ]; then
+              echo "v${package_version} is already published as a stable release; skipping nightly pre-release."
+              skip=true
+            elif [[ "$release_error" != *"release not found"* ]]; then
+              echo "::error::gh release view failed unexpectedly: ${release_error}"
+              exit 1
+            fi
+          fi
+
+          echo "skip=${skip}" >> "$GITHUB_OUTPUT"
+
       - name: Set pre-release version
+        if: steps.release-check.outputs.skip != 'true'
         id: version
         env:
           RUN_NUMBER: ${{ github.run_number }}
@@ -61,6 +87,7 @@ jobs:
           EOF
 
       - name: Build workspace packages
+        if: steps.release-check.outputs.skip != 'true'
         env:
           PKG_RELEASE_CHANNEL: prerelease
         run: |
@@ -68,6 +95,7 @@ jobs:
           pnpm --filter @roo-code/vscode-webview build
 
       - name: Package pre-release VSIX
+        if: steps.release-check.outputs.skip != 'true'
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           PKG_RELEASE_CHANNEL: prerelease
@@ -76,6 +104,7 @@ jobs:
           pnpm --filter ./src exec vsce package --pre-release --no-dependencies --out ../bin
 
       - name: Verify VSIX contents
+        if: steps.release-check.outputs.skip != 'true'
         env:
           VERSION_NUMBER: ${{ steps.version.outputs.number }}
         run: |
@@ -87,6 +116,7 @@ jobs:
           grep -q "extension/webview-ui/audio/celebration.wav" /tmp/zoo-code-vsix-contents.txt
 
       - name: Validate packaged manifest identity
+        if: steps.release-check.outputs.skip != 'true'
         env:
           VERSION_NUMBER: ${{ steps.version.outputs.number }}
         run: |
@@ -98,12 +128,36 @@ jobs:
           test "$artifact_name" = "zoo-code"
           test "$artifact_publisher" = "ZooCodeOrganization"
 
-      # Open VSX is intentionally excluded: it has no pre-release channel concept,
-      # so pre-release builds would surface as the latest stable version for all users.
       - name: Publish pre-release to VS Code Marketplace
+        if: steps.release-check.outputs.skip != 'true'
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           VERSION_NUMBER: ${{ steps.version.outputs.number }}
         run: |
-          npx @vscode/vsce publish --pre-release --packagePath "bin/zoo-code-${VERSION_NUMBER}.vsix"
-          echo "Published ZooCodeOrganization.zoo-code ${VERSION_NUMBER} as a VS Code Marketplace pre-release"
+          npx @vscode/vsce publish --pre-release --skip-duplicate --packagePath "bin/zoo-code-${VERSION_NUMBER}.vsix"
+          echo "Published or skipped existing ZooCodeOrganization.zoo-code ${VERSION_NUMBER} as a VS Code Marketplace pre-release"
+
+      # The VSIX built above with `vsce package --pre-release` already carries the
+      # Microsoft.VisualStudio.Code.PreRelease manifest property, which is what Open
+      # VSX reads to flag the version. `ovsx publish` ignores --pre-release for an
+      # already-packaged .vsix (it only applies when ovsx does the packaging itself),
+      # so it's intentionally omitted here.
+      #
+      # Open VSX's "latest" alias resolves to the highest semver across stable and
+      # pre-release alike (pre-release only breaks ties at equal major.minor.patch),
+      # so a nightly build can transiently become "latest" until the next stable
+      # release outranks it. This mirrors how Marketplace pre-release users already
+      # track the newest published version, so it's an accepted trade-off here too.
+      - name: Publish pre-release to Open VSX Registry
+        if: steps.release-check.outputs.skip != 'true'
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VERSION_NUMBER: ${{ steps.version.outputs.number }}
+        run: |
+          set -o pipefail
+          publish_output=$(pnpm exec ovsx publish "bin/zoo-code-${VERSION_NUMBER}.vsix" --skip-duplicate 2>&1 | tee /dev/stderr)
+          if echo "$publish_output" | grep -q "is already published"; then
+            echo "ZooCodeOrganization.zoo-code ${VERSION_NUMBER} was already published to Open VSX; skipped."
+          else
+            echo "Published ZooCodeOrganization.zoo-code ${VERSION_NUMBER} as an Open VSX pre-release"
+          fi


### PR DESCRIPTION
### Related GitHub Issue

Closes: #784

### Description

Publishes nightly pre-release builds to Open VSX in addition to the VS Code Marketplace, and adds a guard so the release-PR merge back into `main` doesn't also trigger a redundant nightly pre-release.

**Open VSX pre-release publishing**

The workflow previously skipped Open VSX for nightlies, with a comment claiming Open VSX has no pre-release concept. That was incorrect — verified against the Open VSX server source (`ExtensionVersionJooqRepository.findLatestQuery`, [eclipse-openvsx/openvsx](https://github.com/eclipse-openvsx/openvsx)) and confirmed live against the real `ZooCodeOrganization.zoo-code` listing:

- The `pre-release` alias correctly isolates pre-release-flagged versions.
- The `latest` alias resolves to the highest semver across stable **and** pre-release, using the pre-release flag only as a tie-breaker at identical `major.minor.patch`. A nightly build can therefore transiently become `latest` until the next stable release outranks it — the same trade-off already accepted for Marketplace pre-release publishing, since both track "newest published version."

The Open VSX publish step intentionally omits `ovsx publish --pre-release`: for an already-packaged `.vsix` (built earlier in the job via `vsce package --pre-release`), `ovsx` ignores that flag and warns that it's a no-op — the pre-release marker is already baked into the VSIX's `Microsoft.VisualStudio.Code.PreRelease` manifest property, which is what Open VSX actually reads.

**Skip on release merge**

The release runbook (`.roo/commands/release.md`) squash-merges release PRs into `main` with the commit message `chore: prepare v[version] release`, after the tag has already been pushed and stable has already shipped. Without a guard, that merge would also trigger a nightly pre-release publish of code that was just released as stable. Added a "Skip if this push is a release merge" step that checks:
1. The commit subject against the release-prep message pattern, and
2. Whether a GitHub release already exists for the current `src/package.json` version (belt-and-suspenders if the message convention ever drifts).

`gh release view` failures are distinguished by message: "release not found" is the expected non-match; anything else (auth/API failure) fails the step loudly instead of silently falling through to a publish.

**Duplicate-publish logging**

The Open VSX publish step now checks `ovsx`'s output for "is already published" and logs that the version was skipped rather than unconditionally claiming a fresh publish — `--skip-duplicate` returns success without actually publishing in that case.

### Test Procedure

- Manually built a pre-release VSIX with `vsce package --pre-release` and confirmed the `Microsoft.VisualStudio.Code.PreRelease` manifest property is set.
- Published a real test pre-release to the `ZooCodeOrganization.zoo-code` Open VSX listing and confirmed via the registry API that the `pre-release` alias correctly isolated it while `latest` tracked highest-semver as expected.
- Verified the release-merge skip regex against real historical release commits (`chore: prepare v3.64.0 release (#729)`, `chore: prepare v3.62.0 release (#658)`) and against a normal feature commit, confirming correct match/no-match in both directions.
- Verified `gh release view` error handling against three cases: version not found, version found (existing stable release `v3.64.0`), and an invalid token (401) — confirmed each takes the correct branch.
- Verified the duplicate-skip log message against both a real `ovsx` "already published" response and a real publish-success response.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This is a CI/workflow-only change (`.github/workflows/nightly-publish.yml`); there's no application code path to unit test. Verification was done by exercising the actual `ovsx`/`gh` commands and shell logic locally against the real registry and repo, as detailed in the Test Procedure above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly pre-releases now automatically skip build and publishing when the latest commit appears to be a release-prep merge or when the version already exists as a stable release.
  * Improved handling of duplicate publish attempts to reduce unnecessary errors.
* **New Features**
  * Added nightly pre-release publishing to the Open VSX Registry.
  * Made VS Code Marketplace pre-release publishing conditional to prevent redundant uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->