### PR TITLE
feat: add Grok 4.5 model support and fix xAI reasoning format

### DIFF
--- a/apps/vscode-e2e/src/suite/providers/xai.test.ts
+++ b/apps/vscode-e2e/src/suite/providers/xai.test.ts
@@ -12,7 +12,7 @@ const XAI_API_KEY = process.env.XAI_API_KEY
 const XAI_BASE_URL = "https://api.x.ai/v1"
 const XAI_RESPONSES_URL = `${XAI_BASE_URL}/responses`
 // Primary model for the full round-trip test (completion-text assertion included).
-const XAI_MODEL_ID = "grok-4.20"
+const XAI_MODEL_ID = "grok-4.5"
 // Fast variants: tested for API parameter contract only.  They consistently call
 // attempt_completion with an empty result field after a no-tool-error recovery
 // loop, so they cannot satisfy the completion-text assertion at this time.
@@ -492,7 +492,7 @@ suite("xAI provider", function () {
 				const readCallId = modelFixture?.readCallId ?? "call_xai_read_001"
 
 				if (request.functionCallOutputIds.some((id) => id === readCallId)) {
-					// Use recorded turn2 when it contains a function_call (grok-4.20).
+					// Use recorded turn2 when it contains a function_call (grok-4.5).
 					// Fast models return plain text in turn2 — hand-craft attempt_completion
 					// so the task can reach completion.
 					const turn2HasFunctionCall = (modelFixture?.turn2 as ResponsesStreamEvent[] | undefined)?.some(

--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -3,9 +3,25 @@ import type { ModelInfo } from "../model.js"
 // https://docs.x.ai/docs/api-reference
 export type XAIModelId = keyof typeof xaiModels
 
-export const xaiDefaultModelId: XAIModelId = "grok-4.20"
+export const xaiDefaultModelId: XAIModelId = "grok-4.5"
 
 export const xaiModels = {
+	"grok-4.5": {
+		maxTokens: 65_536,
+		contextWindow: 500_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2.0,
+		outputPrice: 6.0,
+		cacheWritesPrice: 0.5,
+		cacheReadsPrice: 0.5,
+		description:
+			"xAI's flagship Grok 4.5 model with 500K context, configurable reasoning (low/medium/high), and agentic tool calling via Responses API.",
+		supportsReasoningEffort: ["low", "medium", "high"],
+		reasoningEffort: "high",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
+	},
 	"grok-4.20": {
 		maxTokens: 65_536,
 		contextWindow: 2_000_000,

--- a/src/api/providers/__tests__/xai.spec.ts
+++ b/src/api/providers/__tests__/xai.spec.ts
@@ -255,7 +255,7 @@ describe("XAIHandler", () => {
 		await expect(handler.completePrompt("test prompt")).rejects.toThrow(`xAI completion error: ${errorMessage}`)
 	})
 
-	it("should include reasoning_effort for mini models", async () => {
+	it("should include reasoning effort for mini models in Responses API format", async () => {
 		const miniModelHandler = new XAIHandler({
 			apiModelId: "grok-3-mini",
 			reasoningEffort: "high",
@@ -269,7 +269,48 @@ describe("XAIHandler", () => {
 		expect(mockResponsesCreate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				reasoning: expect.objectContaining({
-					reasoning_effort: "high",
+					effort: "high",
+				}),
+			}),
+		)
+	})
+
+	it("should include reasoning effort for grok-4.5 with default high effort", async () => {
+		const grok45Handler = new XAIHandler({
+			apiModelId: "grok-4.5",
+		})
+
+		mockResponsesCreate.mockResolvedValueOnce(mockStream([]))
+
+		const stream = grok45Handler.createMessage("test prompt", [])
+		await stream.next()
+
+		expect(mockResponsesCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "grok-4.5",
+				reasoning: expect.objectContaining({
+					effort: "high",
+				}),
+			}),
+		)
+	})
+
+	it("should include reasoning effort for grok-4.5 with custom low effort", async () => {
+		const grok45Handler = new XAIHandler({
+			apiModelId: "grok-4.5",
+			reasoningEffort: "low",
+		})
+
+		mockResponsesCreate.mockResolvedValueOnce(mockStream([]))
+
+		const stream = grok45Handler.createMessage("test prompt", [])
+		await stream.next()
+
+		expect(mockResponsesCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "grok-4.5",
+				reasoning: expect.objectContaining({
+					effort: "low",
 				}),
 			}),
 		)

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -120,9 +120,11 @@ export class XAIHandler extends BaseProvider implements SingleCompletionHandler 
 			requestBody.parallel_tool_calls = metadata?.parallelToolCalls ?? true
 		}
 
-		// Pass reasoning effort for models that support it (e.g., mini models)
+		// Pass reasoning effort for models that support it (e.g., grok-4.5, grok-3-mini).
+		// The xAI Responses API uses `reasoning: { effort }` format (not `reasoning_effort`
+		// which is the Chat Completions format), so we convert from the OpenAI params shape.
 		if (model.reasoning) {
-			requestBody.reasoning = model.reasoning
+			requestBody.reasoning = { effort: model.reasoning.reasoning_effort }
 		}
 
 		let stream: AsyncIterable<any>


### PR DESCRIPTION
### Related GitHub Issue

Closes: #866

### Description

Grok 4.5 was publicly released on July 9, 2026 as xAI's new flagship model. This PR adds support for it in the xAI provider and fixes a latent reasoning format bug.

**Key implementation details:**

1. **New model definition** (`packages/types/src/providers/xai.ts`): Added `grok-4.5` with 500K context window, $2.00/$6.00 input/output pricing, $0.50 cache pricing, and configurable reasoning effort (`["low", "medium", "high"]`, default `"high"`). Updated `xaiDefaultModelId` from `grok-4.20` to `grok-4.5`.

2. **Reasoning format bug fix** (`src/api/providers/xai.ts`): The xAI Responses API expects `reasoning: { effort: "high" }` format, but the handler was passing `reasoning: { reasoning_effort: "high" }` (Chat Completions format). This was a latent bug that affected `grok-3-mini` and would have broken grok-4.5's configurable reasoning. The handler now converts from the OpenAI params shape to the Responses API `{ effort }` format.

3. **Test updates** (`src/api/providers/__tests__/xai.spec.ts`): Fixed the existing grok-3-mini reasoning test to expect the correct `{ effort }` format. Added two new tests for grok-4.5 — one verifying default high reasoning effort, one verifying custom low effort.

4. **E2e test update** (`apps/vscode-e2e/src/suite/providers/xai.test.ts`): Updated the primary model ID from `grok-4.20` to `grok-4.5`.

### Test Procedure

**Unit tests** (all passing):
- `cd src && npx vitest run api/providers/__tests__/xai.spec.ts` — 17 tests pass (15 original + 2 new grok-4.5 tests)
- `cd src && npx vitest run api/transform/__tests__/model-params.spec.ts api/transform/__tests__/reasoning.spec.ts shared/__tests__/api.spec.ts` — 161 tests pass
- `cd src && npx vitest run api/transform/__tests__/openai-format.spec.ts` — 56 tests pass
- `cd src && npx vitest run shared/__tests__/ProfileValidator.spec.ts` — 28 tests pass
- `cd packages/types && npx vitest run` — 230 tests pass

**Lint & type-check** (pre-commit/pre-push hooks):
- ESLint passes with `--max-warnings=0` across all packages
- `tsc --noEmit` passes for `@roo-code/types`, `@roo-code/vscode-e2e`, and `zoo-code`

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to issue #866.
- [x] **Scope**: My changes are focused on the linked issue (adding grok-4.5 support + fixing the reasoning format bug it exposed).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes.
- [x] **Documentation Impact**: No documentation updates required — model definitions are self-documenting via the `description` field.
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshots / Videos

N/A — no UI changes. The new `grok-4.5` model will automatically appear in the xAI provider model dropdown.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

The reasoning format bug (`reasoning_effort` vs `effort`) was pre-existing and would have silently caused grok-4.5 to ignore the user's reasoning effort setting, always falling back to the model's default. The xAI API likely silently ignores unrecognized fields in the `reasoning` object, so this wouldn't have caused errors — just incorrect behavior.

### Get in Touch

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated xAI integration to default to `grok-4.5` instead of `grok-4.20`.
  * Reasoning-effort settings are now sent in the format xAI expects, improving consistency of responses.
  * Default reasoning effort is applied when not provided, and custom values are honored.
* **Tests**
  * Updated end-to-end and provider tests to validate `grok-4.5` plus default and custom reasoning-effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->