### PR TITLE
refactor(types): use canonical identifiers for default models

### DIFF
--- a/packages/types/src/__tests__/provider-default-model.test.ts
+++ b/packages/types/src/__tests__/provider-default-model.test.ts
@@ -1,0 +1,50 @@
+import type { ProviderName } from "../provider-settings.js"
+
+vi.mock("../provider-identifiers.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../provider-identifiers.js")>()
+
+	return {
+		...actual,
+		providerIdentifiers: {
+			...actual.providerIdentifiers,
+			openrouter: "canonical-openrouter-test-value",
+		},
+	}
+})
+
+import { providerIdentifiers } from "../provider-identifiers.js"
+import {
+	anthropicDefaultModelId,
+	getProviderDefaultModelId,
+	mainlandZAiDefaultModelId,
+	openRouterDefaultModelId,
+	vscodeLlmDefaultModelId,
+} from "../providers/index.js"
+
+describe("getProviderDefaultModelId", () => {
+	it("selects a static default through the canonical provider identifier", () => {
+		expect(getProviderDefaultModelId(providerIdentifiers.openrouter as ProviderName)).toBe(openRouterDefaultModelId)
+	})
+
+	it("triangulates static selection with another provider category", () => {
+		expect(getProviderDefaultModelId(providerIdentifiers.vscodeLm)).toBe(vscodeLlmDefaultModelId)
+	})
+
+	it("preserves region-dependent defaults", () => {
+		expect(getProviderDefaultModelId(providerIdentifiers.zai, { isChina: true })).toBe(mainlandZAiDefaultModelId)
+	})
+
+	it.each([providerIdentifiers.openai, providerIdentifiers.ollama, providerIdentifiers.lmstudio])(
+		"returns an empty default for custom or locally selected models from %s",
+		(provider) => {
+			expect(getProviderDefaultModelId(provider)).toBe("")
+		},
+	)
+
+	it.each([providerIdentifiers.anthropic, providerIdentifiers.geminiCli, providerIdentifiers.fakeAi])(
+		"preserves the Anthropic fallback for %s",
+		(provider) => {
+			expect(getProviderDefaultModelId(provider)).toBe(anthropicDefaultModelId)
+		},
+	)
+})

--- a/packages/types/src/__tests__/provider-default-model.test.ts
+++ b/packages/types/src/__tests__/provider-default-model.test.ts
@@ -16,6 +16,7 @@ import { providerIdentifiers } from "../provider-identifiers.js"
 import {
 	anthropicDefaultModelId,
 	getProviderDefaultModelId,
+	internationalZAiDefaultModelId,
 	mainlandZAiDefaultModelId,
 	openRouterDefaultModelId,
 	vscodeLlmDefaultModelId,
@@ -32,6 +33,7 @@ describe("getProviderDefaultModelId", () => {
 
 	it("preserves region-dependent defaults", () => {
 		expect(getProviderDefaultModelId(providerIdentifiers.zai, { isChina: true })).toBe(mainlandZAiDefaultModelId)
+		expect(getProviderDefaultModelId(providerIdentifiers.zai)).toBe(internationalZAiDefaultModelId)
 	})
 
 	it.each([providerIdentifiers.openai, providerIdentifiers.ollama, providerIdentifiers.lmstudio])(

--- a/packages/types/src/__tests__/provider-default-model.test.ts
+++ b/packages/types/src/__tests__/provider-default-model.test.ts
@@ -41,6 +41,8 @@ describe("getProviderDefaultModelId", () => {
 	})
 
 	it("preserves region-dependent defaults", () => {
+		// These defaults currently share the same model ID, so the assertions document
+		// both branches but cannot detect swapped ternary arms until the IDs diverge.
 		expect(getProviderDefaultModelId(providerIdentifiers.zai, { isChina: true })).toBe(mainlandZAiDefaultModelId)
 		expect(getProviderDefaultModelId(providerIdentifiers.zai)).toBe(internationalZAiDefaultModelId)
 	})

--- a/packages/types/src/__tests__/provider-default-model.test.ts
+++ b/packages/types/src/__tests__/provider-default-model.test.ts
@@ -17,9 +17,11 @@ import {
 	anthropicDefaultModelId,
 	getProviderDefaultModelId,
 	internationalZAiDefaultModelId,
+	kimiCodeDefaultModelId,
 	mainlandZAiDefaultModelId,
 	openRouterDefaultModelId,
 	vscodeLlmDefaultModelId,
+	zooGatewayDefaultModelId,
 } from "../providers/index.js"
 
 describe("getProviderDefaultModelId", () => {
@@ -29,6 +31,13 @@ describe("getProviderDefaultModelId", () => {
 
 	it("triangulates static selection with another provider category", () => {
 		expect(getProviderDefaultModelId(providerIdentifiers.vscodeLm)).toBe(vscodeLlmDefaultModelId)
+	})
+
+	it.each([
+		[providerIdentifiers.kimiCode, kimiCodeDefaultModelId],
+		[providerIdentifiers.zooGateway, zooGatewayDefaultModelId],
+	])("preserves the %s default added on main", (provider, expectedModelId) => {
+		expect(getProviderDefaultModelId(provider)).toBe(expectedModelId)
 	})
 
 	it("preserves region-dependent defaults", () => {

--- a/packages/types/src/providers/index.ts
+++ b/packages/types/src/providers/index.ts
@@ -64,6 +64,8 @@ import { zooGatewayDefaultModelId } from "./zoo-gateway.js"
 import type { ProviderName } from "../provider-settings.js"
 import { providerIdentifiers } from "../provider-identifiers.js"
 
+const NO_DEFAULT_MODEL_ID = ""
+
 /**
  * Get the default model ID for a given provider.
  * This function returns only the provider's default model ID, without considering user configuration.
@@ -101,17 +103,16 @@ export function getProviderDefaultModelId(
 		case providerIdentifiers.zai:
 			return options?.isChina ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
 		case providerIdentifiers.openaiNative:
+			// TODO(#992): Replace this stale fallback with openAiNativeDefaultModelId.
 			return "gpt-4o" // Based on openai-native patterns
 		case providerIdentifiers.openaiCodex:
 			return openAiCodexDefaultModelId
 		case providerIdentifiers.mistral:
 			return mistralDefaultModelId
 		case providerIdentifiers.openai:
-			return "" // OpenAI provider uses custom model configuration
 		case providerIdentifiers.ollama:
-			return "" // Ollama uses dynamic model selection
 		case providerIdentifiers.lmstudio:
-			return "" // LMStudio uses dynamic model selection
+			return NO_DEFAULT_MODEL_ID
 		case providerIdentifiers.vscodeLm:
 			return vscodeLlmDefaultModelId
 		case providerIdentifiers.sambanova:

--- a/packages/types/src/providers/index.ts
+++ b/packages/types/src/providers/index.ts
@@ -62,6 +62,7 @@ import { zooGatewayDefaultModelId } from "./zoo-gateway.js"
 
 // Import the ProviderName type from provider-settings to avoid duplication
 import type { ProviderName } from "../provider-settings.js"
+import { providerIdentifiers } from "../provider-identifiers.js"
 
 /**
  * Get the default model ID for a given provider.
@@ -73,71 +74,71 @@ export function getProviderDefaultModelId(
 	options: { isChina?: boolean } = { isChina: false },
 ): string {
 	switch (provider) {
-		case "openrouter":
+		case providerIdentifiers.openrouter:
 			return openRouterDefaultModelId
-		case "requesty":
+		case providerIdentifiers.requesty:
 			return requestyDefaultModelId
-		case "litellm":
+		case providerIdentifiers.litellm:
 			return litellmDefaultModelId
-		case "xai":
+		case providerIdentifiers.xai:
 			return xaiDefaultModelId
-		case "baseten":
+		case providerIdentifiers.baseten:
 			return basetenDefaultModelId
-		case "bedrock":
+		case providerIdentifiers.bedrock:
 			return bedrockDefaultModelId
-		case "vertex":
+		case providerIdentifiers.vertex:
 			return vertexDefaultModelId
-		case "gemini":
+		case providerIdentifiers.gemini:
 			return geminiDefaultModelId
-		case "deepseek":
+		case providerIdentifiers.deepseek:
 			return deepSeekDefaultModelId
-		case "moonshot":
+		case providerIdentifiers.moonshot:
 			return moonshotDefaultModelId
-		case "minimax":
+		case providerIdentifiers.minimax:
 			return minimaxDefaultModelId
-		case "mimo":
+		case providerIdentifiers.mimo:
 			return mimoDefaultModelId
-		case "zai":
+		case providerIdentifiers.zai:
 			return options?.isChina ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
-		case "openai-native":
+		case providerIdentifiers.openaiNative:
 			return "gpt-4o" // Based on openai-native patterns
-		case "openai-codex":
+		case providerIdentifiers.openaiCodex:
 			return openAiCodexDefaultModelId
-		case "mistral":
+		case providerIdentifiers.mistral:
 			return mistralDefaultModelId
-		case "openai":
+		case providerIdentifiers.openai:
 			return "" // OpenAI provider uses custom model configuration
-		case "ollama":
+		case providerIdentifiers.ollama:
 			return "" // Ollama uses dynamic model selection
-		case "lmstudio":
+		case providerIdentifiers.lmstudio:
 			return "" // LMStudio uses dynamic model selection
-		case "vscode-lm":
+		case providerIdentifiers.vscodeLm:
 			return vscodeLlmDefaultModelId
-		case "sambanova":
+		case providerIdentifiers.sambanova:
 			return sambaNovaDefaultModelId
-		case "fireworks":
+		case providerIdentifiers.fireworks:
 			return fireworksDefaultModelId
-		case "friendli":
+		case providerIdentifiers.friendli:
 			return friendliDefaultModelId
-		case "qwen-code":
+		case providerIdentifiers.qwenCode:
 			return qwenCodeDefaultModelId
-		case "poe":
+		case providerIdentifiers.poe:
 			return poeDefaultModelId
-		case "unbound":
+		case providerIdentifiers.unbound:
 			return unboundDefaultModelId
-		case "vercel-ai-gateway":
+		case providerIdentifiers.vercelAiGateway:
 			return vercelAiGatewayDefaultModelId
-		case "opencode-go":
+		case providerIdentifiers.opencodeGo:
 			return opencodeGoDefaultModelId
-		case "kenari":
+		case providerIdentifiers.kenari:
 			return kenariDefaultModelId
-		case "kimi-code":
+		case providerIdentifiers.kimiCode:
 			return kimiCodeDefaultModelId
-		case "zoo-gateway":
+		case providerIdentifiers.zooGateway:
 			return zooGatewayDefaultModelId
-		case "anthropic":
-		case "gemini-cli":
-		case "fake-ai":
+		case providerIdentifiers.anthropic:
+		case providerIdentifiers.geminiCli:
+		case providerIdentifiers.fakeAi:
 		default:
 			return anthropicDefaultModelId
 	}


### PR DESCRIPTION
## Summary

- replace raw provider-name switch cases in `getProviderDefaultModelId()` with the canonical `providerIdentifiers` registry
- preserve all existing static, regional, custom/local, and fallback default-model behavior
- add focused tests using TDD triangulation across representative provider categories

Closes #954

## TDD

The new test first overrides the canonical OpenRouter identifier. Before the implementation change, the literal-based switch fails that case and returns the Anthropic fallback. Migrating the switch to `providerIdentifiers` makes it pass. Additional cases triangulate the behavior across static/internal, region-dependent, custom/local, and fallback providers.

## Verification

- `cd packages/types && npx vitest run src/__tests__/provider-default-model.test.ts src/__tests__/provider-identifiers.test.ts` — 17 passed
- `cd packages/types && npm test` — 253 passed
- `cd packages/types && npm run check-types` — passed
- `cd packages/types && npm run lint` — passed
- repository lint pre-commit hook — passed

## Note

The repository-wide pre-push type check currently reports unrelated pre-existing errors involving MiniMax M3, Moonshot router typing, LiteLLM exports, and `abandonSubtaskWithId`. The affected `@roo-code/types` package type check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider default-model selection to consistently match supported provider identifiers.
  * Preserved region-specific defaults (including China-dependent behavior) and maintained Anthropic fallback behavior.
  * Prevented unintended automatic defaults for custom/local selections (such as OpenAI, Ollama, and LM Studio).
* **Tests**
  * Added new Vitest coverage for provider matching, regional defaults, custom/local cases, and Anthropic fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->