### PR TITLE
fix(webview): anchor thinking timer to message timestamp to survive Virtuoso remounts

### DIFF
--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -14,14 +14,19 @@ interface ReasoningBlockProps {
 	metadata?: any
 }
 
-export const ReasoningBlock = ({ content, isStreaming, isLast }: ReasoningBlockProps) => {
+export const ReasoningBlock = ({ content, isStreaming, isLast, ts }: ReasoningBlockProps) => {
 	const { t } = useTranslation()
 	const { reasoningBlockCollapsed } = useExtensionState()
 
 	const [isCollapsed, setIsCollapsed] = useState(reasoningBlockCollapsed)
 
-	const startTimeRef = useRef<number>(Date.now())
-	const [elapsed, setElapsed] = useState<number>(0)
+	// Anchor the elapsed timer to the message creation timestamp (ts)
+	// rather than component mount time. When Virtuoso recycles or
+	// remounts this component (e.g. during expand/collapse in a
+	// virtualized list), the timer survives because ts is a stable
+	// prop from the message data rather than a fresh Date.now().
+	const startTimeRef = useRef<number>(ts)
+	const [elapsed, setElapsed] = useState<number>(() => (isStreaming ? 0 : Math.max(0, Date.now() - ts)))
 	const contentRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -14,6 +14,16 @@ interface ReasoningBlockProps {
 	metadata?: any
 }
 
+/**
+ * Module-level cache that persists elapsed reasoning durations across
+ * React component remounts. When Virtuoso recycles a ReasoningBlock
+ * (e.g., during expand/collapse or scroll), the cache provides the
+ * final elapsed value from the previous mount cycle instead of
+ * recomputing from Date.now() - ts, which would be wrong if minutes
+ * have passed since the message was created.
+ */
+const elapsedCache = new Map<number, number>()
+
 export const ReasoningBlock = ({ content, isStreaming, isLast, ts }: ReasoningBlockProps) => {
 	const { t } = useTranslation()
 	const { reasoningBlockCollapsed } = useExtensionState()
@@ -26,7 +36,14 @@ export const ReasoningBlock = ({ content, isStreaming, isLast, ts }: ReasoningBl
 	// virtualized list), the timer survives because ts is a stable
 	// prop from the message data rather than a fresh Date.now().
 	const startTimeRef = useRef<number>(ts)
-	const [elapsed, setElapsed] = useState<number>(() => (isStreaming ? 0 : Math.max(0, Date.now() - ts)))
+	// On init, prefer cached elapsed (survives remounts). If not cached,
+	// use Date.now() - ts for a reasonable initial estimate. This handles
+	// the first mount where no cached value exists yet.
+	const [elapsed, setElapsed] = useState<number>(() => {
+		const cached = elapsedCache.get(ts)
+		if (cached !== undefined) return cached
+		return isStreaming ? 0 : Math.max(0, Date.now() - ts)
+	})
 	const contentRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {
@@ -35,12 +52,25 @@ export const ReasoningBlock = ({ content, isStreaming, isLast, ts }: ReasoningBl
 
 	useEffect(() => {
 		if (isLast && isStreaming) {
-			const tick = () => setElapsed(Date.now() - startTimeRef.current)
+			const tick = () => {
+				const current = Date.now() - startTimeRef.current
+				setElapsed(current)
+				elapsedCache.set(ts, current)
+			}
 			tick()
 			const id = setInterval(tick, 1000)
 			return () => clearInterval(id)
 		}
 	}, [isLast, isStreaming])
+
+	// Cache the final elapsed value when streaming stops so it survives
+	// future remounts even if the component unmounts before the timer
+	// effect cleanup runs.
+	useEffect(() => {
+		if (!isStreaming && elapsed > 0) {
+			elapsedCache.set(ts, elapsed)
+		}
+	}, [isStreaming, ts, elapsed])
 
 	const seconds = Math.floor(elapsed / 1000)
 	const secondsLabel = t("chat:reasoning.seconds", { count: seconds })

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -61,7 +61,7 @@ export const ReasoningBlock = ({ content, isStreaming, isLast, ts }: ReasoningBl
 			const id = setInterval(tick, 1000)
 			return () => clearInterval(id)
 		}
-	}, [isLast, isStreaming])
+		}, [isLast, isStreaming, ts])
 
 	// Cache the final elapsed value when streaming stops so it survives
 	// future remounts even if the component unmounts before the timer

--- a/webview-ui/src/components/chat/__tests__/ReasoningBlock.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ReasoningBlock.spec.tsx
@@ -75,30 +75,31 @@ describe("ReasoningBlock", () => {
 		expect(screen.getByText("5s")).toBeInTheDocument()
 	})
 
-	it("preserves elapsed time on remount with same ts (Virtuoso recycle)", () => {
-		// ts is 1 second in the past so elapsed starts at 1s (not 0, since 0 hides the label)
-		const ts = Date.now() - 1000
+		it("preserves elapsed time on remount with same ts (Virtuoso recycle)", () => {
+			// ts is 1 second in the past so elapsed starts at 1s (not 0, since 0 hides the label)
+			const ts = Date.now() - 1000
 
-		const { unmount } = render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+			const { unmount } = render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
 
-		// Initially 1s since ts is 1s ago
-		expect(screen.getByText("1s")).toBeInTheDocument()
+			// Initially 1s since ts is 1s ago
+			expect(screen.getByText("1s")).toBeInTheDocument()
 
-		// Advance time by 10 seconds
-		act(() => {
-			vi.advanceTimersByTime(10_000)
+			// Advance time by 10 seconds
+			act(() => {
+				vi.advanceTimersByTime(10_000)
+			})
+
+			// Unmount (simulating Virtuoso recycling the component)
+			unmount()
+
+			// Remount with the same ts
+			render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+
+			// Should still show 1s — the elapsed value was cached at module level
+			// and survived the remount, instead of recomputing from Date.now() - ts
+			// (which would give 11s and inflate the timer after a scroll away)
+			expect(screen.getByText("1s")).toBeInTheDocument()
 		})
-
-		// Unmount (simulating Virtuoso recycling the component)
-		unmount()
-
-		// Remount with the same ts
-		render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
-
-		// Should still show ~11s, not 1 — timer survived the remount
-		// (elapsed is computed from Date.now() - ts on each mount, and fake timers keep advancing)
-		expect(screen.getByText("11s")).toBeInTheDocument()
-	})
 
 	it("stops timer when streaming ends", () => {
 		const ts = Date.now() - 5000

--- a/webview-ui/src/components/chat/__tests__/ReasoningBlock.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ReasoningBlock.spec.tsx
@@ -1,0 +1,151 @@
+// npx vitest src/components/chat/__tests__/ReasoningBlock.spec.tsx
+
+import React from "react"
+import { render, screen, act } from "@/utils/test-utils"
+
+import { ReasoningBlock } from "../ReasoningBlock"
+
+// Mock i18n
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string, options?: any) => {
+			if (key === "chat:reasoning.seconds") {
+				return `${options?.count ?? 0}s`
+			}
+			return key
+		},
+	}),
+	initReactI18next: {
+		type: "3rdParty",
+		init: vi.fn(),
+	},
+}))
+
+// Mock ExtensionStateContext
+const mockExtensionState = {
+	reasoningBlockCollapsed: false,
+}
+
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => mockExtensionState,
+}))
+
+const defaultProps = {
+	content: "Let me think about this...",
+	ts: Date.now() - 30_000, // 30 seconds ago
+	isStreaming: false,
+	isLast: false,
+} as const
+
+describe("ReasoningBlock", () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.setSystemTime(Date.now())
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it("renders the thinking label", () => {
+		render(<ReasoningBlock {...defaultProps} />)
+		expect(screen.getByText("chat:reasoning.thinking")).toBeInTheDocument()
+	})
+
+	it("shows elapsed time for non-streaming blocks anchored to ts", () => {
+		const thirtySecAgo = Date.now() - 30_000
+		render(<ReasoningBlock {...defaultProps} ts={thirtySecAgo} isStreaming={false} />)
+
+		// Should show ~30s since the timestamp
+		expect(screen.getByText("30s")).toBeInTheDocument()
+	})
+
+	it("starts timer at 0 when streaming and is last message", () => {
+		const ts = Date.now()
+		render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={true} isLast={true} content="" />)
+
+		// Initially 0 while streaming (just started) — no label shown when elapsed is 0
+		expect(screen.queryByText(/^\d+s$/)).not.toBeInTheDocument()
+
+		// Advance time by 5 seconds
+		act(() => {
+			vi.advanceTimersByTime(5000)
+		})
+
+		expect(screen.getByText("5s")).toBeInTheDocument()
+	})
+
+	it("preserves elapsed time on remount with same ts (Virtuoso recycle)", () => {
+		// ts is 1 second in the past so elapsed starts at 1s (not 0, since 0 hides the label)
+		const ts = Date.now() - 1000
+
+		const { unmount } = render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+
+		// Initially 1s since ts is 1s ago
+		expect(screen.getByText("1s")).toBeInTheDocument()
+
+		// Advance time by 10 seconds
+		act(() => {
+			vi.advanceTimersByTime(10_000)
+		})
+
+		// Unmount (simulating Virtuoso recycling the component)
+		unmount()
+
+		// Remount with the same ts
+		render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+
+		// Should still show ~11s, not 1 — timer survived the remount
+		// (elapsed is computed from Date.now() - ts on each mount, and fake timers keep advancing)
+		expect(screen.getByText("11s")).toBeInTheDocument()
+	})
+
+	it("stops timer when streaming ends", () => {
+		const ts = Date.now() - 5000
+
+		const { rerender } = render(
+			<ReasoningBlock {...defaultProps} ts={ts} isStreaming={true} isLast={true} content="" />,
+		)
+
+		// Streaming — timer is active
+		expect(screen.getByText("5s")).toBeInTheDocument()
+
+		// Advance time while streaming
+		act(() => {
+			vi.advanceTimersByTime(3000)
+		})
+
+		expect(screen.getByText("8s")).toBeInTheDocument()
+
+		// Streaming stops — rerender with isStreaming=false
+		rerender(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+
+		// Timer should stop at current value
+		act(() => {
+			vi.advanceTimersByTime(5000)
+		})
+
+		// Should NOT have advanced
+		expect(screen.getByText("8s")).toBeInTheDocument()
+	})
+
+	it("collapses when reasoningBlockCollapsed is true", () => {
+		mockExtensionState.reasoningBlockCollapsed = true
+
+		render(<ReasoningBlock {...defaultProps} />)
+
+		// Content and markdown should be hidden
+		expect(screen.queryByText(defaultProps.content)).not.toBeInTheDocument()
+
+		// Reset for other tests
+		mockExtensionState.reasoningBlockCollapsed = false
+	})
+
+	it("hides elapsed label when elapsed is 0", () => {
+		const ts = Date.now()
+		render(<ReasoningBlock {...defaultProps} ts={ts} isStreaming={false} isLast={false} />)
+
+		// No seconds label because elapsed is 0
+		expect(screen.queryByText(/^\d+s$/)).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION
### Related GitHub Issue

Closes: #656

### Description

The thinking/reasoning timer (e.g., "Thought for 30s") was resetting to 0 or disappearing when the user expanded and then collapsed the thinking section. This happened because `ReasoningBlock` used `Date.now()` as the timer anchor at component mount time — but inside a `Virtuoso` virtual list, expand/collapse can trigger DOM recycling that unmounts and remounts the component. On remount, `startTimeRef` gets a fresh `Date.now()`, and since `isStreaming` is already `false` (the message finished streaming before the user interacted), the timer effect never runs — leaving `elapsed` at 0.

This was more visible with zh_CN locale because CJK character widths in the header text produced different DOM geometry, pushing the layout past Virtuoso recycle thresholds in viewports where Latin text would not trigger a remount.

**Fix**: The component now uses the message creation timestamp (`ts` prop, already passed from `ChatRow.tsx` but previously discarded in the destructuring) as the timer anchor. On remount after streaming has finished, `elapsed` is initialized from `Date.now() - ts`, giving a reasonable approximation of the thinking duration instead of 0.

### Test Procedure

1. Start a chat with any provider that supports thinking/reasoning (Claude with extended thinking, DeepSeek, etc.)
2. Wait for the thinking section to appear with a timer (e.g., "30s")
3. Expand the thinking section, then collapse it
4. Verify the timer still shows the original duration — not 0s or hidden
5. Repeat with different locales (en, zh_CN) to confirm the fix is locale-independent

### Pre-Submission Checklist

- [x] **Issue Linked**: Closes #656
- [x] **Scope**: One focused fix — anchors timer to stable message data
- [x] **Self-Review**: Props interface already had `ts`; component just wasn't using it — this is a pure hook into existing data
- [x] **Testing**: TypeScript compilation verified; tested the remount scenario with the init function fallback
- [x] **Documentation Impact**: No documentation updates required
- [x] **Contribution Guidelines**: Read and agree

### Screenshots / Videos

N/A — state management fix, no visual change beyond the timer not resetting.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

Edge case: for messages scrolled away for minutes and then scrolled back, `Date.now() - ts` will show longer than the actual thinking time. This is cosmetic and far preferable to showing 0 or hiding the timer entirely — and only affects the unlikely case of a late remount after significant wall-clock time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elapsed-time display for streaming and non-streaming reasoning by basing the timer on the message’s creation time rather than when the UI mounts.
  * Elapsed-time now starts at 0 while streaming, stays consistent if the view is reopened for the same message, and stops updating when streaming ends.
* **Tests**
  * Added automated coverage for elapsed-time rendering, streaming updates, caching across remounts, and collapsed/zero-duration display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->