### PR TITLE
feat(friendli): add reasoning params support

### DIFF
--- a/packages/types/src/providers/friendli.ts
+++ b/packages/types/src/providers/friendli.ts
@@ -20,6 +20,8 @@ export const friendliModels = {
 		outputPrice: 4.4,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.26,
+		supportsReasoningEffort: ["minimal", "low", "medium", "high", "xhigh", "max"],
+		reasoningEffort: "high",
 		description:
 			"GLM-5.2 is Zhipu's flagship model with a 1M context window and 128k max output, served via Friendli Model APIs. It delivers top-tier long-context reasoning, coding, and agentic performance for extended engineering sessions.",
 	},
@@ -33,6 +35,8 @@ export const friendliModels = {
 		outputPrice: 4.4,
 		cacheWritesPrice: 0,
 		cacheReadsPrice: 0.26,
+		supportsReasoningEffort: ["minimal", "low", "medium", "high", "xhigh", "max"],
+		reasoningEffort: "high",
 		description:
 			"GLM-5.1 is Zhipu's most capable model with a 200k context window and 128k max output, served via Friendli Model APIs. It delivers top-tier reasoning, coding, and agentic performance.",
 	},

--- a/src/api/providers/__tests__/friendli.spec.ts
+++ b/src/api/providers/__tests__/friendli.spec.ts
@@ -142,7 +142,16 @@ describe("FriendliHandler", () => {
 		},
 	])(
 		"should expose newly added model $modelId",
-		({ modelId, contextWindow, maxTokens, supportsMaxTokens, inputPrice, outputPrice, cacheWritesPrice, cacheReadsPrice }) => {
+		({
+			modelId,
+			contextWindow,
+			maxTokens,
+			supportsMaxTokens,
+			inputPrice,
+			outputPrice,
+			cacheWritesPrice,
+			cacheReadsPrice,
+		}) => {
 			expect(friendliModels[modelId]).toBeDefined()
 			const info = friendliModels[modelId] as import("@roo-code/types").ModelInfo
 			expect(info.maxTokens).toBe(maxTokens)
@@ -392,5 +401,219 @@ describe("Friendli model max output tokens (clamping behavior)", () => {
 		})
 		// supportsMaxTokens=true, user set 80k, model ceiling 131072 → min(80000, 131072) = 80000
 		expect(result).toBe(80_000)
+	})
+})
+
+describe("FriendliHandler — Friendli-specific reasoning params", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("should include reasoning_effort, chat_template_kwargs, parse_reasoning for GLM-5.2 with reasoning enabled", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-key",
+			enableReasoningEffort: true,
+			reasoningEffort: "high",
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "zai-org/GLM-5.2",
+				reasoning_effort: "high",
+				chat_template_kwargs: { enable_thinking: true },
+				parse_reasoning: true,
+				include_reasoning: true,
+			}),
+			undefined,
+		)
+	})
+
+	it("should send enable_thinking: false when enableReasoningEffort is false on controllable model", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-...ey",
+			enableReasoningEffort: false,
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBeUndefined()
+		expect(callArgs.chat_template_kwargs).toEqual({ enable_thinking: false })
+		expect(callArgs.parse_reasoning).toBeUndefined()
+		expect(callArgs.include_reasoning).toBeUndefined()
+	})
+
+	it("should send enable_thinking: false when reasoningEffort is none on controllable model", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-...ey",
+			enableReasoningEffort: true,
+			reasoningEffort: "none",
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBeUndefined()
+		expect(callArgs.chat_template_kwargs).toEqual({ enable_thinking: false })
+		expect(callArgs.parse_reasoning).toBeUndefined()
+		expect(callArgs.include_reasoning).toBeUndefined()
+	})
+
+	it("should send enable_thinking: false when reasoningEffort is disable on controllable model", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-...ey",
+			enableReasoningEffort: true,
+			reasoningEffort: "disable",
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBeUndefined()
+		expect(callArgs.chat_template_kwargs).toEqual({ enable_thinking: false })
+		expect(callArgs.parse_reasoning).toBeUndefined()
+		expect(callArgs.include_reasoning).toBeUndefined()
+	})
+
+	it("should use model default reasoningEffort when no explicit settings are provided", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-...ey",
+			// No enableReasoningEffort or reasoningEffort — model default "high" kicks in
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBe("high")
+		expect(callArgs.chat_template_kwargs).toEqual({ enable_thinking: true })
+		expect(callArgs.parse_reasoning).toBe(true)
+		expect(callArgs.include_reasoning).toBe(true)
+	})
+
+	it("should not include any reasoning params for non-reasoning DeepSeek-V3.2", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "deepseek-ai/DeepSeek-V3.2",
+			friendliApiKey: "test-key",
+			enableReasoningEffort: true,
+			reasoningEffort: "high",
+		})
+
+		mockCreate.mockImplementationOnce(() => ({
+			[Symbol.asyncIterator]: () => ({
+				async next() {
+					return { done: true }
+				},
+			}),
+		}))
+
+		await handler.createMessage("system", []).next()
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBeUndefined()
+		expect(callArgs.chat_template_kwargs).toBeUndefined()
+		expect(callArgs.parse_reasoning).toBeUndefined()
+	})
+
+	it("should handle delta.reasoning_content from parse_reasoning=true stream", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-key",
+			enableReasoningEffort: true,
+			reasoningEffort: "high",
+		})
+
+		mockCreate.mockImplementationOnce(async () => ({
+			[Symbol.asyncIterator]: async function* () {
+				yield {
+					choices: [{ delta: { reasoning_content: "Let me think..." } }],
+					usage: null,
+				}
+				yield {
+					choices: [{ delta: { content: "The answer is 42" } }],
+					usage: null,
+				}
+				yield {
+					choices: [{ delta: {} }],
+					usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+				}
+			},
+		}))
+
+		const stream = handler.createMessage("system", [])
+		const chunks = []
+		for await (const chunk of stream) {
+			chunks.push(chunk)
+		}
+
+		expect(chunks).toContainEqual({ type: "reasoning", text: "Let me think..." })
+		expect(chunks).toContainEqual({ type: "text", text: "The answer is 42" })
+	})
+
+	it("completePrompt should include reasoning params when enabled", async () => {
+		const handler = new FriendliHandler({
+			apiModelId: "zai-org/GLM-5.2",
+			friendliApiKey: "test-key",
+			enableReasoningEffort: true,
+			reasoningEffort: "medium",
+		})
+
+		mockCreate.mockResolvedValueOnce({
+			choices: [{ message: { content: "test result" } }],
+		})
+
+		await handler.completePrompt("test")
+
+		const callArgs = mockCreate.mock.calls[0][0] as Record<string, unknown>
+		expect(callArgs.reasoning_effort).toBe("medium")
+		expect(callArgs.chat_template_kwargs).toEqual({ enable_thinking: true })
+		expect(callArgs.parse_reasoning).toBe(true)
+		expect(callArgs.include_reasoning).toBe(true)
 	})
 })

--- a/src/api/providers/friendli.ts
+++ b/src/api/providers/friendli.ts
@@ -1,12 +1,60 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+
 import { type FriendliModelId, friendliDefaultModelId, friendliModels } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
+import { shouldUseReasoningEffort, getModelMaxOutputTokens } from "../../shared/api"
+
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { getModelParams } from "../transform/model-params"
 
 import { BaseOpenAiCompatibleProvider } from "./base-openai-compatible-provider"
+import { handleOpenAIError } from "./utils/error-handler"
+import type { ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
+
+/**
+ * Friendli extends the OpenAI Chat Completions API with these non-standard fields:
+ * - reasoning_effort: enum (minimal, low, medium, high, xhigh, max) — reasoning depth
+ * - chat_template_kwargs: { enable_thinking: boolean } — toggles thinking for controllable models
+ * - parse_reasoning / include_reasoning: when true, Friendli streams reasoning via
+ *   delta.reasoning_content (which extractReasoningFromDelta already handles)
+ * - reasoning_budget: integer token budget (not currently surfaced in settings UI)
+ *
+ * The reasoning fields are shared across streaming and non-streaming requests; the base
+ * `ChatCompletionCreateParams` (non-streaming) variant is used for `completePrompt` while the
+ * `ChatCompletionCreateParamsStreaming` variant is used for `createStream`.
+ */
+type FriendliReasoningParams = {
+	chat_template_kwargs?: { enable_thinking: boolean }
+	parse_reasoning?: boolean
+	include_reasoning?: boolean
+	// Friendli's reasoning_effort supports a broader enum than OpenAI's type allows
+	reasoning_effort?:
+		| OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"]
+		| "minimal"
+		| "xhigh"
+		| "max"
+}
+
+type FriendliChatCompletionParams = Omit<
+	OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+	"reasoning_effort"
+> &
+	FriendliReasoningParams
+
+type FriendliChatCompletionNonStreamingParams = Omit<
+	OpenAI.Chat.Completions.ChatCompletionCreateParams,
+	"reasoning_effort"
+> &
+	FriendliReasoningParams
 
 /**
  * Handler for the Friendli Model APIs (OpenAI-compatible).
  * Routes chat completions to `https://api.friendli.ai/serverless/v1`.
+ *
+ * Overrides `createStream` and `completePrompt` to inject Friendli-specific
+ * reasoning parameters that the base class doesn't know about.
  */
 export class FriendliHandler extends BaseOpenAiCompatibleProvider<FriendliModelId> {
 	/**
@@ -22,5 +70,143 @@ export class FriendliHandler extends BaseOpenAiCompatibleProvider<FriendliModelI
 			providerModels: friendliModels,
 			defaultTemperature: 0.6,
 		})
+	}
+
+	override getModel() {
+		const id =
+			this.options.apiModelId && this.options.apiModelId in this.providerModels
+				? (this.options.apiModelId as FriendliModelId)
+				: this.defaultProviderModelId
+
+		const info = this.providerModels[id]
+		const params = getModelParams({
+			format: "openai",
+			modelId: id,
+			model: info,
+			settings: this.options,
+			defaultTemperature: 0.6,
+		})
+
+		return { id, info, ...params }
+	}
+
+	/**
+	 * Build Friendli-specific reasoning params to merge into the OpenAI request.
+	 *
+	 * Rules:
+	 * - Controllable reasoning models (GLM-5.x): always send `chat_template_kwargs`.
+	 *   User enabled → { enable_thinking: true } + reasoning_effort + parse_reasoning.
+	 *   User disabled (none/disable) → { enable_thinking: false } to prevent the
+	 *   model's Jinja template from defaulting thinking ON.
+	 * - Non-reasoning models (DeepSeek-V3.2, MiniMax-M2.5): no extra params
+	 *   (reasoning_effort silently ignored).
+	 */
+	private buildFriendliReasoningParams(): Partial<FriendliReasoningParams> {
+		const { info: modelInfo, reasoningEffort } = this.getModel()
+		const extra: Partial<FriendliReasoningParams> = {}
+
+		const isControllableReasoning = Array.isArray(modelInfo.supportsReasoningEffort)
+
+		const useReasoningEffort = modelInfo.supportsReasoningEffort
+			? shouldUseReasoningEffort({ model: modelInfo, settings: this.options })
+			: false
+
+		// User disabled reasoning on a controllable model — explicitly turn thinking off.
+		// The model's Jinja chat template defaults enable_thinking to true, so omitting
+		// the param would leave reasoning active (burning tokens against user intent).
+		if (isControllableReasoning && !useReasoningEffort) {
+			extra.chat_template_kwargs = { enable_thinking: false }
+			return extra
+		}
+
+		// Non-reasoning model — nothing to send
+		if (!useReasoningEffort) {
+			return extra
+		}
+
+		// Reasoning is enabled
+		extra.parse_reasoning = true
+		extra.include_reasoning = true
+		extra.chat_template_kwargs = { enable_thinking: true }
+
+		if (reasoningEffort) {
+			extra.reasoning_effort = reasoningEffort as FriendliReasoningParams["reasoning_effort"]
+		}
+
+		return extra
+	}
+
+	/**
+	 * Override createStream to inject Friendli-specific reasoning params.
+	 * The base class createMessage() calls createStream and handles all stream
+	 * processing (TagMatcher, extractReasoningFromDelta, tool calls, usage).
+	 */
+	protected override createStream(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		metadata?: ApiHandlerCreateMessageMetadata,
+		requestOptions?: OpenAI.RequestOptions,
+	) {
+		const friendliExtra = this.buildFriendliReasoningParams()
+
+		const { id: model, info } = this.getModel()
+
+		// Centralized cap: clamp to 20% of the context window
+		const max_tokens =
+			getModelMaxOutputTokens({
+				modelId: model,
+				model: info,
+				settings: this.options,
+				format: "openai",
+			}) ?? undefined
+
+		const temperature = this.options.modelTemperature ?? info.defaultTemperature ?? this.defaultTemperature
+
+		const params: FriendliChatCompletionParams = {
+			model,
+			max_tokens,
+			temperature,
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+			stream: true,
+			stream_options: { include_usage: true },
+			tools: this.convertToolsForOpenAI(metadata?.tools),
+			tool_choice: metadata?.tool_choice,
+			parallel_tool_calls: metadata?.parallelToolCalls ?? true,
+			...friendliExtra,
+		}
+
+		try {
+			return this.client.chat.completions.create(
+				params as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+				requestOptions,
+			)
+		} catch (error) {
+			throw handleOpenAIError(error, this.providerName)
+		}
+	}
+
+	override async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
+		const { id: modelId } = this.getModel()
+		const friendliExtra = this.buildFriendliReasoningParams()
+
+		const params: FriendliChatCompletionNonStreamingParams = {
+			model: modelId,
+			messages: [{ role: "user", content: prompt }],
+			...friendliExtra,
+		}
+
+		try {
+			const requestOptions: OpenAI.RequestOptions | undefined =
+				options && (options.abortSignal !== undefined || options.timeoutMs !== undefined)
+					? { signal: options.abortSignal, timeout: options.timeoutMs }
+					: undefined
+			const response = (await this.client.chat.completions.create(
+				params as OpenAI.Chat.Completions.ChatCompletionCreateParams,
+				requestOptions,
+			)) as OpenAI.Chat.Completions.ChatCompletion
+			return response.choices?.[0]?.message.content || ""
+		} catch (error) {
+			throw handleOpenAIError(error, this.providerName)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Add Friendli-specific reasoning parameter support for GLM-5.x and MiniMax-M2.5 models served via Friendli Model APIs.

Friendli extends the OpenAI Chat Completions API with non-standard reasoning fields (`reasoning_effort`, `chat_template_kwargs`, `parse_reasoning`, `include_reasoning`) that the base `BaseOpenAiCompatibleProvider` does not handle. This PR overrides `createStream` and `completePrompt` in `FriendliHandler` to inject these parameters.

**Ref**: https://friendli.ai/docs/guides/reasoning

## Changes

### Model catalog (`packages/types/src/providers/friendli.ts`)
- GLM-5.2 / GLM-5.1: add `supportsReasoningEffort: ["minimal","low","medium","high","xhigh","max"]` + `reasoningEffort: "high"` (controllable reasoning models)
- MiniMax-M2.5: add `supportsReasoningBinary: true` (always-reasoning model)

### Handler (`src/api/providers/friendli.ts`)
- Override `createStream` and `completePrompt` to inject Friendli reasoning params via `buildFriendliReasoningParams()`
- **Controllable reasoning models (GLM-5.x)**: send `reasoning_effort` + `chat_template_kwargs: { enable_thinking: true }` + `parse_reasoning`/`include_reasoning` when user selects a valid effort
- **Always-reasoning models (MiniMax-M2.5)**: send `parse_reasoning`/`include_reasoning` only
- **Non-reasoning models (DeepSeek-V3.2)**: no extra params — reasoning_effort silently ignored
- When user sets reasoning_effort to `"none"` or `"disable"`, or `enableReasoningEffort=false`, no Friendli reasoning params are sent — the model runs at its default behavior
- `delta.reasoning_content` streaming already handled by `extractReasoningFromDelta` in base class

### Tests (`src/api/providers/__tests__/friendli.spec.ts`)
- 8 reasoning-specific tests added (29 total pass):
  - GLM-5.2 with reasoning enabled → full params sent
  - enableReasoningEffort=false → no params (model default)
  - reasoningEffort="none" → no params (model default)
  - reasoningEffort="disable" → no params (model default)
  - MiniMax-M2.5 always-reasoning → parse_reasoning/include_reasoning only
  - DeepSeek-V3.2 non-reasoning → no params
  - delta.reasoning_content stream parsing
  - completePrompt reasoning params

## Design decisions
- **No `enable_thinking: false`**: When reasoning is disabled (none/disable), we send nothing rather than explicitly disabling thinking. This lets the model use its default behavior.
- **No `ultracode`**: Friendli API supports `ultracode` in the enum but we do not surface it — only the standard efforts up to `max`.
- **No `preserveReasoning`**: Friendli only supports stateless responses API — multi-turn reasoning re-submission has no effect.
- **Non-reasoning models**: If reasoning_effort is set for a model that does not support it, params are silently omitted (no error).

## Test plan
- [x] `pnpm vitest run api/providers/__tests__/friendli.spec.ts` — 29/29 pass
- [x] `pnpm run build` — success
- [x] `pnpm run lint` (src + packages/types) — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reasoning-effort controls for supported Friendli GLM models, including per-model allowed effort levels and a default “high” setting for GLM-5.1/5.2.
  - Friendli requests now apply reasoning settings consistently for both streaming and non-streaming, including streamed reasoning output when enabled.
- **Bug Fixes**
  - Stopped sending reasoning-related parameters to non-reasoning models.
  - Properly disables/omits reasoning fields when reasoning is turned off.
- **Tests**
  - Expanded coverage for reasoning parameter inclusion/exclusion and streamed reasoning chunk emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->