### PR TITLE
fix(webview): dismiss welcome after Zoo Gateway sign-in (#961)

### DIFF
--- a/src/shared/__tests__/checkExistApiConfig.spec.ts
+++ b/src/shared/__tests__/checkExistApiConfig.spec.ts
@@ -86,4 +86,36 @@ describe("checkExistKey", () => {
 		}
 		expect(checkExistKey(config)).toBe(false)
 	})
+
+	it("should return false for zoo-gateway without session token or auth", () => {
+		const config: ProviderSettings = {
+			apiProvider: "zoo-gateway",
+			zooGatewayModelId: "alibaba/qwen-3.6-max-preview",
+		}
+		expect(checkExistKey(config)).toBe(false)
+		expect(checkExistKey(config, false)).toBe(false)
+	})
+
+	it("should return true for zoo-gateway when profile has zooSessionToken", () => {
+		const config: ProviderSettings = {
+			apiProvider: "zoo-gateway",
+			zooSessionToken: "zoo_ext_test_token",
+		}
+		expect(checkExistKey(config)).toBe(true)
+	})
+
+	it("should return true for zoo-gateway when Zoo Code session auth is active", () => {
+		const config: ProviderSettings = {
+			apiProvider: "zoo-gateway",
+			zooGatewayModelId: "alibaba/qwen-3.6-max-preview",
+		}
+		expect(checkExistKey(config, true)).toBe(true)
+	})
+
+	it("should ignore zooCodeIsAuthenticated for non-zoo-gateway providers", () => {
+		const config: ProviderSettings = {
+			apiProvider: "openrouter",
+		}
+		expect(checkExistKey(config, true)).toBe(false)
+	})
 })

--- a/src/shared/checkExistApiConfig.ts
+++ b/src/shared/checkExistApiConfig.ts
@@ -1,6 +1,14 @@
 import { SECRET_STATE_KEYS, GLOBAL_SECRET_KEYS, ProviderSettings } from "@roo-code/types"
 
-export function checkExistKey(config: ProviderSettings | undefined) {
+/**
+ * Returns whether a provider profile is sufficiently configured to leave the
+ * welcome/setup gate.
+ *
+ * `zooCodeIsAuthenticated` is needed for Zoo Gateway: auth lives in global
+ * secret storage (`zoo-code-auth`), and `zooSessionToken` is not part of
+ * `SECRET_STATE_KEYS`, so session-auth alone would otherwise look unconfigured.
+ */
+export function checkExistKey(config: ProviderSettings | undefined, zooCodeIsAuthenticated?: boolean) {
 	if (!config) {
 		return false
 	}
@@ -8,6 +16,12 @@ export function checkExistKey(config: ProviderSettings | undefined) {
 	// Special case for fake-ai, openai-codex, and qwen-code providers which don't need any configuration.
 	if (config.apiProvider && ["fake-ai", "openai-codex", "qwen-code"].includes(config.apiProvider)) {
 		return true
+	}
+
+	// Zoo Gateway uses session auth (profile token and/or global Zoo Code login),
+	// not a traditional API key listed in SECRET_STATE_KEYS.
+	if (config.apiProvider === "zoo-gateway") {
+		return Boolean(config.zooSessionToken) || Boolean(zooCodeIsAuthenticated)
 	}
 
 	// Check all secret keys from the centralized SECRET_STATE_KEYS array.

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -317,7 +317,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 				case "state": {
 					const newState = message.state ?? {}
 					setState((prevState) => mergeExtensionState(prevState, newState))
-					setShowWelcome(!checkExistKey(newState.apiConfiguration))
+					setShowWelcome(!checkExistKey(newState.apiConfiguration, newState.zooCodeIsAuthenticated))
 					setDidHydrateState(true)
 					// Update alwaysAllowFollowupQuestions if present in state message
 					if ((newState as any).alwaysAllowFollowupQuestions !== undefined) {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #961

### Description

Users who complete Zoo Gateway onboarding (sign in + choose a model + click **Finish**) can remain stuck on the welcome "Choose your provider" screen. Finish appears to do nothing even though auth succeeded and credits are available.

**Root cause:** Leaving welcome is gated by `checkExistKey()`, which only treats a profile as configured when:
- the provider is a special-cased no-key provider (`fake-ai` / `openai-codex` / `qwen-code`), or
- a key in `SECRET_STATE_KEYS` (or a few non-secret fields) is set

Zoo Gateway does not use those keys. Login is session-based:
1. Global Zoo Code auth in secret storage (`zooCodeIsAuthenticated` / green checkmark)
2. Optionally a copy of that token on the provider profile as `zooSessionToken` (internal; users never enter this)

Finish already validates Zoo Gateway via either signal (`validate.ts`), then upserts the profile. The subsequent state update still called `checkExistKey` without Zoo Gateway awareness, so `showWelcome` stayed `true`.

**Changes:**
- Treat `apiProvider === "zoo-gateway"` as configured when the profile has `zooSessionToken` **or** `zooCodeIsAuthenticated` is true (mirrors Finish validation)
- Pass `zooCodeIsAuthenticated` from extension state into `checkExistKey` when updating `showWelcome`
- Add unit coverage for the Zoo Gateway cases

### Test Procedure

**Automated**
- [x] `npx vitest run shared/__tests__/checkExistApiConfig.spec.ts` (14 tests passed)

**Manual regression (VS Code)**
1. Fresh install / clear provider profiles so welcome shows
2. Choose **Zoo Gateway**, complete device/sign-in until green authenticated checkmark
3. Select a model, click **Finish**
4. Confirm welcome dismisses and chat UI is usable
5. Confirm signed-out Zoo Gateway still cannot leave welcome via Finish
6. Confirm OpenRouter (or another API-key provider) onboarding still works

### Pre-Submission Checklist

- [x] **Issue Linked**: Closes #961
- [x] **Scope**: Focused on welcome-gate recognition of Zoo Gateway session auth
- [x] **Self-Review**: Done
- [x] **Testing**: Unit tests added/updated for `checkExistKey`
- [x] **Documentation Impact**: No user-facing docs required
- [x] **Contribution Guidelines**: Followed

### Screenshots / Videos

N/A — behavior fix; welcome should dismiss after Finish when Zoo Gateway is authenticated (previously stayed on the Finish screen).

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

Workaround for affected users until this ships: temporarily select another provider that requires an API key to exit welcome, then switch back to Zoo Gateway in Settings (Settings is not welcome-gated).

### Get in Touch

—


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Zoo Gateway welcome and setup flow.
  * Users with an active Zoo session or enabled Zoo Code authentication are now recognized as configured.
  * Authentication status for Zoo Code no longer affects setup checks for other providers.

* **Tests**
  * Added coverage for Zoo Gateway session tokens, authentication, missing credentials, and other provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->