### PR TITLE
refactor(shared): use canonical profile provider identifiers

### DIFF
--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1689,11 +1689,6 @@
 			"count": 2
 		}
 	},
-	"shared/__tests__/ProfileValidator.spec.ts": {
-		"@typescript-eslint/no-explicit-any": {
-			"count": 2
-		}
-	},
 	"shared/__tests__/api.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
 			"count": 8

--- a/src/shared/ProfileValidator.ts
+++ b/src/shared/ProfileValidator.ts
@@ -1,4 +1,4 @@
-import type { ProviderSettings, OrganizationAllowList } from "@roo-code/types"
+import { providerIdentifiers, type ProviderSettings, type OrganizationAllowList } from "@roo-code/types"
 
 export class ProfileValidator {
 	public static isProfileAllowed(profile: ProviderSettings, allowList: OrganizationAllowList): boolean {
@@ -51,36 +51,36 @@ export class ProfileValidator {
 
 	private static getModelIdFromProfile(profile: ProviderSettings): string | undefined {
 		switch (profile.apiProvider) {
-			case "openai":
+			case providerIdentifiers.openai:
 				return profile.openAiModelId
-			case "anthropic":
-			case "openai-native":
-			case "bedrock":
-			case "vertex":
-			case "gemini":
-			case "mistral":
-			case "deepseek":
-			case "xai":
-			case "sambanova":
-			case "fireworks":
-			case "friendli":
+			case providerIdentifiers.anthropic:
+			case providerIdentifiers.openaiNative:
+			case providerIdentifiers.bedrock:
+			case providerIdentifiers.vertex:
+			case providerIdentifiers.gemini:
+			case providerIdentifiers.mistral:
+			case providerIdentifiers.deepseek:
+			case providerIdentifiers.xai:
+			case providerIdentifiers.sambanova:
+			case providerIdentifiers.fireworks:
+			case providerIdentifiers.friendli:
 				return profile.apiModelId
-			case "litellm":
+			case providerIdentifiers.litellm:
 				return profile.litellmModelId
-			case "lmstudio":
+			case providerIdentifiers.lmstudio:
 				return profile.lmStudioModelId
-			case "vscode-lm":
+			case providerIdentifiers.vscodeLm:
 				// We probably need something more flexible for this one, if we need to really support it here.
 				return profile.vsCodeLmModelSelector?.id
-			case "openrouter":
+			case providerIdentifiers.openrouter:
 				return profile.openRouterModelId
-			case "ollama":
+			case providerIdentifiers.ollama:
 				return profile.ollamaModelId
-			case "requesty":
+			case providerIdentifiers.requesty:
 				return profile.requestyModelId
-			case "unbound":
+			case providerIdentifiers.unbound:
 				return profile.unboundModelId
-			case "fake-ai":
+			case providerIdentifiers.fakeAi:
 			default:
 				return undefined
 		}

--- a/src/shared/__tests__/ProfileValidator.spec.ts
+++ b/src/shared/__tests__/ProfileValidator.spec.ts
@@ -1,11 +1,97 @@
 // npx vitest run src/shared/__tests__/ProfileValidator.spec.ts
 
-import type { ProviderSettings, OrganizationAllowList } from "@roo-code/types"
+import { providerIdentifiers, type ProviderSettings, type OrganizationAllowList } from "@roo-code/types"
 
 import { ProfileValidator } from "../ProfileValidator"
 
 describe("ProfileValidator", () => {
 	describe("isProfileAllowed", () => {
+		it.each([
+			["openai", { openAiModelId: "model" }],
+			["anthropic", { apiModelId: "model" }],
+			["openaiNative", { apiModelId: "model" }],
+			["bedrock", { apiModelId: "model" }],
+			["vertex", { apiModelId: "model" }],
+			["gemini", { apiModelId: "model" }],
+			["mistral", { apiModelId: "model" }],
+			["deepseek", { apiModelId: "model" }],
+			["xai", { apiModelId: "model" }],
+			["sambanova", { apiModelId: "model" }],
+			["fireworks", { apiModelId: "model" }],
+			["friendli", { apiModelId: "model" }],
+			["litellm", { litellmModelId: "model" }],
+			["lmstudio", { lmStudioModelId: "model" }],
+			["vscodeLm", { vsCodeLmModelSelector: { id: "model" } }],
+			["openrouter", { openRouterModelId: "model" }],
+			["ollama", { ollamaModelId: "model" }],
+			["requesty", { requestyModelId: "model" }],
+			["unbound", { unboundModelId: "model" }],
+		])("resolves %s model fields through canonical identifiers", (identifierKey, profileSettings) => {
+			const identifiers = providerIdentifiers as Record<string, string>
+			const originalIdentifier = identifiers[identifierKey]
+			const canonicalIdentifier = `canonical-${identifierKey}`
+			const modelId = "model"
+
+			try {
+				identifiers[identifierKey] = canonicalIdentifier
+
+				const profile = {
+					apiProvider: canonicalIdentifier,
+					...profileSettings,
+				} as ProviderSettings
+				const allowList: OrganizationAllowList = {
+					allowAll: false,
+					providers: {
+						[canonicalIdentifier]: { allowAll: false, models: [modelId] },
+					},
+				}
+
+				expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(true)
+			} finally {
+				identifiers[identifierKey] = originalIdentifier
+			}
+		})
+
+		it.each([
+			{ identifierKey: "fakeAi", profileSettings: {}, modelId: undefined, expected: false },
+			{
+				identifierKey: "fakeAi",
+				profileSettings: {},
+				modelId: undefined,
+				expected: true,
+				providerAllowAll: true,
+			},
+		])(
+			"preserves canonical fallback behavior when provider allowAll is $providerAllowAll",
+			({ identifierKey, profileSettings, modelId, expected, providerAllowAll = false }) => {
+				const identifiers = providerIdentifiers as Record<string, string>
+				const originalIdentifier = identifiers[identifierKey]
+				const canonicalIdentifier = `canonical-${identifierKey}`
+
+				try {
+					identifiers[identifierKey] = canonicalIdentifier
+
+					const profile = {
+						apiProvider: canonicalIdentifier,
+						...profileSettings,
+					} as unknown as ProviderSettings
+					const allowList: OrganizationAllowList = {
+						allowAll: false,
+						providers: {
+							[canonicalIdentifier]: {
+								allowAll: providerAllowAll,
+								models: modelId ? [modelId] : undefined,
+							},
+						},
+					}
+
+					expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(expected)
+				} finally {
+					identifiers[identifierKey] = originalIdentifier
+				}
+			},
+		)
+
 		it("should allow any profile when allowAll is true", () => {
 			const allowList: OrganizationAllowList = {
 				allowAll: true,

--- a/src/shared/__tests__/ProfileValidator.spec.ts
+++ b/src/shared/__tests__/ProfileValidator.spec.ts
@@ -27,38 +27,30 @@ describe("ProfileValidator", () => {
 			["requesty", { requestyModelId: "model" }],
 			["unbound", { unboundModelId: "model" }],
 		])("resolves %s model fields through canonical identifiers", (identifierKey, profileSettings) => {
-			const identifiers = providerIdentifiers as Record<string, string>
-			const originalIdentifier = identifiers[identifierKey]
-			const canonicalIdentifier = `canonical-${identifierKey}`
+			const canonicalIdentifier = providerIdentifiers[identifierKey as keyof typeof providerIdentifiers]
 			const modelId = "model"
 
-			try {
-				identifiers[identifierKey] = canonicalIdentifier
-
-				const profile = {
-					apiProvider: canonicalIdentifier,
-					...profileSettings,
-				} as ProviderSettings
-				const allowList: OrganizationAllowList = {
-					allowAll: false,
-					providers: {
-						[canonicalIdentifier]: { allowAll: false, models: [modelId] },
-					},
-				}
-
-				expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(true)
-
-				const negativeAllowList: OrganizationAllowList = {
-					allowAll: false,
-					providers: {
-						[canonicalIdentifier]: { allowAll: false, models: ["other-model"] },
-					},
-				}
-
-				expect(ProfileValidator.isProfileAllowed(profile, negativeAllowList)).toBe(false)
-			} finally {
-				identifiers[identifierKey] = originalIdentifier
+			const profile = {
+				apiProvider: canonicalIdentifier,
+				...profileSettings,
+			} as ProviderSettings
+			const allowList: OrganizationAllowList = {
+				allowAll: false,
+				providers: {
+					[canonicalIdentifier]: { allowAll: false, models: [modelId] },
+				},
 			}
+
+			expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(true)
+
+			const negativeAllowList: OrganizationAllowList = {
+				allowAll: false,
+				providers: {
+					[canonicalIdentifier]: { allowAll: false, models: ["other-model"] },
+				},
+			}
+
+			expect(ProfileValidator.isProfileAllowed(profile, negativeAllowList)).toBe(false)
 		})
 
 		it.each([

--- a/src/shared/__tests__/ProfileValidator.spec.ts
+++ b/src/shared/__tests__/ProfileValidator.spec.ts
@@ -47,48 +47,37 @@ describe("ProfileValidator", () => {
 				}
 
 				expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(true)
+
+				const negativeAllowList: OrganizationAllowList = {
+					allowAll: false,
+					providers: {
+						[canonicalIdentifier]: { allowAll: false, models: ["other-model"] },
+					},
+				}
+
+				expect(ProfileValidator.isProfileAllowed(profile, negativeAllowList)).toBe(false)
 			} finally {
 				identifiers[identifierKey] = originalIdentifier
 			}
 		})
 
 		it.each([
-			{ identifierKey: "fakeAi", profileSettings: {}, modelId: undefined, expected: false },
-			{
-				identifierKey: "fakeAi",
-				profileSettings: {},
-				modelId: undefined,
-				expected: true,
-				providerAllowAll: true,
-			},
+			{ providerAllowAll: false, expected: false },
+			{ providerAllowAll: true, expected: true },
 		])(
-			"preserves canonical fallback behavior when provider allowAll is $providerAllowAll",
-			({ identifierKey, profileSettings, modelId, expected, providerAllowAll = false }) => {
-				const identifiers = providerIdentifiers as Record<string, string>
-				const originalIdentifier = identifiers[identifierKey]
-				const canonicalIdentifier = `canonical-${identifierKey}`
-
-				try {
-					identifiers[identifierKey] = canonicalIdentifier
-
-					const profile = {
-						apiProvider: canonicalIdentifier,
-						...profileSettings,
-					} as unknown as ProviderSettings
-					const allowList: OrganizationAllowList = {
-						allowAll: false,
-						providers: {
-							[canonicalIdentifier]: {
-								allowAll: providerAllowAll,
-								models: modelId ? [modelId] : undefined,
-							},
-						},
-					}
-
-					expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(expected)
-				} finally {
-					identifiers[identifierKey] = originalIdentifier
+			"preserves missing-model fallback behavior when provider allowAll is $providerAllowAll",
+			({ providerAllowAll, expected }) => {
+				const profile: ProviderSettings = {
+					apiProvider: providerIdentifiers.openai,
 				}
+				const allowList: OrganizationAllowList = {
+					allowAll: false,
+					providers: {
+						[providerIdentifiers.openai]: { allowAll: providerAllowAll },
+					},
+				}
+
+				expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(expected)
 			},
 		)
 
@@ -254,17 +243,17 @@ describe("ProfileValidator", () => {
 
 		// Test specific providers that use apiModelId
 		const apiModelProviders = [
-			"anthropic",
-			"openai-native",
-			"bedrock",
-			"vertex",
-			"gemini",
-			"mistral",
-			"deepseek",
-			"xai",
-			"sambanova",
-			"fireworks",
-			"friendli",
+			providerIdentifiers.anthropic,
+			providerIdentifiers.openaiNative,
+			providerIdentifiers.bedrock,
+			providerIdentifiers.vertex,
+			providerIdentifiers.gemini,
+			providerIdentifiers.mistral,
+			providerIdentifiers.deepseek,
+			providerIdentifiers.xai,
+			providerIdentifiers.sambanova,
+			providerIdentifiers.fireworks,
+			providerIdentifiers.friendli,
 		]
 
 		apiModelProviders.forEach((provider) => {
@@ -276,7 +265,7 @@ describe("ProfileValidator", () => {
 					},
 				}
 				const profile: ProviderSettings = {
-					apiProvider: provider as any, // Type assertion needed here
+					apiProvider: provider,
 					apiModelId: "test-model",
 				}
 
@@ -289,11 +278,11 @@ describe("ProfileValidator", () => {
 			const allowList: OrganizationAllowList = {
 				allowAll: false,
 				providers: {
-					litellm: { allowAll: false, models: ["test-model"] },
+					[providerIdentifiers.litellm]: { allowAll: false, models: ["test-model"] },
 				},
 			}
 			const profile: ProviderSettings = {
-				apiProvider: "litellm" as any,
+				apiProvider: providerIdentifiers.litellm,
 				litellmModelId: "test-model",
 			}
 
@@ -304,11 +293,11 @@ describe("ProfileValidator", () => {
 			const allowList: OrganizationAllowList = {
 				allowAll: false,
 				providers: {
-					"vscode-lm": { allowAll: false, models: ["copilot-gpt-3.5"] },
+					[providerIdentifiers.vscodeLm]: { allowAll: false, models: ["copilot-gpt-3.5"] },
 				},
 			}
 			const profile: ProviderSettings = {
-				apiProvider: "vscode-lm",
+				apiProvider: providerIdentifiers.vscodeLm,
 				vsCodeLmModelSelector: { id: "copilot-gpt-3.5" },
 			}
 
@@ -364,11 +353,11 @@ describe("ProfileValidator", () => {
 			const allowList: OrganizationAllowList = {
 				allowAll: false,
 				providers: {
-					"fake-ai": { allowAll: false },
+					[providerIdentifiers.fakeAi]: { allowAll: false },
 				},
 			}
 			const profile: ProviderSettings = {
-				apiProvider: "fake-ai",
+				apiProvider: providerIdentifiers.fakeAi,
 			}
 
 			expect(ProfileValidator.isProfileAllowed(profile, allowList)).toBe(false)


### PR DESCRIPTION
## Summary

- replace raw provider-name literals in profile model resolution with canonical `providerIdentifiers` values
- preserve every existing provider-to-model-field mapping and fallback behavior
- add focused registry-driven coverage for provider-specific model fields and missing-model fallback behavior

## TDD

Implemented with iterative red-green triangulation:

1. Added an OpenAI canonical-identifier regression test and confirmed it failed.
2. Migrated the OpenAI case minimally and confirmed it passed.
3. Triangulated across `apiModelId`, OpenRouter, and VS Code LM mappings and confirmed the tests failed before migrating those cases.
4. Triangulated the remaining provider-specific mappings, then completed the canonical migration.
5. Covered fallback behavior for profiles without a model ID, including provider-level `allowAll`.

## Verification

- `cd src && npx vitest run shared/__tests__/ProfileValidator.spec.ts` — 50 passed
- `cd src && npx vitest run shared` — 410 passed
- focused ESLint — passed
- `cd src && npm run check-types` — passed
- repository pre-commit lint — passed
- repository pre-push type checks — passed
- `git diff --check` — passed

Closes #956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile validation across supported AI providers by resolving provider/model identifiers consistently.
  * Preserved existing fallback behavior for unknown providers and configurations where model lists are missing.

* **Tests**
  * Expanded automated coverage for provider-specific model resolution.
  * Added scenarios to verify correct “missing-model” handling when provider permissions are toggled and model lists are undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->