### PR TITLE
fix(settings): buffer Save-managed settings in cachedState until Save

### DIFF
--- a/webview-ui/src/components/mcp/McpEnabledToggle.tsx
+++ b/webview-ui/src/components/mcp/McpEnabledToggle.tsx
@@ -5,9 +5,21 @@ import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { vscode } from "@src/utils/vscode"
 
-const McpEnabledToggle = () => {
-	const { mcpEnabled, setMcpEnabled } = useExtensionState()
+interface McpEnabledToggleProps {
+	mcpEnabled?: boolean
+	setMcpEnabled?: (value: boolean) => void
+}
+
+const McpEnabledToggle = ({
+	mcpEnabled: propsMcpEnabled,
+	setMcpEnabled: propsSetMcpEnabled,
+}: McpEnabledToggleProps = {}) => {
+	const { mcpEnabled: contextMcpEnabled, setMcpEnabled: contextSetMcpEnabled } = useExtensionState()
 	const { t } = useAppTranslation()
+
+	// When rendered inside SettingsView the value is buffered in `cachedState` and
+	// only persisted on Save. Fall back to live extension state when used uncontrolled.
+	const mcpEnabled = propsMcpEnabled ?? contextMcpEnabled
 
 	const handleChange = (e: Event | FormEvent<HTMLElement>) => {
 		const target = ("target" in e ? e.target : null) as HTMLInputElement | null
@@ -16,8 +28,12 @@ const McpEnabledToggle = () => {
 			return
 		}
 
-		setMcpEnabled(target.checked)
-		vscode.postMessage({ type: "updateSettings", updatedSettings: { mcpEnabled: target.checked } })
+		if (propsSetMcpEnabled) {
+			propsSetMcpEnabled(target.checked)
+		} else {
+			contextSetMcpEnabled(target.checked)
+			vscode.postMessage({ type: "updateSettings", updatedSettings: { mcpEnabled: target.checked } })
+		}
 	}
 
 	return (

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -28,8 +28,17 @@ import McpResourceRow from "./McpResourceRow"
 import McpEnabledToggle from "./McpEnabledToggle"
 import { McpErrorRow } from "./McpErrorRow"
 
-const McpView = () => {
-	const { mcpServers: servers, alwaysAllowMcp, mcpEnabled } = useExtensionState()
+interface McpViewProps {
+	mcpEnabled?: boolean
+	setMcpEnabled?: (value: boolean) => void
+}
+
+const McpView = ({ mcpEnabled: propsMcpEnabled, setMcpEnabled }: McpViewProps = {}) => {
+	const { mcpServers: servers, alwaysAllowMcp, mcpEnabled: contextMcpEnabled } = useExtensionState()
+
+	// When rendered inside SettingsView the value is buffered in `cachedState` and
+	// only persisted on Save. Fall back to live extension state when used uncontrolled.
+	const mcpEnabled = propsMcpEnabled ?? contextMcpEnabled
 
 	const { t } = useAppTranslation()
 	const { isOverThreshold, title, message } = useTooManyTools()
@@ -55,7 +64,7 @@ const McpView = () => {
 					</Trans>
 				</div>
 
-				<McpEnabledToggle />
+				<McpEnabledToggle mcpEnabled={mcpEnabled} setMcpEnabled={setMcpEnabled} />
 
 				{mcpEnabled && (
 					<>

--- a/webview-ui/src/components/mcp/__tests__/McpEnabledToggle.spec.tsx
+++ b/webview-ui/src/components/mcp/__tests__/McpEnabledToggle.spec.tsx
@@ -1,0 +1,58 @@
+// npx vitest src/components/mcp/__tests__/McpEnabledToggle.spec.tsx
+
+import { render, screen, fireEvent } from "@/utils/test-utils"
+
+import McpEnabledToggle from "../McpEnabledToggle"
+import { vscode } from "@src/utils/vscode"
+
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+vi.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const contextSetMcpEnabled = vi.fn()
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		mcpEnabled: true,
+		setMcpEnabled: contextSetMcpEnabled,
+	}),
+}))
+
+const getCheckbox = () => screen.getByRole("checkbox")
+
+describe("McpEnabledToggle - Save/Discard contract", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	// Case 6: controlled (inside SettingsView) must buffer, not persist before Save.
+	it("buffers via the setter prop without persisting before Save when controlled", () => {
+		const setMcpEnabled = vi.fn()
+		render(<McpEnabledToggle mcpEnabled={true} setMcpEnabled={setMcpEnabled} />)
+
+		fireEvent.click(getCheckbox())
+
+		expect(setMcpEnabled).toHaveBeenCalledWith(false)
+		expect(vscode.postMessage).not.toHaveBeenCalled()
+		// Must not touch live extension state either.
+		expect(contextSetMcpEnabled).not.toHaveBeenCalled()
+	})
+
+	// Regression guard: uncontrolled usage keeps the original immediate behavior.
+	it("persists immediately via live state when used uncontrolled", () => {
+		render(<McpEnabledToggle />)
+
+		fireEvent.click(getCheckbox())
+
+		expect(contextSetMcpEnabled).toHaveBeenCalledWith(false)
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			type: "updateSettings",
+			updatedSettings: { mcpEnabled: false },
+		})
+	})
+})

--- a/webview-ui/src/components/mcp/__tests__/McpView.spec.tsx
+++ b/webview-ui/src/components/mcp/__tests__/McpView.spec.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@/utils/test-utils"
+
+import McpView from "../McpView"
+
+const setMcpEnabled = vi.fn()
+
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		mcpServers: [],
+		alwaysAllowMcp: false,
+		mcpEnabled: false,
+	}),
+}))
+
+vi.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@src/hooks/useTooManyTools", () => ({
+	useTooManyTools: () => ({ isOverThreshold: false, title: "", message: "" }),
+}))
+
+vi.mock("@src/components/settings/Section", () => ({
+	Section: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@src/components/settings/SectionHeader", () => ({
+	SectionHeader: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock("@src/components/ui", () => ({
+	Button: ({ children, onClick }: { children: React.ReactNode; onClick: () => void }) => (
+		<button onClick={onClick}>{children}</button>
+	),
+	Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	ToggleSwitch: () => null,
+	StandardTooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../McpEnabledToggle", () => ({
+	default: ({
+		mcpEnabled,
+		setMcpEnabled: setEnabled,
+	}: {
+		mcpEnabled: boolean
+		setMcpEnabled?: (value: boolean) => void
+	}) => (
+		<button data-testid="mcp-enabled-toggle" onClick={() => setEnabled?.(!mcpEnabled)}>
+			{String(mcpEnabled)}
+		</button>
+	),
+}))
+
+describe("McpView", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("uses extension state when no buffered value is provided", () => {
+		render(<McpView />)
+
+		expect(screen.getByTestId("mcp-enabled-toggle")).toHaveTextContent("false")
+	})
+
+	it("uses and updates the buffered value when controlled", () => {
+		render(<McpView mcpEnabled={true} setMcpEnabled={setMcpEnabled} />)
+
+		fireEvent.click(screen.getByTestId("mcp-enabled-toggle"))
+
+		expect(setMcpEnabled).toHaveBeenCalledWith(false)
+	})
+})

--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -88,7 +88,6 @@ export const AutoApproveSettings = ({
 			const newCommands = [...currentCommands, commandInput]
 			setCachedStateField("allowedCommands", newCommands)
 			setCommandInput("")
-			vscode.postMessage({ type: "updateSettings", updatedSettings: { allowedCommands: newCommands } })
 		}
 	}
 
@@ -99,7 +98,6 @@ export const AutoApproveSettings = ({
 			const newCommands = [...currentCommands, deniedCommandInput]
 			setCachedStateField("deniedCommands", newCommands)
 			setDeniedCommandInput("")
-			vscode.postMessage({ type: "updateSettings", updatedSettings: { deniedCommands: newCommands } })
 		}
 	}
 
@@ -317,11 +315,6 @@ export const AutoApproveSettings = ({
 									onClick={() => {
 										const newCommands = (allowedCommands ?? []).filter((_, i) => i !== index)
 										setCachedStateField("allowedCommands", newCommands)
-
-										vscode.postMessage({
-											type: "updateSettings",
-											updatedSettings: { allowedCommands: newCommands },
-										})
 									}}>
 									<div className="flex flex-row items-center gap-1">
 										<div>{cmd}</div>
@@ -376,11 +369,6 @@ export const AutoApproveSettings = ({
 									onClick={() => {
 										const newCommands = (deniedCommands ?? []).filter((_, i) => i !== index)
 										setCachedStateField("deniedCommands", newCommands)
-
-										vscode.postMessage({
-											type: "updateSettings",
-											updatedSettings: { deniedCommands: newCommands },
-										})
 									}}>
 									<div className="flex flex-row items-center gap-1">
 										<div>{cmd}</div>

--- a/webview-ui/src/components/settings/ContextManagementSettings.tsx
+++ b/webview-ui/src/components/settings/ContextManagementSettings.tsx
@@ -24,7 +24,6 @@ import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 import { SearchableSetting } from "./SearchableSetting"
-import { vscode } from "@/utils/vscode"
 
 type ContextManagementSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	autoCondenseContext: boolean
@@ -139,7 +138,6 @@ export const ContextManagementSettings = ({
 			}
 
 			setCachedStateField("profileThresholds", newThresholds)
-			vscode.postMessage({ type: "updateSettings", updatedSettings: { profileThresholds: newThresholds } })
 		}
 	}
 	return (

--- a/webview-ui/src/components/settings/PromptsSettings.tsx
+++ b/webview-ui/src/components/settings/PromptsSettings.tsx
@@ -208,6 +208,17 @@ const PromptsSettings = ({
 										}
 
 										setIncludeTaskHistoryInEnhance(target.checked)
+
+										// Controlled: setter buffers into cachedState (Save persists).
+										// Uncontrolled: context setter is local-only, so persist here.
+										if (!propsSetIncludeTaskHistoryInEnhance) {
+											vscode.postMessage({
+												type: "updateSettings",
+												updatedSettings: {
+													includeTaskHistoryInEnhance: target.checked,
+												},
+											})
+										}
 									}}>
 									<span className="font-medium">
 										{t("prompts:supportPrompts.enhance.includeTaskHistory")}

--- a/webview-ui/src/components/settings/PromptsSettings.tsx
+++ b/webview-ui/src/components/settings/PromptsSettings.tsx
@@ -208,11 +208,6 @@ const PromptsSettings = ({
 										}
 
 										setIncludeTaskHistoryInEnhance(target.checked)
-
-										vscode.postMessage({
-											type: "updateSettings",
-											updatedSettings: { includeTaskHistoryInEnhance: target.checked },
-										})
 									}}>
 									<span className="font-medium">
 										{t("prompts:supportPrompts.enhance.includeTaskHistory")}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -900,7 +900,12 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 						{renderTab === "modes" && <ModesView />}
 
 						{/* MCP Section */}
-						{renderTab === "mcp" && <McpView />}
+						{renderTab === "mcp" && (
+							<McpView
+								mcpEnabled={mcpEnabled}
+								setMcpEnabled={(value) => setCachedStateField("mcpEnabled", value)}
+							/>
+						)}
 
 						{/* Worktrees Section */}
 						{renderTab === "worktrees" && <WorktreesView />}

--- a/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/AutoApproveSettings.spec.tsx
@@ -1,0 +1,100 @@
+// npx vitest src/components/settings/__tests__/AutoApproveSettings.spec.tsx
+
+import { render, screen, fireEvent } from "@/utils/test-utils"
+
+import { AutoApproveSettings } from "../AutoApproveSettings"
+import { vscode } from "@/utils/vscode"
+
+vi.mock("@/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+vi.mock("@/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// AutoApproveSettings reads a couple of live-state values that are genuinely
+// immediate actions (autoApprovalEnabled). Those are out of scope for the
+// Save/Discard buffering contract, so we just provide inert stand-ins.
+vi.mock("@/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		autoApprovalEnabled: false,
+		setAutoApprovalEnabled: vi.fn(),
+	}),
+}))
+
+vi.mock("@/hooks/useAutoApprovalToggles", () => ({
+	useAutoApprovalToggles: () => ({}),
+}))
+
+vi.mock("@/hooks/useAutoApprovalState", () => ({
+	useAutoApprovalState: () => ({ effectiveAutoApprovalEnabled: false, hasEnabledOptions: false }),
+}))
+
+const renderSettings = (overrides = {}) => {
+	const setCachedStateField = vi.fn()
+	const props = {
+		alwaysAllowExecute: true, // reveal the command list section
+		allowedCommands: [] as string[],
+		deniedCommands: [] as string[],
+		setCachedStateField,
+		...overrides,
+	}
+	render(<AutoApproveSettings {...(props as any)} />)
+	return { setCachedStateField }
+}
+
+// A change is "Save-managed" if it must NOT reach the extension host before Save.
+const expectNoImmediateUpdateSettings = () => {
+	expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "updateSettings" }))
+}
+
+describe("AutoApproveSettings - Save/Discard contract", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	// Case 1: allowedCommands add
+	it("buffers an added allowed command without persisting before Save", () => {
+		const { setCachedStateField } = renderSettings()
+
+		fireEvent.change(screen.getByTestId("command-input"), { target: { value: "npm test" } })
+		fireEvent.click(screen.getByTestId("add-command-button"))
+
+		expect(setCachedStateField).toHaveBeenCalledWith("allowedCommands", ["npm test"])
+		expectNoImmediateUpdateSettings()
+	})
+
+	// Case 2: allowedCommands remove
+	it("buffers a removed allowed command without persisting before Save", () => {
+		const { setCachedStateField } = renderSettings({ allowedCommands: ["npm test"] })
+
+		fireEvent.click(screen.getByTestId("remove-command-0"))
+
+		expect(setCachedStateField).toHaveBeenCalledWith("allowedCommands", [])
+		expectNoImmediateUpdateSettings()
+	})
+
+	// Case 3a: deniedCommands add
+	it("buffers an added denied command without persisting before Save", () => {
+		const { setCachedStateField } = renderSettings()
+
+		fireEvent.change(screen.getByTestId("denied-command-input"), { target: { value: "rm -rf" } })
+		fireEvent.click(screen.getByTestId("add-denied-command-button"))
+
+		expect(setCachedStateField).toHaveBeenCalledWith("deniedCommands", ["rm -rf"])
+		expectNoImmediateUpdateSettings()
+	})
+
+	// Case 3b: deniedCommands remove
+	it("buffers a removed denied command without persisting before Save", () => {
+		const { setCachedStateField } = renderSettings({ deniedCommands: ["rm -rf"] })
+
+		fireEvent.click(screen.getByTestId("remove-denied-command-0"))
+
+		expect(setCachedStateField).toHaveBeenCalledWith("deniedCommands", [])
+		expectNoImmediateUpdateSettings()
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/ContextManagementSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ContextManagementSettings.spec.tsx
@@ -2,6 +2,7 @@
 
 import { render, screen, fireEvent, waitFor } from "@/utils/test-utils"
 import { ContextManagementSettings } from "../ContextManagementSettings"
+import { vscode } from "@/utils/vscode"
 
 // Mock the translation hook
 vi.mock("@/hooks/useAppTranslation", () => ({
@@ -47,8 +48,16 @@ vi.mock("@/components/ui", () => ({
 			{children}
 		</button>
 	),
-	Select: ({ children, ...props }: any) => (
-		<div role="combobox" {...props}>
+	Select: ({ children, value, onValueChange, ...props }: any) => (
+		<div role="combobox" data-value={value} {...props}>
+			{/* Hidden trigger lets tests drive profile selection deterministically:
+			    set data-next-value on the button, then click it. */}
+			<button
+				type="button"
+				aria-hidden="true"
+				data-testid="threshold-profile-change"
+				onClick={(e: any) => onValueChange?.(e.currentTarget.getAttribute("data-next-value"))}
+			/>
 			{children}
 		</div>
 	),
@@ -390,6 +399,26 @@ describe("ContextManagementSettings", () => {
 		it("displays correct auto condense context percent value", () => {
 			render(<ContextManagementSettings {...autoCondenseProps} />)
 			expect(screen.getByText("75%")).toBeInTheDocument()
+		})
+
+		// Case 4: profileThresholds must buffer through cachedState, not persist before Save.
+		it("buffers profile threshold changes without persisting before Save", () => {
+			const mockSetCachedStateField = vitest.fn()
+			const props = { ...autoCondenseProps, setCachedStateField: mockSetCachedStateField }
+			render(<ContextManagementSettings {...props} />)
+
+			// Select a non-default profile so the slider edits profileThresholds.
+			const profileTrigger = screen.getByTestId("threshold-profile-change")
+			profileTrigger.setAttribute("data-next-value", "config-1")
+			fireEvent.click(profileTrigger)
+
+			// Move the threshold slider for that profile.
+			const slider = screen.getByTestId("condense-threshold-slider")
+			slider.focus()
+			fireEvent.keyDown(slider, { key: "ArrowRight" })
+
+			expect(mockSetCachedStateField).toHaveBeenCalledWith("profileThresholds", { "config-1": 76 })
+			expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "updateSettings" }))
 		})
 	})
 

--- a/webview-ui/src/components/settings/__tests__/PromptsSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/PromptsSettings.spec.tsx
@@ -1,0 +1,62 @@
+// npx vitest src/components/settings/__tests__/PromptsSettings.spec.tsx
+
+import { render, screen, fireEvent } from "@/utils/test-utils"
+
+import PromptsSettings from "../PromptsSettings"
+import { vscode } from "@src/utils/vscode"
+
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+vi.mock("@src/i18n/TranslationContext", () => ({
+	useAppTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// PromptsSettings falls back to context when props are absent; we always pass
+// props here (the SettingsView wiring), so the context values are inert.
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		listApiConfigMeta: [],
+		enhancementApiConfigId: "",
+		setEnhancementApiConfigId: vi.fn(),
+		includeTaskHistoryInEnhance: true,
+		setIncludeTaskHistoryInEnhance: vi.fn(),
+	}),
+}))
+
+const renderSettings = (overrides = {}) => {
+	const setIncludeTaskHistoryInEnhance = vi.fn()
+	const props = {
+		customSupportPrompts: {},
+		setCustomSupportPrompts: vi.fn(),
+		includeTaskHistoryInEnhance: true,
+		setIncludeTaskHistoryInEnhance,
+		...overrides,
+	}
+	render(<PromptsSettings {...(props as any)} />)
+	return { setIncludeTaskHistoryInEnhance }
+}
+
+describe("PromptsSettings - Save/Discard contract", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	// Case 5: includeTaskHistoryInEnhance must buffer, not persist before Save.
+	it("buffers includeTaskHistoryInEnhance toggle without persisting before Save", () => {
+		const { setIncludeTaskHistoryInEnhance } = renderSettings({ includeTaskHistoryInEnhance: true })
+
+		// The ENHANCE support option is active by default, so the checkbox is present.
+		const checkbox = screen
+			.getByText("prompts:supportPrompts.enhance.includeTaskHistory")
+			.closest("label")!
+			.querySelector('input[type="checkbox"]')!
+		fireEvent.click(checkbox)
+
+		expect(setIncludeTaskHistoryInEnhance).toHaveBeenCalledWith(false)
+		expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "updateSettings" }))
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/PromptsSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/PromptsSettings.spec.tsx
@@ -15,15 +15,19 @@ vi.mock("@src/i18n/TranslationContext", () => ({
 	useAppTranslation: () => ({ t: (key: string) => key }),
 }))
 
-// PromptsSettings falls back to context when props are absent; we always pass
-// props here (the SettingsView wiring), so the context values are inert.
+// Exposed so tests can assert the context (uncontrolled) setter still fires.
+const { contextSetIncludeTaskHistoryInEnhance } = vi.hoisted(() => ({
+	contextSetIncludeTaskHistoryInEnhance: vi.fn(),
+}))
+
+// PromptsSettings falls back to context when props are absent.
 vi.mock("@src/context/ExtensionStateContext", () => ({
 	useExtensionState: () => ({
 		listApiConfigMeta: [],
 		enhancementApiConfigId: "",
 		setEnhancementApiConfigId: vi.fn(),
 		includeTaskHistoryInEnhance: true,
-		setIncludeTaskHistoryInEnhance: vi.fn(),
+		setIncludeTaskHistoryInEnhance: contextSetIncludeTaskHistoryInEnhance,
 	}),
 }))
 
@@ -58,5 +62,30 @@ describe("PromptsSettings - Save/Discard contract", () => {
 
 		expect(setIncludeTaskHistoryInEnhance).toHaveBeenCalledWith(false)
 		expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "updateSettings" }))
+	})
+
+	// Uncontrolled usage (props omitted) has no cachedState/Save wiring, so the
+	// toggle must persist immediately via updateSettings — otherwise it is lost.
+	it("persists includeTaskHistoryInEnhance immediately when used uncontrolled", () => {
+		render(
+			<PromptsSettings
+				customSupportPrompts={{}}
+				setCustomSupportPrompts={vi.fn()}
+				// includeTaskHistoryInEnhance / setIncludeTaskHistoryInEnhance omitted → context fallback
+			/>,
+		)
+
+		const checkbox = screen
+			.getByText("prompts:supportPrompts.enhance.includeTaskHistory")
+			.closest("label")!
+			.querySelector('input[type="checkbox"]')!
+		fireEvent.click(checkbox)
+
+		// Still updates local (context) state, and also persists immediately.
+		expect(contextSetIncludeTaskHistoryInEnhance).toHaveBeenCalledWith(false)
+		expect(vscode.postMessage).toHaveBeenCalledWith({
+			type: "updateSettings",
+			updatedSettings: { includeTaskHistoryInEnhance: false },
+		})
 	})
 })

--- a/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
@@ -777,9 +777,9 @@ describe("SettingsView - Duplicate Commands", () => {
 		)
 	})
 
-	it("does not persist allowed commands when discarding unsaved changes", () => {
+	it("reverts and does not persist allowed commands when discarding unsaved changes", () => {
 		// Render once and get the activateTab helper
-		const { activateTab, getSettingsContent } = renderSettingsView()
+		const { onDone, activateTab, getSettingsContent } = renderSettingsView()
 
 		// Activate the autoApprove tab
 		activateTab("autoApprove")
@@ -794,6 +794,9 @@ describe("SettingsView - Duplicate Commands", () => {
 		fireEvent.change(input, { target: { value: "npm test" } })
 		const addButton = within(content).getByTestId("add-command-button")
 		fireEvent.click(addButton)
+
+		// Verify the command was buffered and rendered before discarding it
+		expect(within(content).getByText("npm test")).toBeInTheDocument()
 
 		// Click Done, which opens the unsaved-changes dialog since a change is detected
 		const doneButton = screen.getByText("settings:common.done")
@@ -810,5 +813,9 @@ describe("SettingsView - Duplicate Commands", () => {
 				updatedSettings: expect.objectContaining({ allowedCommands: ["npm test"] }),
 			}),
 		)
+
+		// The buffered edit must be reverted before leaving Settings
+		expect(within(getSettingsContent()).queryByText("npm test")).not.toBeInTheDocument()
+		expect(onDone).toHaveBeenCalledTimes(1)
 	})
 })

--- a/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
@@ -629,13 +629,13 @@ describe("SettingsView - Allowed Commands", () => {
 		// Verify command was added
 		expect(within(content).getByText("npm test")).toBeInTheDocument()
 
-		// Verify VSCode message was sent
-		expect(vscode.postMessage).toHaveBeenCalledWith({
-			type: "updateSettings",
-			updatedSettings: {
-				allowedCommands: ["npm test"],
-			},
-		})
+		// Adding a command must NOT persist before Save; it only buffers in cachedState.
+		expect(vscode.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ allowedCommands: ["npm test"] }),
+			}),
+		)
 	})
 
 	it("removes command from the list", () => {
@@ -663,13 +663,13 @@ describe("SettingsView - Allowed Commands", () => {
 		// Verify command was removed
 		expect(within(content).queryByText("npm test")).not.toBeInTheDocument()
 
-		// Verify VSCode message was sent
-		expect(vscode.postMessage).toHaveBeenLastCalledWith({
-			type: "updateSettings",
-			updatedSettings: {
-				allowedCommands: [],
-			},
-		})
+		// Removing a command must NOT persist before Save; it only buffers in cachedState.
+		expect(vscode.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ allowedCommands: expect.anything() }),
+			}),
+		)
 	})
 
 	describe("SettingsView - Tab Navigation", () => {
@@ -773,6 +773,41 @@ describe("SettingsView - Duplicate Commands", () => {
 				updatedSettings: expect.objectContaining({
 					allowedCommands: ["npm test"],
 				}),
+			}),
+		)
+	})
+
+	it("does not persist allowed commands when discarding unsaved changes", () => {
+		// Render once and get the activateTab helper
+		const { activateTab, getSettingsContent } = renderSettingsView()
+
+		// Activate the autoApprove tab
+		activateTab("autoApprove")
+
+		const content = getSettingsContent()
+		// Enable always allow execute
+		const executeCheckbox = within(content).getByTestId("always-allow-execute-toggle")
+		fireEvent.click(executeCheckbox)
+
+		// Add a command (buffers into cachedState, must not persist yet)
+		const input = within(content).getByTestId("command-input")
+		fireEvent.change(input, { target: { value: "npm test" } })
+		const addButton = within(content).getByTestId("add-command-button")
+		fireEvent.click(addButton)
+
+		// Click Done, which opens the unsaved-changes dialog since a change is detected
+		const doneButton = screen.getByText("settings:common.done")
+		fireEvent.click(doneButton)
+
+		// Confirm discard
+		const discardButton = screen.getByTestId("alert-dialog-action")
+		fireEvent.click(discardButton)
+
+		// Discarding must never persist the buffered command edit
+		expect(vscode.postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ allowedCommands: ["npm test"] }),
 			}),
 		)
 	})

--- a/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
@@ -4,13 +4,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import React from "react"
 
 import SettingsView from "../SettingsView"
+import { vscode } from "@src/utils/vscode"
 
-// Mock vscode API
-const mockPostMessage = vi.fn()
-const mockVscode = {
-	postMessage: mockPostMessage,
-}
-;(global as any).acquireVsCodeApi = () => mockVscode
+const postMessage = vi.spyOn(vscode, "postMessage").mockImplementation(() => {})
 
 // Mock the extension state context
 vi.mock("@src/context/ExtensionStateContext", () => ({
@@ -170,7 +166,14 @@ vi.mock("@src/components/modes/ModesView", () => ({
 }))
 
 vi.mock("@src/components/mcp/McpView", () => ({
-	default: () => null,
+	default: ({ mcpEnabled, setMcpEnabled }: any) => (
+		<button
+			data-testid="mcp-enabled-toggle"
+			data-mcp-enabled={String(mcpEnabled)}
+			onClick={() => setMcpEnabled(!mcpEnabled)}>
+			Toggle MCP
+		</button>
+	),
 }))
 
 // Mock Tab components
@@ -595,5 +598,34 @@ describe("SettingsView - Unsaved Changes Detection", () => {
 
 		// No dialog should appear
 		expect(screen.queryByText("settings:unsavedChangesDialog.title")).not.toBeInTheDocument()
+	})
+
+	it("buffers MCP enablement until Save", async () => {
+		render(
+			<QueryClientProvider client={queryClient}>
+				<SettingsView onDone={vi.fn()} targetSection="mcp" />
+			</QueryClientProvider>,
+		)
+
+		const toggle = await screen.findByTestId("mcp-enabled-toggle")
+		fireEvent.click(toggle)
+
+		await waitFor(() => expect(toggle).toHaveAttribute("data-mcp-enabled", "true"))
+		expect(postMessage).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ mcpEnabled: true }),
+			}),
+		)
+
+		await waitFor(() => expect(screen.getByTestId("save-button")).toBeEnabled())
+		fireEvent.click(screen.getByTestId("save-button"))
+
+		expect(postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ mcpEnabled: true }),
+			}),
+		)
 	})
 })


### PR DESCRIPTION
<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #862 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

Several controls inside `SettingsView` wrote their changes to the extension host **immediately** via `updateSettings`, instead of buffering them in the local `cachedState` and waiting for the user to click **Save**. Because **Discard** reverts edits by resetting `cachedState` back to the persisted state (`setCachedState(extensionState)`), any control that had already posted `updateSettings` poisoned that source of truth — so Discard could no longer undo the change, silently breaking the Save/Discard contract.

This PR routes all five Save-managed values exclusively through `cachedState` / `setCachedStateField` while `SettingsView` is open:

- **`allowedCommands` / `deniedCommands`** (`AutoApproveSettings`) — drop the immediate `updateSettings` on command add/remove.
- **`profileThresholds`** (`ContextManagementSettings`) — drop the immediate `updateSettings` on the non-default profile branch; remove the now-unused `vscode` import.
- **`includeTaskHistoryInEnhance`** (`PromptsSettings`) — drop the immediate `updateSettings` on toggle.
- **`mcpEnabled`** (`McpEnabledToggle` / `McpView`) — adopt the existing "props first, fall back to context" pattern so `SettingsView` can pass the buffered value and a `cachedState`-backed setter. Because `mcpEnabled` is also read by `McpView` to gate the server list, the prop is threaded through `McpView` down to the toggle.

**Design choices / trade-offs:**

- The extension host side (`webviewMessageHandler.ts`) is correct and left untouched — persisting on receipt of `updateSettings` is expected. The fix belongs on the webview side: stop sending it before Save.
- `McpEnabledToggle` and `McpView` stay backward compatible: when used **uncontrolled** (no props), they fall back to live extension state and keep the original immediate-persist behavior. Only the `SettingsView` (controlled) path buffers.
- Genuinely-immediate actions are intentionally left unchanged because they are **not** part of the Save payload: `autoApprovalEnabled` and the per-server MCP actions (`toggleMcpServer`, `deleteMcpServer`, `restartMcpServer`, `updateMcpTimeout`).


### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

**Automated (webview-ui component/unit layer — the lowest layer that would have failed):**

```bash
cd webview-ui
npx vitest run \
  src/components/settings/__tests__/AutoApproveSettings.spec.tsx \
  src/components/settings/__tests__/ContextManagementSettings.spec.tsx \
  src/components/settings/__tests__/PromptsSettings.spec.tsx \
  src/components/mcp/__tests__/McpEnabledToggle.spec.tsx \
  src/components/settings/__tests__/SettingsView.spec.tsx
```

Added / updated tests:

- `AutoApproveSettings` — adding/removing allowed & denied commands buffers via `setCachedStateField` and posts **no** `updateSettings`.
- `ContextManagementSettings` — changing a non-default profile threshold buffers and posts **no** `updateSettings`.
- `PromptsSettings` — toggling include-task-history calls the setter and posts **no** `updateSettings`.
- `McpEnabledToggle` — controlled usage buffers via the setter prop and posts nothing; uncontrolled usage keeps the original immediate behavior.
- `SettingsView` — existing allowed-command tests updated to assert no pre-Save persistence, plus a new Discard regression test.

**Manual (reproduces the original bug; using Allowed Commands as the example):**

1. Open Settings → **Auto Approve** → enable **Execute**.
2. Type `npm test` in the allowed-commands input and click **Add**.
3. Do **not** click Save. Click **Done** and choose **Discard changes**.
4. Reopen Settings → Auto Approve → Execute.
5. **Before:** `npm test` is still there. **After this PR:** it is gone.

The same flow reproduces for denied commands, non-default profile thresholds,
Prompts → Enhance → include task history, and MCP → Enable MCP.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->
The behavior now matches the repository's Settings View Pattern: Save-managed values bind to local `cachedState`, `Save` posts them once via `handleSubmit`, and `Discard` fully reverts. No changes to the extension host or message protocol.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MCP enablement in Settings to support buffered, controlled edits with Save/Discard behavior.
* **Bug Fixes**
  * Prevented immediate persistence for command allow/deny edits, non-default context threshold changes, and the task-history prompt toggle; these now update locally until Save.
* **Tests**
  * Added/updated Vitest coverage to verify Save/Discard buffering for MCP, Auto-Approve commands, context thresholds, prompt preferences, and discard flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->