### PR TITLE
feat(api): add CompletePromptOptions parameter to completePrompt method

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -42,8 +42,17 @@ import {
 } from "./providers"
 import { NativeOllamaHandler } from "./providers/native-ollama"
 
+/**
+ * Options for completePrompt — unified with ApiHandlerCreateMessageMetadata.
+ * Uses abortSignal (not signal) to match the metadata pattern used in stream path.
+ */
+export interface CompletePromptOptions extends Pick<ApiHandlerCreateMessageMetadata, "abortSignal"> {
+	/** Optional timeout override (ms) — falls back to provider default if omitted */
+	timeoutMs?: number
+}
+
 export interface SingleCompletionHandler {
-	completePrompt(prompt: string): Promise<string>
+	completePrompt(prompt: string, metadata?: CompletePromptOptions): Promise<string>
 }
 
 export interface ApiHandlerCreateMessageMetadata {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -52,7 +52,7 @@ export interface CompletePromptOptions extends Pick<ApiHandlerCreateMessageMetad
 }
 
 export interface SingleCompletionHandler {
-	completePrompt(prompt: string, metadata?: CompletePromptOptions): Promise<string>
+	completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string>
 }
 
 export interface ApiHandlerCreateMessageMetadata {

--- a/src/api/providers/__tests__/fake-ai.spec.ts
+++ b/src/api/providers/__tests__/fake-ai.spec.ts
@@ -1,0 +1,79 @@
+import type { Anthropic } from "@anthropic-ai/sdk"
+
+import type { ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../../index"
+import { FakeAIHandler } from "../fake-ai"
+
+const modelInfo = {
+	contextWindow: 8192,
+	maxTokens: 4096,
+	supportsImages: false,
+	supportsPromptCache: false,
+}
+
+describe("FakeAIHandler", () => {
+	it("should delegate completePrompt with options to the cached FakeAI instance", async () => {
+		const completePrompt = vitest.fn().mockResolvedValue("delegated response")
+		const fakeAi: {
+			id: string
+			createMessage: () => AsyncGenerator<never, void, unknown>
+			getModel: () => { id: string; info: typeof modelInfo }
+			countTokens: ReturnType<typeof vitest.fn>
+			completePrompt: typeof completePrompt
+			removeFromCache?: () => void
+		} = {
+			id: "fake-ai-completePrompt-delegation",
+			createMessage: async function* () {},
+			getModel: () => ({ id: "fake-model", info: modelInfo }),
+			countTokens: vitest.fn().mockResolvedValue(0),
+			completePrompt,
+		}
+		const controller = new AbortController()
+		const options: CompletePromptOptions = { abortSignal: controller.signal, timeoutMs: 1234 }
+
+		const handler = new FakeAIHandler({ fakeAi })
+		const result = await handler.completePrompt("Test prompt", options)
+
+		expect(result).toBe("delegated response")
+		expect(completePrompt).toHaveBeenCalledWith("Test prompt", options)
+		fakeAi.removeFromCache?.()
+	})
+
+	it("should delegate createMessage, getModel, and countTokens to FakeAI", async () => {
+		const metadata = { taskId: "task-1" } as ApiHandlerCreateMessageMetadata
+		const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "Hello" }]
+		const content: Anthropic.Messages.ContentBlockParam[] = [{ type: "text", text: "Hello" }]
+		const createMessage = vitest.fn(async function* () {
+			yield { type: "text" as const, text: "Hello" }
+		})
+		const getModel = vitest.fn(() => ({ id: "fake-model", info: modelInfo }))
+		const countTokens = vitest.fn().mockResolvedValue(7)
+		const fakeAi: {
+			id: string
+			createMessage: typeof createMessage
+			getModel: typeof getModel
+			countTokens: typeof countTokens
+			completePrompt: ReturnType<typeof vitest.fn>
+			removeFromCache?: () => void
+		} = {
+			id: "fake-ai-handler-delegation",
+			createMessage,
+			getModel,
+			countTokens,
+			completePrompt: vitest.fn().mockResolvedValue("complete"),
+		}
+
+		const handler = new FakeAIHandler({ fakeAi })
+		const chunks = []
+		for await (const chunk of handler.createMessage("System", messages, metadata)) {
+			chunks.push(chunk)
+		}
+
+		expect(chunks).toEqual([{ type: "text", text: "Hello" }])
+		expect(createMessage).toHaveBeenCalledWith("System", messages, metadata)
+		expect(handler.getModel()).toEqual({ id: "fake-model", info: modelInfo })
+		expect(getModel).toHaveBeenCalledTimes(1)
+		await expect(handler.countTokens(content)).resolves.toBe(7)
+		expect(countTokens).toHaveBeenCalledWith(content)
+		fakeAi.removeFromCache?.()
+	})
+})

--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -25,7 +25,7 @@ import {
 
 import { BaseProvider } from "./base-provider"
 import { parseVertexJsonCredentials } from "./utils/vertex-credentials"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 // https://docs.anthropic.com/en/api/claude-on-vertex-ai
 export class AnthropicVertexHandler extends BaseProvider implements SingleCompletionHandler {
@@ -270,7 +270,7 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: CompletePromptOptions) {
 		try {
 			const {
 				id,

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -22,7 +22,7 @@ import { getAnthropicProviderReasoning } from "../transform/reasoning"
 import { handleProviderError } from "./utils/error-handler"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { calculateApiCostAnthropic } from "../../shared/cost"
 import {
 	convertOpenAIToolsToAnthropic,
@@ -429,7 +429,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: CompletePromptOptions) {
 		const { id: model, temperature } = this.getModel()
 
 		let message

--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -8,7 +8,7 @@ import { TagMatcher } from "../../utils/tag-matcher"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
 import { handleOpenAIError } from "./utils/error-handler"
@@ -212,7 +212,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, info: modelInfo } = this.getModel()
 
 		const params: OpenAI.Chat.Completions.ChatCompletionCreateParams = {

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -44,7 +44,7 @@ import { convertToBedrockConverseMessages as sharedConverter } from "../transfor
 import { getModelParams } from "../transform/model-params"
 import { shouldUseReasoningBudget } from "../../shared/api"
 import { normalizeToolSchema } from "../../utils/json-schema"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 /************************************************************************************
  *
@@ -798,7 +798,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
 			const modelConfig = this.getModel()
 

--- a/src/api/providers/fake-ai.ts
+++ b/src/api/providers/fake-ai.ts
@@ -2,7 +2,12 @@ import { Anthropic } from "@anthropic-ai/sdk"
 
 import type { ModelInfo } from "@roo-code/types"
 
-import type { ApiHandler, SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type {
+	ApiHandler,
+	SingleCompletionHandler,
+	ApiHandlerCreateMessageMetadata,
+	CompletePromptOptions,
+} from "../index"
 import type { ApiHandlerOptions } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
 
@@ -28,7 +33,7 @@ interface FakeAI {
 	): ApiStream
 	getModel(): { id: string; info: ModelInfo }
 	countTokens(content: Array<Anthropic.Messages.ContentBlockParam>): Promise<number>
-	completePrompt(prompt: string): Promise<string>
+	completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string>
 }
 
 /**
@@ -75,7 +80,7 @@ export class FakeAIHandler implements ApiHandler, SingleCompletionHandler {
 		return this.ai.countTokens(content)
 	}
 
-	completePrompt(prompt: string): Promise<string> {
-		return this.ai.completePrompt(prompt)
+	completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
+		return this.ai.completePrompt(prompt, options)
 	}
 }

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -23,7 +23,7 @@ import { t } from "i18next"
 import type { ApiStream, GroundingSource } from "../transform/stream"
 import { getModelParams } from "../transform/model-params"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { BaseProvider } from "./base-provider"
 import { parseVertexJsonCredentials } from "./utils/vertex-credentials"
 
@@ -576,7 +576,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		return citationLinks.join(", ")
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: model, info } = this.getModel()
 
 		try {

--- a/src/api/providers/kenari.ts
+++ b/src/api/providers/kenari.ts
@@ -13,7 +13,7 @@ import { ApiHandlerOptions } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { RouterProvider } from "./router-provider"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
 
@@ -123,7 +123,7 @@ export class KenariHandler extends RouterProvider implements SingleCompletionHan
 	 * @returns The model's reply text, or an empty string if no content is returned.
 	 * @throws Error with a Kenari-specific prefix if the request fails.
 	 */
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, info } = await this.fetchModel()
 
 		try {

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -12,7 +12,7 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { GEMINI_THOUGHT_SIGNATURE_BYPASS } from "../transform/gemini-format"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { RouterProvider } from "./router-provider"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
 
@@ -311,7 +311,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, info } = await this.fetchModel()
 
 		// Check if this is a GPT-5 model that requires max_completion_tokens instead of max_tokens

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -13,7 +13,7 @@ import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStream } from "../transform/stream"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { getModelsFromCache } from "./fetchers/modelCache"
 import { handleOpenAIError } from "./utils/error-handler"
 
@@ -187,7 +187,7 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
 			// Create params object with optional draft model
 			const params: any = {

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -12,7 +12,7 @@ import { getModelParams } from "../transform/model-params"
 import { mergeEnvironmentDetailsForMiniMax } from "../transform/minimax-format"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { calculateApiCostAnthropic } from "../../shared/cost"
 import { convertOpenAIToolsToAnthropic } from "../../core/prompts/tools/native-tools/converters"
 
@@ -289,7 +289,7 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 		}
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: CompletePromptOptions) {
 		const { id: model, temperature } = this.getModel()
 
 		const message = await this.client.messages.create({

--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -18,7 +18,7 @@ import { ApiStream } from "../transform/stream"
 import { handleProviderError } from "./utils/error-handler"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 // Type helper to handle thinking chunks from Mistral API
 // The SDK includes ThinkChunk but TypeScript has trouble with the discriminated union
@@ -192,8 +192,7 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 
 		return { id, info, maxTokens, temperature }
 	}
-
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: model, temperature } = this.getModel()
 
 		try {

--- a/src/api/providers/native-ollama.ts
+++ b/src/api/providers/native-ollama.ts
@@ -7,7 +7,7 @@ import { BaseProvider } from "./base-provider"
 import type { ApiHandlerOptions } from "../../shared/api"
 import { getOllamaModels } from "./fetchers/ollama"
 import { TagMatcher } from "../../utils/tag-matcher"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 interface OllamaChatOptions {
 	temperature: number
@@ -550,7 +550,7 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
 			const client = this.ensureClient()
 			const { id: modelId } = await this.fetchModel()

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -21,7 +21,7 @@ import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { getModelParams } from "../transform/model-params"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { isMcpTool } from "../../utils/mcp-name"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 import { openAiCodexOAuthManager } from "../../integrations/openai-codex/oauth"
@@ -1154,7 +1154,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		return this.lastResponseId
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		this.abortController = new AbortController()
 
 		try {

--- a/src/api/providers/openai-compatible.ts
+++ b/src/api/providers/openai-compatible.ts
@@ -17,7 +17,7 @@ import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 /**
  * Configuration options for creating an OpenAI-compatible provider.
@@ -197,7 +197,7 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 	/**
 	 * Complete a prompt using the AI SDK generateText.
 	 */
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const languageModel = this.getLanguageModel()
 
 		const { text } = await generateText({

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -26,7 +26,7 @@ import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { getModelParams } from "../transform/model-params"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { isMcpTool } from "../../utils/mcp-name"
 import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 
@@ -1484,14 +1484,12 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 	getResponseId(): string | undefined {
 		return this.lastResponseId
 	}
-
-	async completePrompt(prompt: string): Promise<string> {
-		// Create AbortController for cancellation
-		this.abortController = new AbortController()
-
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
+			this.abortController = new AbortController()
+
 			const model = this.getModel()
-			const { verbosity, reasoning } = model
+			const { verbosity } = model
 
 			// Resolve reasoning effort for models that support it
 			const reasoningEffort = this.getReasoningEffort(model)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -296,7 +296,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		return { id, info, ...params }
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: import("../../api").CompletePromptOptions): Promise<string> {
 		try {
 			const isAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 			const model = this.getModel()

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -21,7 +21,7 @@ import { getModelParams } from "../transform/model-params"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { handleOpenAIError } from "./utils/error-handler"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
 
@@ -296,7 +296,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		return { id, info, ...params }
 	}
 
-	async completePrompt(prompt: string, options?: import("../../api").CompletePromptOptions): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
 			const isAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 			const model = this.getModel()

--- a/src/api/providers/opencode-go.ts
+++ b/src/api/providers/opencode-go.ts
@@ -18,7 +18,7 @@ import { convertToR1Format } from "../transform/r1-format"
 import { filterNonAnthropicBlocks } from "../transform/anthropic-filter"
 import { getModelParams } from "../transform/model-params"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { RouterProvider } from "./router-provider"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
 import { DEFAULT_HEADERS } from "./constants"
@@ -485,7 +485,7 @@ export class OpencodeGoHandler extends RouterProvider implements SingleCompletio
 	 * @returns The model's reply text, or an empty string if no content is returned.
 	 * @throws Error with an Opencode Go-specific prefix if the request fails.
 	 */
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, format, temperature, reasoningEffort, maxTokens } = await this.resolveModel()
 
 		if (format === "anthropic") {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -35,7 +35,7 @@ import { getModelEndpoints } from "./fetchers/modelEndpointCache"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
-import type { ApiHandlerCreateMessageMetadata, SingleCompletionHandler } from "../index"
+import type { ApiHandlerCreateMessageMetadata, CompletePromptOptions, SingleCompletionHandler } from "../index"
 import { handleOpenAIError } from "./utils/error-handler"
 import { generateImageWithProvider, ImageGenerationResult } from "./utils/image-generation"
 import { applyRouterToolPreferences } from "./utils/router-tool-preferences"
@@ -574,7 +574,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		return { id, info, topP: isDeepSeekR1 ? 0.95 : undefined, ...params }
 	}
 
-	async completePrompt(prompt: string) {
+	async completePrompt(prompt: string, options?: CompletePromptOptions) {
 		const { id: modelId, maxTokens, temperature, reasoning } = await this.fetchModel()
 
 		const completionParams: OpenRouterChatCompletionParams = {

--- a/src/api/providers/poe.ts
+++ b/src/api/providers/poe.ts
@@ -18,7 +18,7 @@ import { convertToAiSdkMessages, convertToolsForAiSdk, processAiSdkStreamPart } 
 import { ApiStream } from "../transform/stream"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { getModelsFromCache } from "./fetchers/modelCache"
 
 const DEFAULT_THINKING_BUDGET = 8192
@@ -138,7 +138,7 @@ export class PoeHandler extends BaseProvider implements SingleCompletionHandler 
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id } = this.getModel()
 		try {
 			const { text } = await generateText({

--- a/src/api/providers/qwen-code.ts
+++ b/src/api/providers/qwen-code.ts
@@ -15,7 +15,7 @@ import { ApiStream } from "../transform/stream"
 
 import { BaseProvider } from "./base-provider"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 const QWEN_OAUTH_BASE_URL = "https://chat.qwen.ai"
 const QWEN_OAUTH_TOKEN_ENDPOINT = `${QWEN_OAUTH_BASE_URL}/api/v1/oauth2/token`
@@ -327,7 +327,7 @@ export class QwenCodeHandler extends BaseProvider implements SingleCompletionHan
 		return { id, info }
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		await this.ensureAuthenticated()
 		const client = this.ensureClient()
 		const model = this.getModel()

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -14,7 +14,7 @@ import { AnthropicProviderReasoningParams, getAnthropicProviderReasoning } from 
 import { DEFAULT_HEADERS } from "./constants"
 import { getModels } from "./fetchers/modelCache"
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { toRequestyServiceUrl } from "../../shared/utils/requesty"
 import { handleOpenAIError } from "./utils/error-handler"
 import { applyRouterToolPreferences } from "./utils/router-tool-preferences"
@@ -204,7 +204,7 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: model, maxTokens: max_tokens, temperature } = await this.fetchModel()
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [{ role: "system", content: prompt }]

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -14,7 +14,7 @@ import { OpenAiReasoningParams } from "../transform/reasoning"
 import { DEFAULT_HEADERS } from "./constants"
 import { getModels } from "./fetchers/modelCache"
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { handleOpenAIError } from "./utils/error-handler"
 import { applyRouterToolPreferences } from "./utils/router-tool-preferences"
 import { extractReasoningFromDelta } from "./utils/extract-reasoning"
@@ -192,7 +192,7 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: model, maxTokens: max_tokens, temperature } = await this.fetchModel()
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [{ role: "system", content: prompt }]

--- a/src/api/providers/vercel-ai-gateway.ts
+++ b/src/api/providers/vercel-ai-gateway.ts
@@ -14,7 +14,7 @@ import { ApiStream } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { addCacheBreakpoints } from "../transform/caching/vercel-ai-gateway"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { RouterProvider } from "./router-provider"
 
 // Extend OpenAI's CompletionUsage to include Vercel AI Gateway specific fields
@@ -117,7 +117,7 @@ export class VercelAiGatewayHandler extends RouterProvider implements SingleComp
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const { id: modelId, info } = await this.fetchModel()
 
 		try {

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -12,7 +12,7 @@ import { ApiStream } from "../transform/stream"
 import { convertToVsCodeLmMessages, extractTextCountFromMessage } from "../transform/vscode-lm-format"
 
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 
 /**
  * Converts OpenAI-format tools to VSCode Language Model tools.
@@ -582,7 +582,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		return this.getModel().info.contextWindow
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		try {
 			const client = await this.getClient()
 			const response = await client.sendRequest(

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -13,7 +13,7 @@ import { getModelParams } from "../transform/model-params"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { handleOpenAIError } from "./utils/error-handler"
 import { isMcpTool } from "../../utils/mcp-name"
 
@@ -144,7 +144,7 @@ export class XAIHandler extends BaseProvider implements SingleCompletionHandler 
 		yield* processResponsesApiStream(stream, normalizeUsage)
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		const model = this.getModel()
 
 		try {

--- a/src/api/providers/zoo-gateway.ts
+++ b/src/api/providers/zoo-gateway.ts
@@ -18,7 +18,7 @@ import { ApiStream } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { addCacheBreakpoints } from "../transform/caching/vercel-ai-gateway"
 
-import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata, CompletePromptOptions } from "../index"
 import { RouterProvider } from "./router-provider"
 
 function getApiErrorStatus(error: unknown): number | undefined {
@@ -276,7 +276,7 @@ export class ZooGatewayHandler extends RouterProvider implements SingleCompletio
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
+	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
 		this.ensureAuthenticated()
 
 		const { id: modelId, info } = await this.fetchModel()

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -1812,7 +1812,7 @@ describe("Cline", () => {
 
 					expect(summarizeConversation).toHaveBeenCalled()
 					const [options] = vi.mocked(summarizeConversation).mock.calls.at(-1)!
-					expect(options.metadata?.abortSignal).toBeInstanceOf(AbortSignal)
+					expect(options.metadata?.abortSignal).toBe(task.currentRequestAbortController!.signal)
 				})
 
 				it("should omit abortSignal from condenseContext metadata when no current request exists", async () => {
@@ -1899,7 +1899,7 @@ describe("Cline", () => {
 					const [, , metadata] = createMessageSpy.mock.calls[0]!
 
 					expect(metadata).toBeDefined()
-					expect(metadata!.abortSignal).toBeInstanceOf(AbortSignal)
+					expect(metadata!.abortSignal).toBe(task.currentRequestAbortController!.signal)
 				})
 
 				it("should invoke abort on currentRequestAbortController during first-chunk wait", async () => {
@@ -2136,7 +2136,7 @@ describe("Cline", () => {
 					const [, , metadata] = createMessageSpy.mock.calls[0]!
 					expect(metadata).toBeDefined()
 					expect("abortSignal" in metadata!).toBe(true)
-					expect(metadata!.abortSignal).toBeInstanceOf(AbortSignal)
+					expect(metadata!.abortSignal).toBe(task.currentRequestAbortController!.signal)
 				})
 
 				it("should keep createMessage abortSignal metadata unaborted before cancellation", async () => {
@@ -2197,9 +2197,98 @@ describe("Cline", () => {
 					await iterator.next()
 
 					const [, , metadata] = createMessageSpy.mock.calls[0]!
-					expect(metadata?.abortSignal).toBeInstanceOf(AbortSignal)
+					expect(metadata?.abortSignal).toBe(task.currentRequestAbortController!.signal)
 					expect(metadata?.abortSignal?.aborted).toBe(false)
 				})
+			})
+
+			it("should create a fresh AbortController for each sequential request", async () => {
+				const task = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "test task",
+					startTask: false,
+				})
+
+				vi.spyOn(task as any, "getSystemPrompt").mockResolvedValue("mock system prompt")
+				vi.spyOn(task.api, "getModel").mockReturnValue({
+					id: mockApiConfig.apiModelId!,
+					info: {
+						supportsImages: false,
+						supportsPromptCache: true,
+						contextWindow: 200000,
+						maxTokens: 4096,
+						inputPrice: 0.3,
+						outputPrice: 1.5,
+					} as ModelInfo,
+				})
+
+				const providerState = await mockProvider.getState()
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({
+					...providerState,
+					apiConfiguration: mockApiConfig,
+					autoApprovalEnabled: true,
+					requestDelaySeconds: 0,
+				})
+
+				let callCount = 0
+				const mockStreamFactory = () => {
+					return {
+						async *[Symbol.asyncIterator]() {
+							yield { type: "text", text: `response ${callCount}` }
+						},
+						async next() {
+							callCount++
+							return { done: true, value: { type: "text", text: `response ${callCount - 1}` } }
+						},
+						async return() {
+							return { done: true, value: undefined }
+						},
+						async throw(e: any) {
+							throw e
+						},
+						[Symbol.asyncDispose]: async () => {},
+					} as AsyncGenerator<ApiStreamChunk>
+				}
+
+				const createMessageSpy = vi
+					.spyOn(task.api, "createMessage")
+					.mockImplementation(() => mockStreamFactory())
+
+				task.apiConversationHistory = [
+					{
+						role: "user" as const,
+						content: [{ type: "text" as const, text: "test message" }],
+						ts: Date.now(),
+					},
+				] as any
+
+				// First request
+				const iterator1 = task.attemptApiRequest(0)
+				await iterator1.next()
+
+				expect(createMessageSpy).toHaveBeenCalledTimes(1)
+				const [, , metadata1] = createMessageSpy.mock.calls[0]!
+				const signal1 = metadata1!.abortSignal
+				expect(signal1).toBeDefined()
+				expect(signal1!.aborted).toBe(false)
+
+				// Simulate request completion and cancellation to clear the controller
+				task.cancelCurrentRequest()
+
+				// Second request should create a fresh AbortController with a new signal
+				callCount = 0
+				const iterator2 = task.attemptApiRequest(0)
+				await iterator2.next()
+
+				expect(createMessageSpy).toHaveBeenCalledTimes(2)
+				const [, , metadata2] = createMessageSpy.mock.calls[1]!
+				const signal2 = metadata2!.abortSignal
+
+				// Signals should be different instances (fresh controller per request)
+				expect(signal2).not.toBe(signal1)
+				expect(signal2).toBe(task.currentRequestAbortController!.signal)
+				expect(signal2!.aborted).toBe(false)
 			})
 
 			it("should propagate AbortController signal through attemptApiRequest context-window retry path", async () => {

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -2232,25 +2232,10 @@ describe("Cline", () => {
 				})
 
 				let callCount = 0
-				const mockStreamFactory = () => {
-					return {
-						async *[Symbol.asyncIterator]() {
-							yield { type: "text", text: `response ${callCount}` }
-						},
-						async next() {
-							callCount++
-							return { done: true, value: { type: "text", text: `response ${callCount - 1}` } }
-						},
-						async return() {
-							return { done: true, value: undefined }
-						},
-						async throw(e: any) {
-							throw e
-						},
-						[Symbol.asyncDispose]: async () => {},
-					} as AsyncGenerator<ApiStreamChunk>
+				const mockStreamFactory = async function* (): AsyncGenerator<ApiStreamChunk> {
+					yield { type: "text", text: `response ${callCount}` }
+					callCount++
 				}
-
 				const createMessageSpy = vi
 					.spyOn(task.api, "createMessage")
 					.mockImplementation(() => mockStreamFactory())

--- a/src/utils/__tests__/enhance-prompt.spec.ts
+++ b/src/utils/__tests__/enhance-prompt.spec.ts
@@ -42,7 +42,7 @@ describe("enhancePrompt", () => {
 
 		expect(result).toBe("Enhanced prompt")
 		const handler = buildApiHandler(mockApiConfig)
-		expect((handler as any).completePrompt).toHaveBeenCalledWith(`Test prompt`)
+		expect((handler as any).completePrompt).toHaveBeenCalledWith(`Test prompt`, undefined)
 	})
 
 	it("enhances prompt using custom enhancement prompt when provided", async () => {
@@ -64,7 +64,7 @@ describe("enhancePrompt", () => {
 
 		expect(result).toBe("Enhanced prompt")
 		const handler = buildApiHandler(mockApiConfig)
-		expect((handler as any).completePrompt).toHaveBeenCalledWith(`${customEnhancePrompt}\n\nTest prompt`)
+		expect((handler as any).completePrompt).toHaveBeenCalledWith(`${customEnhancePrompt}\n\nTest prompt`, undefined)
 	})
 
 	it("throws error for empty prompt input", async () => {

--- a/src/utils/single-completion-handler.ts
+++ b/src/utils/single-completion-handler.ts
@@ -1,12 +1,16 @@
 import type { ProviderSettings } from "@roo-code/types"
 
-import { buildApiHandler, SingleCompletionHandler } from "../api"
+import { buildApiHandler, SingleCompletionHandler, type CompletePromptOptions } from "../api"
 
 /**
  * Enhances a prompt using the configured API without creating a full Cline instance or task history.
  * This is a lightweight alternative that only uses the API's completion functionality.
  */
-export async function singleCompletionHandler(apiConfiguration: ProviderSettings, promptText: string): Promise<string> {
+export async function singleCompletionHandler(
+	apiConfiguration: ProviderSettings,
+	promptText: string,
+	options?: CompletePromptOptions,
+): Promise<string> {
 	if (!promptText) {
 		throw new Error("No prompt text provided")
 	}
@@ -21,5 +25,5 @@ export async function singleCompletionHandler(apiConfiguration: ProviderSettings
 		throw new Error("The selected API provider does not support prompt enhancement")
 	}
 
-	return (handler as SingleCompletionHandler).completePrompt(promptText)
+	return (handler as SingleCompletionHandler).completePrompt(promptText, options)
 }


### PR DESCRIPTION
## Summary

Fixes #615 — Core plumbing for abort signal in `completePrompt` path.

This PR adds an optional second parameter (`CompletePromptOptions`) to all provider `completePrompt` methods, enabling future abort signal and timeout support without breaking existing callers.

## Changes

### New: `CompletePromptOptions` interface
```ts
export interface CompletePromptOptions extends Pick<ApiHandlerCreateMessageMetadata, "abortSignal"> {
    /** Optional timeout override (ms) — falls back to provider default if omitted */
    timeoutMs?: number
}
```

**Design note:** Rather than passing the full `ApiHandlerCreateMessageMetadata` as issue #615 described, this PR introduces a minimal interface that only exposes `abortSignal` and `timeoutMs`. This keeps the API surface clean while still enabling abort signal pass-through. The `metadata` pattern used in the stream path (via `ApiHandlerCreateMessageMetadata`) is already handled separately.

### Updated files
- **`src/api/index.ts`** — Added `CompletePromptOptions`, updated `SingleCompletionHandler.completePrompt` signature
- **25+ provider implementations** — All now accept `options?: CompletePromptOptions` (backward compatible, optional)
- **`src/utils/single-completion-handler.ts`** — Forwards options to the handler

### Tests (`Task.spec.ts`)
- Updated existing assertions from `toBeInstanceOf(AbortSignal)` → `toBe(task.currentRequestAbortController!.signal)` for signal identity verification
- Added new test: "should create a fresh AbortController for each sequential request" confirming controllers are not reused across requests

## Acceptance criteria (from #615)
- [x] `SingleCompletionHandler.completePrompt` interface accepts optional metadata/options
- [x] `single-completion-handler.ts` forwards options to the provider
- [x] `Task.ts` attaches abortSignal to metadata (already wired in #434, this PR completes the interface layer)
- [x] Tests verify signal identity and fresh-controller-per-request

## Related
- Part of #404 — Stop does not abort underlying HTTP request
- Depends on #434 (abort signal core plumbing already merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional structured controls for non-streaming prompt completion via a shared `options` parameter, including `abortSignal` and optional `timeoutMs`.
  * Updated `completePrompt` across providers and the single-completion flow to accept and forward these options.

* **Tests**
  * Strengthened cancellation assertions to require the exact `abortSignal` instance and verified retries use a fresh, initially un-aborted signal.
  * Updated prompt enhancement tests to expect `completePrompt` to be called with an explicit `undefined` options argument when omitted.
  * Added coverage ensuring the fake provider delegates `completePrompt` with the correct prompt/options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->