### PR TITLE
fix(skills): safely serialize skill frontmatter

### DIFF
--- a/packages/types/src/skills.ts
+++ b/packages/types/src/skills.ts
@@ -20,6 +20,15 @@ export interface SkillMetadata {
 	modeSlugs?: string[]
 }
 
+/** A user-actionable problem found while loading a SKILL.md file. */
+export interface SkillDiagnostic {
+	path: string
+	source: "global" | "project"
+	message: string
+	line?: number
+	column?: number
+}
+
 /**
  * Skill name validation constants per agentskills.io specification:
  * https://agentskills.io/specification

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -14,7 +14,7 @@ import type { GitCommit } from "./git.js"
 import type { McpServer } from "./mcp.js"
 import type { ModelRecord, RouterModels } from "./model.js"
 import type { OpenAiCodexRateLimitInfo } from "./providers/openai-codex-rate-limits.js"
-import type { SkillMetadata } from "./skills.js"
+import type { SkillDiagnostic, SkillMetadata } from "./skills.js"
 import type { RuleMetadata } from "./rules.js"
 import type { TelemetrySetting } from "./telemetry.js"
 import type { WorktreeIncludeStatus } from "./worktree.js"
@@ -180,6 +180,7 @@ export interface ExtensionMessage {
 	list?: string[] // For dismissedUpsells
 	tools?: SerializedCustomToolDefinition[] // For customToolsResult
 	skills?: SkillMetadata[] // For skills response
+	skillDiagnostics?: SkillDiagnostic[] // For malformed skills omitted from the skills response
 	rules?: RuleMetadata[] // For rules response
 	modes?: { slug: string; name: string }[] // For modes response
 	rooHistoryImportProgress?: {

--- a/src/core/webview/__tests__/skillsMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/skillsMessageHandler.spec.ts
@@ -47,6 +47,7 @@ describe("skillsMessageHandler", () => {
 	const mockLog = vi.fn()
 	const mockPostMessageToWebview = vi.fn()
 	const mockGetSkillsMetadata = vi.fn()
+	const mockGetSkillDiagnostics = vi.fn()
 	const mockCreateSkill = vi.fn()
 	const mockDeleteSkill = vi.fn()
 	const mockMoveSkill = vi.fn()
@@ -57,6 +58,7 @@ describe("skillsMessageHandler", () => {
 		const skillsManager = hasSkillsManager
 			? {
 					getSkillsMetadata: mockGetSkillsMetadata,
+					getSkillDiagnostics: mockGetSkillDiagnostics,
 					createSkill: mockCreateSkill,
 					deleteSkill: mockDeleteSkill,
 					moveSkill: mockMoveSkill,
@@ -90,6 +92,7 @@ describe("skillsMessageHandler", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
+		mockGetSkillDiagnostics.mockReturnValue([])
 	})
 
 	describe("handleRequestSkills", () => {
@@ -100,7 +103,34 @@ describe("skillsMessageHandler", () => {
 			const result = await handleRequestSkills(provider)
 
 			expect(result).toEqual(mockSkills)
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: mockSkills })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: mockSkills,
+				skillDiagnostics: [],
+			})
+		})
+
+		it("sends structured malformed-skill diagnostics without hiding valid skills", async () => {
+			const provider = createMockProvider(true)
+			const diagnostics = [
+				{
+					path: "/workspace/.roo/skills/broken/SKILL.md",
+					source: "project" as const,
+					message: "bad indentation of a mapping entry",
+					line: 3,
+					column: 20,
+				},
+			]
+			mockGetSkillsMetadata.mockReturnValue(mockSkills)
+			mockGetSkillDiagnostics.mockReturnValue(diagnostics)
+
+			await handleRequestSkills(provider)
+
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: mockSkills,
+				skillDiagnostics: diagnostics,
+			})
 		})
 
 		it("returns empty skills when skills manager is not available", async () => {
@@ -109,7 +139,11 @@ describe("skillsMessageHandler", () => {
 			const result = await handleRequestSkills(provider)
 
 			expect(result).toEqual([])
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: [] })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: [],
+				skillDiagnostics: [],
+			})
 		})
 
 		it("handles errors and returns empty skills", async () => {
@@ -122,7 +156,11 @@ describe("skillsMessageHandler", () => {
 
 			expect(result).toEqual([])
 			expect(mockLog).toHaveBeenCalled()
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: [] })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: [],
+				skillDiagnostics: [],
+			})
 		})
 	})
 
@@ -142,7 +180,11 @@ describe("skillsMessageHandler", () => {
 			expect(result).toEqual(mockSkills)
 			expect(mockCreateSkill).toHaveBeenCalledWith("new-skill", "global", "New skill description", undefined)
 			expect(openFile).toHaveBeenCalledWith("/path/to/new-skill/SKILL.md")
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: mockSkills })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: mockSkills,
+				skillDiagnostics: [],
+			})
 		})
 
 		it("creates a skill with mode restriction", async () => {
@@ -212,7 +254,11 @@ describe("skillsMessageHandler", () => {
 
 			expect(result).toEqual([mockSkills[1]])
 			expect(mockDeleteSkill).toHaveBeenCalledWith("test-skill", "global", undefined)
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: [mockSkills[1]] })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: [mockSkills[1]],
+				skillDiagnostics: [],
+			})
 		})
 
 		it("deletes a skill with mode restriction", async () => {
@@ -280,7 +326,11 @@ describe("skillsMessageHandler", () => {
 
 			expect(result).toEqual([mockSkills[0]])
 			expect(mockMoveSkill).toHaveBeenCalledWith("test-skill", "global", undefined, "code")
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: [mockSkills[0]] })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({
+				type: "skills",
+				skills: [mockSkills[0]],
+				skillDiagnostics: [],
+			})
 		})
 
 		it("moves a skill from one mode to another", async () => {

--- a/src/core/webview/skillsMessageHandler.ts
+++ b/src/core/webview/skillsMessageHandler.ts
@@ -16,15 +16,16 @@ export async function handleRequestSkills(provider: ClineProvider): Promise<Skil
 		const skillsManager = provider.getSkillsManager()
 		if (skillsManager) {
 			const skills = skillsManager.getSkillsMetadata()
-			await provider.postMessageToWebview({ type: "skills", skills })
+			const skillDiagnostics = skillsManager.getSkillDiagnostics()
+			await provider.postMessageToWebview({ type: "skills", skills, skillDiagnostics })
 			return skills
 		} else {
-			await provider.postMessageToWebview({ type: "skills", skills: [] })
+			await provider.postMessageToWebview({ type: "skills", skills: [], skillDiagnostics: [] })
 			return []
 		}
 	} catch (error) {
 		provider.log(`Error fetching skills: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`)
-		await provider.postMessageToWebview({ type: "skills", skills: [] })
+		await provider.postMessageToWebview({ type: "skills", skills: [], skillDiagnostics: [] })
 		return []
 	}
 }
@@ -59,7 +60,8 @@ export async function handleCreateSkill(
 
 		// Send updated skills list
 		const skills = skillsManager.getSkillsMetadata()
-		await provider.postMessageToWebview({ type: "skills", skills })
+		const skillDiagnostics = skillsManager.getSkillDiagnostics()
+		await provider.postMessageToWebview({ type: "skills", skills, skillDiagnostics })
 		return skills
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
@@ -95,7 +97,8 @@ export async function handleDeleteSkill(
 
 		// Send updated skills list
 		const skills = skillsManager.getSkillsMetadata()
-		await provider.postMessageToWebview({ type: "skills", skills })
+		const skillDiagnostics = skillsManager.getSkillDiagnostics()
+		await provider.postMessageToWebview({ type: "skills", skills, skillDiagnostics })
 		return skills
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
@@ -131,7 +134,8 @@ export async function handleMoveSkill(
 
 		// Send updated skills list
 		const skills = skillsManager.getSkillsMetadata()
-		await provider.postMessageToWebview({ type: "skills", skills })
+		const skillDiagnostics = skillsManager.getSkillDiagnostics()
+		await provider.postMessageToWebview({ type: "skills", skills, skillDiagnostics })
 		return skills
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)
@@ -166,7 +170,8 @@ export async function handleUpdateSkillModes(
 
 		// Send updated skills list
 		const skills = skillsManager.getSkillsMetadata()
-		await provider.postMessageToWebview({ type: "skills", skills })
+		const skillDiagnostics = skillsManager.getSkillDiagnostics()
+		await provider.postMessageToWebview({ type: "skills", skills, skillDiagnostics })
 		return skills
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error)

--- a/src/services/skills/SkillsManager.ts
+++ b/src/services/skills/SkillsManager.ts
@@ -6,7 +6,7 @@ import matter from "gray-matter"
 import type { ClineProvider } from "../../core/webview/ClineProvider"
 import { getGlobalRooDirectory, getGlobalAgentsDirectory, getProjectAgentsDirectoryForCwd } from "../roo-config"
 import { directoryExists, fileExists } from "../roo-config"
-import { SkillMetadata, SkillContent } from "../../shared/skills"
+import { SkillMetadata, SkillContent, SkillDiagnostic } from "../../shared/skills"
 import { modes, getAllModes } from "../../shared/modes"
 import {
 	validateSkillName as validateSkillNameShared,
@@ -16,10 +16,11 @@ import {
 import { t } from "../../i18n"
 
 // Re-export for convenience
-export type { SkillMetadata, SkillContent }
+export type { SkillMetadata, SkillContent, SkillDiagnostic }
 
 export class SkillsManager {
 	private skills: Map<string, SkillMetadata> = new Map()
+	private diagnostics: SkillDiagnostic[] = []
 	private providerRef: WeakRef<ClineProvider>
 	private disposables: vscode.Disposable[] = []
 	private isDisposed = false
@@ -42,6 +43,7 @@ export class SkillsManager {
 	 */
 	async discoverSkills(): Promise<void> {
 		this.skills.clear()
+		this.diagnostics = []
 		const skillsDirs = await this.getSkillsDirectories()
 
 		for (const { dir, source, mode } of skillsDirs) {
@@ -100,9 +102,17 @@ export class SkillsManager {
 
 		try {
 			const fileContent = await fs.readFile(skillMdPath, "utf-8")
+			let parsed: ReturnType<typeof matter>
 
-			// Use gray-matter to parse frontmatter
-			const { data: frontmatter, content: body } = matter(fileContent)
+			try {
+				parsed = matter(fileContent)
+			} catch (error) {
+				this.recordDiagnostic(skillMdPath, source, error)
+				console.error(`Failed to parse skill at ${skillDir}:`, error)
+				return
+			}
+
+			const { data: frontmatter } = parsed
 
 			// Validate required fields (only name and description for now)
 			if (!frontmatter.name || typeof frontmatter.name !== "string") {
@@ -173,6 +183,20 @@ export class SkillsManager {
 		} catch (error) {
 			console.error(`Failed to load skill at ${skillDir}:`, error)
 		}
+	}
+
+	private recordDiagnostic(path: string, source: "global" | "project", error: unknown): void {
+		const yamlError = error as {
+			reason?: unknown
+			message?: unknown
+			mark?: { line?: unknown; column?: unknown }
+		}
+		const reason = typeof yamlError.reason === "string" ? yamlError.reason : undefined
+		const errorMessage = error instanceof Error ? error.message.split("\n", 1)[0] : String(error)
+		const line = typeof yamlError.mark?.line === "number" ? yamlError.mark.line + 1 : undefined
+		const column = typeof yamlError.mark?.column === "number" ? yamlError.mark.column + 1 : undefined
+
+		this.diagnostics.push({ path, source, message: reason ?? errorMessage, line, column })
 	}
 
 	/**
@@ -290,6 +314,10 @@ export class SkillsManager {
 		return this.getAllSkills()
 	}
 
+	getSkillDiagnostics(): SkillDiagnostic[] {
+		return [...this.diagnostics]
+	}
+
 	/**
 	 * Get a skill by name, source, and optionally mode
 	 */
@@ -394,25 +422,19 @@ export class SkillsManager {
 			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 			.join(" ")
 
-		// Build frontmatter with optional modeSlugs
-		const frontmatterLines = [`name: ${name}`, `description: ${trimmedDescription}`]
-		if (modeSlugs && modeSlugs.length > 0) {
-			frontmatterLines.push(`modeSlugs:`)
-			for (const slug of modeSlugs) {
-				frontmatterLines.push(`  - ${slug}`)
-			}
+		const frontmatter = {
+			name,
+			description: trimmedDescription,
+			...(modeSlugs && modeSlugs.length > 0 ? { modeSlugs } : {}),
 		}
-
-		const skillContent = `---
-${frontmatterLines.join("\n")}
----
-
+		const body = `
 # ${titleName}
 
 ## Instructions
 
 Add your skill instructions here.
 `
+		const skillContent = matter.stringify(body, frontmatter)
 
 		// Write the SKILL.md file
 		await fs.writeFile(skillMdPath, skillContent, "utf-8")

--- a/src/services/skills/__tests__/SkillsManager.spec.ts
+++ b/src/services/skills/__tests__/SkillsManager.spec.ts
@@ -1,4 +1,5 @@
 import * as path from "path"
+import matter from "gray-matter"
 
 // Use vi.hoisted to ensure mocks are available during hoisting
 const {
@@ -1233,6 +1234,47 @@ Instructions`)
 			expect(writeCall[1]).toContain("- code")
 		})
 
+		it("round-trips the issue description and mode slugs through YAML frontmatter", async () => {
+			mockDirectoryExists.mockResolvedValue(false)
+			mockRealpath.mockImplementation(async (p: string) => p)
+			mockReaddir.mockResolvedValue([])
+			mockFileExists.mockResolvedValue(false)
+			mockMkdir.mockResolvedValue(undefined)
+			mockWriteFile.mockResolvedValue(undefined)
+			const description = 'Triggers on: "TDD", "test-driven development"'
+
+			await skillsManager.createSkill("tdd-skill", "global", description, ["code", "debug"])
+
+			const generatedContent = mockWriteFile.mock.calls[0][1] as string
+			const parsed = matter(generatedContent)
+			expect(parsed.data).toEqual({
+				name: "tdd-skill",
+				description,
+				modeSlugs: ["code", "debug"],
+			})
+			expect(parsed.content).toBe("\n# Tdd Skill\n\n## Instructions\n\nAdd your skill instructions here.\n")
+		})
+
+		it.each([
+			["colon-space", "Use when: tests fail"],
+			["quotes", "Use \"red-green-refactor\" and 'small steps'"],
+			["hash", "Use tests # not comments"],
+			["leading punctuation", "- Start from a failing test"],
+			["multiline", "First line\nSecond line: with # and quotes"],
+		])("preserves YAML-sensitive %s descriptions", async (_caseName, description) => {
+			mockDirectoryExists.mockResolvedValue(false)
+			mockRealpath.mockImplementation(async (p: string) => p)
+			mockReaddir.mockResolvedValue([])
+			mockFileExists.mockResolvedValue(false)
+			mockMkdir.mockResolvedValue(undefined)
+			mockWriteFile.mockResolvedValue(undefined)
+
+			await skillsManager.createSkill("yaml-sensitive", "global", description)
+
+			const generatedContent = mockWriteFile.mock.calls[0][1] as string
+			expect(matter(generatedContent).data.description).toBe(description)
+		})
+
 		it("should create a project skill", async () => {
 			mockDirectoryExists.mockResolvedValue(false)
 			mockRealpath.mockImplementation(async (p: string) => p)
@@ -1296,6 +1338,45 @@ Instructions`)
 			await expect(skillsManager.createSkill("existing-skill", "global", "Description")).rejects.toThrow(
 				"already exists",
 			)
+		})
+	})
+
+	describe("skill diagnostics", () => {
+		it("reports malformed YAML with location while retaining valid skills", async () => {
+			const validSkillDir = p(globalSkillsDir, "valid-skill")
+			const malformedSkillDir = p(globalSkillsDir, "malformed-skill")
+			const validSkillPath = p(validSkillDir, "SKILL.md")
+			const malformedSkillPath = p(malformedSkillDir, "SKILL.md")
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) =>
+				dir === globalSkillsDir ? ["valid-skill", "malformed-skill"] : [],
+			)
+			mockStat.mockResolvedValue({ isDirectory: () => true })
+			mockFileExists.mockImplementation(async (file: string) =>
+				[validSkillPath, malformedSkillPath].includes(file),
+			)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === validSkillPath) {
+					return "---\nname: valid-skill\ndescription: Still visible\n---\nValid instructions"
+				}
+				return '---\nname: malformed-skill\ndescription: Triggers on: "TDD"\n---\nBroken instructions'
+			})
+
+			await skillsManager.discoverSkills()
+
+			expect(skillsManager.getSkillsMetadata()).toEqual([
+				expect.objectContaining({ name: "valid-skill", description: "Still visible" }),
+			])
+			expect(skillsManager.getSkillDiagnostics()).toEqual([
+				expect.objectContaining({
+					path: malformedSkillPath,
+					source: "global",
+					message: expect.any(String),
+					line: 3,
+					column: expect.any(Number),
+				}),
+			])
 		})
 	})
 

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -20,6 +20,15 @@ export interface SkillMetadata {
 	modeSlugs?: string[]
 }
 
+/** A user-actionable problem found while loading a SKILL.md file. */
+export interface SkillDiagnostic {
+	path: string
+	source: "global" | "project"
+	message: string
+	line?: number
+	column?: number
+}
+
 /**
  * Full skill content (loaded on activation)
  */

--- a/webview-ui/src/components/settings/SkillsSettings.tsx
+++ b/webview-ui/src/components/settings/SkillsSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react"
-import { Plus, Globe, Folder, Edit, Trash2, Settings } from "lucide-react"
+import { Plus, Globe, Folder, Edit, Trash2, Settings, TriangleAlert } from "lucide-react"
 import { Trans } from "react-i18next"
 
 import type { SkillMetadata } from "@roo-code/types"
@@ -35,7 +35,7 @@ import { CreateSkillDialog } from "./CreateSkillDialog"
 
 export const SkillsSettings: React.FC = () => {
 	const { t } = useAppTranslation()
-	const { cwd, skills: rawSkills, customModes } = useExtensionState()
+	const { cwd, skills: rawSkills, skillDiagnostics, customModes } = useExtensionState()
 	const skills = useMemo(() => rawSkills ?? [], [rawSkills])
 
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
@@ -232,6 +232,34 @@ export const SkillsSettings: React.FC = () => {
 							}}
 						/>
 					</p>
+					{skillDiagnostics.length > 0 && (
+						<div
+							role="alert"
+							className="flex gap-2 rounded-md border border-vscode-inputValidation-warningBorder bg-vscode-inputValidation-warningBackground p-3 text-sm">
+							<TriangleAlert className="mt-0.5 size-4 shrink-0" />
+							<div className="min-w-0">
+								<div className="font-medium">{t("settings:skills.diagnostics.title")}</div>
+								<div className="text-vscode-descriptionForeground">
+									{t("settings:skills.diagnostics.description")}
+								</div>
+								<ul className="mb-0 mt-2 space-y-1 pl-4">
+									{skillDiagnostics.map((diagnostic) => {
+										const location = diagnostic.line
+											? `:${diagnostic.line}${diagnostic.column ? `:${diagnostic.column}` : ""}`
+											: ""
+										return (
+											<li key={`${diagnostic.path}-${diagnostic.line}-${diagnostic.column}`}>
+												<span className="break-all font-mono">
+													{diagnostic.path + location}
+												</span>
+												<span>: {diagnostic.message}</span>
+											</li>
+										)
+									})}
+								</ul>
+							</div>
+						</div>
+					)}
 
 					{/* Add Skill button */}
 					<Button variant="secondary" className="py-1" onClick={() => setCreateDialogOpen(true)}>

--- a/webview-ui/src/components/settings/__tests__/SkillsSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SkillsSettings.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@/utils/test-utils"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
-import type { SkillMetadata } from "@roo-code/types"
+import type { SkillDiagnostic, SkillMetadata } from "@roo-code/types"
 
 import { ExtensionStateContextProvider } from "@/context/ExtensionStateContext"
 import { vscode } from "@/utils/vscode"
@@ -166,7 +166,11 @@ vi.mock("@/context/ExtensionStateContext", () => ({
 	useExtensionState: () => mockExtensionState,
 }))
 
-const renderSkillsSettings = (skills: SkillMetadata[] = mockSkills, cwd?: string) => {
+const renderSkillsSettings = (
+	skills: SkillMetadata[] = mockSkills,
+	cwd?: string,
+	skillDiagnostics: SkillDiagnostic[] = [],
+) => {
 	const queryClient = new QueryClient({
 		defaultOptions: {
 			queries: { retry: false },
@@ -177,6 +181,7 @@ const renderSkillsSettings = (skills: SkillMetadata[] = mockSkills, cwd?: string
 	// Update the mock state before rendering
 	mockExtensionState = {
 		skills,
+		skillDiagnostics,
 		cwd: cwd !== undefined ? cwd : "/workspace",
 		customModes: [],
 	}
@@ -206,6 +211,25 @@ describe("SkillsSettings", () => {
 		renderSkillsSettings()
 
 		expect(vscode.postMessage).toHaveBeenCalledWith({ type: "requestSkills" })
+	})
+
+	it("displays an actionable malformed-skill warning with file location and message", () => {
+		renderSkillsSettings(mockSkills, undefined, [
+			{
+				path: "/workspace/.roo/skills/broken/SKILL.md",
+				source: "project",
+				message: "bad indentation of a mapping entry",
+				line: 3,
+				column: 20,
+			},
+		])
+
+		const warning = screen.getByRole("alert")
+		expect(warning).toHaveTextContent("settings:skills.diagnostics.title")
+		expect(warning).toHaveTextContent("settings:skills.diagnostics.description")
+		expect(warning).toHaveTextContent("/workspace/.roo/skills/broken/SKILL.md:3:20")
+		expect(warning).toHaveTextContent("bad indentation of a mapping entry")
+		expect(screen.getByText("global-skill")).toBeInTheDocument()
 	})
 
 	it("displays project skills section when in a workspace", () => {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -14,6 +14,7 @@ import {
 	type ExtensionState,
 	type MarketplaceInstalledMetadata,
 	type SkillMetadata,
+	type SkillDiagnostic,
 	type RuleMetadata,
 	type Command,
 	type McpServer,
@@ -149,6 +150,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	showWorktreesInHomeScreen: boolean
 	setShowWorktreesInHomeScreen: (value: boolean) => void
 	skills?: SkillMetadata[]
+	skillDiagnostics: SkillDiagnostic[]
 	rules: RuleMetadata[]
 }
 
@@ -290,6 +292,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		global: {},
 	})
 	const [skills, setSkills] = useState<SkillMetadata[]>([])
+	const [skillDiagnostics, setSkillDiagnostics] = useState<SkillDiagnostic[]>([])
 	const [rules, setRules] = useState<RuleMetadata[]>([])
 	const [includeTaskHistoryInEnhance, setIncludeTaskHistoryInEnhance] = useState(true)
 	const [includeCurrentTime, setIncludeCurrentTime] = useState(true)
@@ -401,9 +404,8 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					break
 				}
 				case "skills": {
-					if (message.skills) {
-						setSkills(message.skills)
-					}
+					setSkills(message.skills ?? [])
+					setSkillDiagnostics(message.skillDiagnostics ?? [])
 					break
 				}
 				case "rules": {
@@ -628,6 +630,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		includeCurrentCost,
 		setIncludeCurrentCost,
 		skills,
+		skillDiagnostics,
 		rules,
 		showWorktreesInHomeScreen: state.showWorktreesInHomeScreen ?? true,
 		setShowWorktreesInHomeScreen: (value) =>

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -176,6 +176,10 @@
 		"configureModes": "Mode availability",
 		"modeAny": "Any mode",
 		"modeCount": "{{count}} modes",
+		"diagnostics": {
+			"title": "Some skills could not be loaded",
+			"description": "Fix the YAML frontmatter in the listed SKILL.md files, then reopen or refresh this page."
+		},
 		"deleteDialog": {
 			"title": "Delete Skill",
 			"description": "Are you sure you want to delete the skill \"{{name}}\"? This action cannot be undone.",


### PR DESCRIPTION
## Summary

- Safely serialize generated skill frontmatter as YAML so descriptions containing quotes or other YAML-sensitive characters remain valid.
- Surface visible diagnostics for malformed skills instead of silently omitting them or showing a misleading missing-name error.

## Root cause and user impact

Skill creation interpolated description text directly into double-quoted YAML frontmatter. Descriptions containing unescaped double quotes could therefore produce invalid `SKILL.md` files, causing frontmatter parsing to fail even when the required `name` field was present. The parsing failure was then obscured by misleading or absent diagnostics, leaving affected skills unavailable without explaining the actual malformed YAML.

This change uses safe YAML serialization for generated frontmatter and preserves actionable parse diagnostics so users can identify and correct malformed skill files.

## Testing and validation

- Backend skill test suites: 74 tests passed.
- Webview skill test suites: 20 tests passed.
- Package typechecks passed.
- Lint and formatting checks passed.
- No-mistakes run `01KXSJBKY4H2SA0KV63NCNQ210` completed with no findings.
- Push-time repository typechecks passed.

Fixes #859


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added diagnostics for malformed `SKILL.md` files, including the file path plus optional line/column and error details.
  - Malformed skills no longer block loading valid skills.
  - Skills settings now shows a warning panel listing affected files and guidance to fix them.
- **Bug Fixes**
  - Improved skill creation/frontmatter generation to reliably preserve descriptions and mode settings.
  - Improved handling of YAML-sensitive characters/formatting in skill metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->