### PR TITLE
fix(shell): delegate VS Code profile reads to Terminal methods (issue #634)

### DIFF
--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1706,7 +1706,7 @@
 	},
 	"utils/__tests__/shell.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 46
+			"count": 35
 		}
 	},
 	"utils/__tests__/storage.spec.ts": {

--- a/src/integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
+++ b/src/integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
@@ -1,0 +1,169 @@
+// Regression test for https://github.com/Zoo-Code-Org/Zoo-Code/issues/634
+//
+// When the user sets terminal.integrated.defaultProfile.windows in *workspace*
+// settings, getShell() (used for the system prompt) picks it up via config.get()
+// which merges all scopes, but Terminal.getConfiguredDefaultProfileName() only
+// reads inspect().globalValue ?? inspect().defaultValue — intentionally excluding
+// workspace for security.
+//
+// The result: the system prompt tells the model "you have PowerShell" but the
+// actual terminal VS Code opens defaults to cmd.exe (or whatever VS Code picks
+// when no global/default profile is set), so every PowerShell command fails.
+//
+// Run: node_modules/.bin/vitest run integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
+
+import { existsSync } from "fs"
+import * as vscode from "vscode"
+
+vi.mock("execa", () => ({ execa: vi.fn() }))
+vi.mock("fs", () => ({ existsSync: vi.fn(() => false) }))
+vi.mock("os", () => ({ userInfo: vi.fn(() => ({ shell: null })) }))
+
+const mockedExistsSync = existsSync as unknown as ReturnType<typeof vi.fn>
+
+const { Terminal } = await import("../Terminal")
+const { getShell } = await import("../../../utils/shell")
+
+describe("issue #634 — system prompt shell vs actual terminal shell divergence", () => {
+	let originalPlatform: NodeJS.Platform
+
+	beforeEach(() => {
+		originalPlatform = process.platform
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true })
+		Terminal.setTerminalProfile(undefined)
+		mockedExistsSync.mockReset()
+		// pwsh.exe exists — getShell() fallback path prefers PowerShell 7 over legacy
+		mockedExistsSync.mockImplementation((p: string) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+	})
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+		Terminal.setTerminalProfile(undefined)
+		vi.restoreAllMocks()
+	})
+
+	/**
+	 * Stubs VS Code config to simulate a workspace-scoped default profile.
+	 *
+	 * getShell() (shell.ts) uses getConfiguration("terminal.integrated").get() which
+	 * returns the merged/effective value across all scopes — workspace value wins.
+	 *
+	 * Terminal.getConfiguredDefaultProfileName() uses inspect().globalValue ?? defaultValue,
+	 * intentionally excluding workspace scope for security. Both undefined here.
+	 */
+	function stubWorkspaceScopedProfile(profileName: string, profilePath: string) {
+		const profiles = { [profileName]: { path: profilePath } }
+		vi.spyOn(vscode.workspace, "getConfiguration").mockImplementation((section?: string) => {
+			if (section === "terminal.integrated") {
+				return {
+					// get() merges all scopes — shell.ts uses this, picks up workspace value
+					get: (key: string) => {
+						if (key === "defaultProfile.windows") return profileName
+						if (key === "profiles.windows") return profiles
+						return undefined
+					},
+					// Terminal uses inspect() and only reads globalValue ?? defaultValue
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: undefined,
+						workspaceValue: profileName,
+					}),
+				} as unknown as vscode.WorkspaceConfiguration
+			}
+
+			if (section === "terminal.integrated.profiles") {
+				return {
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: undefined,
+						workspaceValue: profiles,
+					}),
+				} as unknown as vscode.WorkspaceConfiguration
+			}
+
+			return {
+				get: (_key: string, dv?: unknown) => dv,
+				inspect: () => undefined,
+			} as unknown as vscode.WorkspaceConfiguration
+		})
+	}
+
+	it("Terminal.getConfiguredDefaultProfileName ignores workspace-scoped profile (confirms the bug)", () => {
+		// User set PowerShell as default only in their workspace .vscode/settings.json
+		stubWorkspaceScopedProfile("PowerShell", "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+
+		// Terminal intentionally excludes workspace scope for security.
+		// With no global/default profile set, it returns undefined.
+		const terminalSeesProfileName = Terminal.getConfiguredDefaultProfileName("win32")
+		expect(terminalSeesProfileName).toBeUndefined()
+
+		// As a consequence, isActiveShellPowerShell returns false even though the
+		// user configured PowerShell — the terminal will not be treated as PowerShell.
+		expect(Terminal.isActiveShellPowerShell("win32")).toBe(false)
+	})
+
+	it("getShell() and Terminal agree on PowerShell when the default profile is set at global/user scope", () => {
+		// When the profile is set at user (global) scope, both paths see the same value.
+		const profilePath = "C:\\Program Files\\Git\\bin\\bash.exe" // non-PowerShell so name-matching doesn't hide the bug
+		const profileName = "Git Bash"
+		vi.spyOn(vscode.workspace, "getConfiguration").mockImplementation((section?: string) => {
+			if (section === "terminal.integrated") {
+				return {
+					get: (key: string) => {
+						if (key === "defaultProfile.windows") return profileName
+						if (key === "profiles.windows") return { [profileName]: { path: profilePath } }
+						return undefined
+					},
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: profileName,
+						workspaceValue: undefined,
+					}),
+				} as unknown as vscode.WorkspaceConfiguration
+			}
+
+			if (section === "terminal.integrated.profiles") {
+				const profiles = { [profileName]: { path: profilePath } }
+				return {
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: profiles,
+						workspaceValue: undefined,
+					}),
+				} as unknown as vscode.WorkspaceConfiguration
+			}
+
+			return {
+				get: (_key: string, dv?: unknown) => dv,
+				inspect: () => undefined,
+			} as unknown as vscode.WorkspaceConfiguration
+		})
+		mockedExistsSync.mockImplementation((p: string) => p === profilePath)
+
+		const shellForSystemPrompt = getShell()
+		const terminalSeesProfileName = Terminal.getConfiguredDefaultProfileName("win32")
+
+		// Both agree: Git Bash
+		expect(terminalSeesProfileName).toBe(profileName)
+		expect(shellForSystemPrompt).toBe(profilePath)
+	})
+
+	it("divergence: getShell() reports PowerShell but Terminal sees no profile when set at workspace scope only", () => {
+		stubWorkspaceScopedProfile("PowerShell", "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+
+		// getShell() uses config.get() → picks up workspace value → sees "PowerShell" name
+		// → name-match path returns pwsh.exe (since existsSync mocked true for it)
+		const shellForSystemPrompt = getShell()
+		expect(shellForSystemPrompt).toContain("PowerShell")
+
+		// Terminal.getConfiguredDefaultProfileName() uses inspect().globalValue → undefined
+		const terminalSeesProfileName = Terminal.getConfiguredDefaultProfileName("win32")
+		expect(terminalSeesProfileName).toBeUndefined()
+
+		// Terminal therefore can't identify the active shell as PowerShell
+		expect(Terminal.isActiveShellPowerShell("win32")).toBe(false)
+
+		// Divergence: system prompt claims PowerShell, Terminal has no profile → falls
+		// through to VS Code's own autodetect which may open cmd.exe on this machine.
+	})
+})

--- a/src/integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
+++ b/src/integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
@@ -1,14 +1,14 @@
 // Regression test for https://github.com/Zoo-Code-Org/Zoo-Code/issues/634
 //
-// When the user sets terminal.integrated.defaultProfile.windows in *workspace*
-// settings, getShell() (used for the system prompt) picks it up via config.get()
-// which merges all scopes, but Terminal.getConfiguredDefaultProfileName() only
-// reads inspect().globalValue ?? inspect().defaultValue — intentionally excluding
-// workspace for security.
+// Root cause: getShell() (system prompt) used config.get() which merges all scopes
+// including workspace, while Terminal.getConfiguredDefaultProfileName() used
+// inspect().globalValue — intentionally excluding workspace scope for security.
+// terminal.integrated.defaultProfile.* is APPLICATION-scoped; workspace values are
+// technically accepted by VS Code but ignored by the terminal itself.
 //
-// The result: the system prompt tells the model "you have PowerShell" but the
-// actual terminal VS Code opens defaults to cmd.exe (or whatever VS Code picks
-// when no global/default profile is set), so every PowerShell command fails.
+// Fix: getShell() now delegates to Terminal.getConfiguredDefaultProfileName() and
+// Terminal.getConfiguredProfiles(), so both paths read the same inspect()-based values
+// and can never disagree.
 //
 // Run: node_modules/.bin/vitest run integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
 
@@ -44,12 +44,9 @@ describe("issue #634 — system prompt shell vs actual terminal shell divergence
 
 	/**
 	 * Stubs VS Code config to simulate a workspace-scoped default profile.
-	 *
-	 * getShell() (shell.ts) uses getConfiguration("terminal.integrated").get() which
-	 * returns the merged/effective value across all scopes — workspace value wins.
-	 *
-	 * Terminal.getConfiguredDefaultProfileName() uses inspect().globalValue ?? defaultValue,
-	 * intentionally excluding workspace scope for security. Both undefined here.
+	 * globalValue is undefined for both the profile name and profiles map,
+	 * so Terminal (which reads only globalValue ?? defaultValue) sees no profile.
+	 * The workspace-scoped value is present to verify it is correctly ignored.
 	 */
 	function stubWorkspaceScopedProfile(profileName: string, profilePath: string) {
 		const profiles = { [profileName]: { path: profilePath } }
@@ -148,22 +145,23 @@ describe("issue #634 — system prompt shell vs actual terminal shell divergence
 		expect(shellForSystemPrompt).toBe(profilePath)
 	})
 
-	it("divergence: getShell() reports PowerShell but Terminal sees no profile when set at workspace scope only", () => {
+	it("convergence: getShell() and Terminal both ignore a workspace-scoped-only profile (fix verification)", () => {
+		// beforeEach mocks existsSync to return true only for PS7 path.
+		// Here we want to test the no-profile fallback, so make existsSync return false.
+		mockedExistsSync.mockReturnValue(false)
 		stubWorkspaceScopedProfile("PowerShell", "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 
-		// getShell() uses config.get() → picks up workspace value → sees "PowerShell" name
-		// → name-match path returns pwsh.exe (since existsSync mocked true for it)
-		const shellForSystemPrompt = getShell()
-		expect(shellForSystemPrompt).toContain("PowerShell")
-
-		// Terminal.getConfiguredDefaultProfileName() uses inspect().globalValue → undefined
+		// Terminal reads only inspect().globalValue → no profile configured at global scope.
 		const terminalSeesProfileName = Terminal.getConfiguredDefaultProfileName("win32")
 		expect(terminalSeesProfileName).toBeUndefined()
 
-		// Terminal therefore can't identify the active shell as PowerShell
-		expect(Terminal.isActiveShellPowerShell("win32")).toBe(false)
+		// After the fix, getShell() delegates to Terminal's inspect()-based methods,
+		// so it also sees no profile. It falls back to the Windows no-profile default
+		// (PS legacy, since existsSync returns false for PS7 in this test).
+		const shellForSystemPrompt = getShell()
+		expect(shellForSystemPrompt).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 
-		// Divergence: system prompt claims PowerShell, Terminal has no profile → falls
-		// through to VS Code's own autodetect which may open cmd.exe on this machine.
+		// Both paths agree: no profile resolved → no active shell identified as PowerShell.
+		expect(Terminal.isActiveShellPowerShell("win32")).toBe(false)
 	})
 })

--- a/src/utils/__tests__/shell.spec.ts
+++ b/src/utils/__tests__/shell.spec.ts
@@ -36,23 +36,29 @@ describe("Shell Detection Tests", () => {
 	 * how Terminal.getConfiguredDefaultProfileName and Terminal.getConfiguredProfiles
 	 * read config (globalValue only — workspace excluded per APPLICATION scope).
 	 */
-	function mockVsCodeConfig(_platformKey: string, defaultProfileName: string | null, profiles: Record<string, any>) {
+	function mockVsCodeConfig(platformKey: string, defaultProfileName: string | null, profiles: Record<string, any>) {
 		vscode.workspace.getConfiguration = (section?: string) => {
 			if (section === "terminal.integrated") {
 				return {
-					inspect: (_key: string) => ({
-						defaultValue: undefined,
-						globalValue: defaultProfileName ?? undefined,
-					}),
+					inspect: (key: string) => {
+						expect(key).toBe(`defaultProfile.${platformKey}`)
+						return {
+							defaultValue: undefined,
+							globalValue: defaultProfileName ?? undefined,
+						}
+					},
 					get: () => undefined,
 				} as any
 			}
 			if (section === "terminal.integrated.profiles") {
 				return {
-					inspect: (_key: string) => ({
-						defaultValue: undefined,
-						globalValue: profiles,
-					}),
+					inspect: (key: string) => {
+						expect(key).toBe(platformKey)
+						return {
+							defaultValue: undefined,
+							globalValue: profiles,
+						}
+					},
 					get: () => undefined,
 				} as any
 			}
@@ -450,7 +456,7 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).toBe("/bin/bash")
 		})
 
-		it("should validate array shell paths and use first allowlisted path", () => {
+		it("should resolve array shell paths and use first path", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
 			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 			mockVsCodeConfig("windows", "PowerShell", {

--- a/src/utils/__tests__/shell.spec.ts
+++ b/src/utils/__tests__/shell.spec.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode"
 import { existsSync } from "fs"
 import { userInfo } from "os"
 import { getShell } from "../shell"
+import { BaseTerminal } from "../../integrations/terminal/BaseTerminal"
+import { Terminal } from "../../integrations/terminal/Terminal"
 
 vi.mock("vscode", () => ({
 	workspace: {
@@ -77,12 +79,17 @@ describe("Shell Detection Tests", () => {
 		vi.mocked(userInfo).mockReturnValue({ shell: null } as any)
 		// Default: PowerShell 7 is not installed, so the probe falls back to legacy.
 		vi.mocked(existsSync).mockReturnValue(false)
+		// Clear Zoo profile override and execa shell path between tests.
+		Terminal.setTerminalProfile(undefined)
+		BaseTerminal.setExecaShellPath(undefined)
 	})
 
 	afterEach(() => {
 		Object.defineProperty(process, "platform", { value: originalPlatform })
 		process.env = originalEnv
 		vscode.workspace.getConfiguration = originalGetConfig
+		Terminal.setTerminalProfile(undefined)
+		BaseTerminal.setExecaShellPath(undefined)
 		vi.clearAllMocks()
 	})
 
@@ -512,6 +519,79 @@ describe("Shell Detection Tests", () => {
 			mockVsCodeConfig("linux", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: "" } as any)
 			delete process.env.SHELL
+			expect(getShell()).toBe("/bin/bash")
+		})
+	})
+
+	// --------------------------------------------------------------------------
+	// Zoo profile override (Terminal.getProfileShell) takes precedence
+	// --------------------------------------------------------------------------
+	describe("Zoo profile override", () => {
+		it("uses Zoo profile shell over VS Code default profile", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			// VS Code default profile is PowerShell
+			vi.mocked(existsSync).mockReturnValue(true)
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+			})
+			// Zoo profile override points to Git Bash
+			Terminal.setTerminalProfile("Git Bash")
+			vi.spyOn(Terminal, "getProfileShell").mockReturnValue({
+				shellPath: "C:\\Program Files\\Git\\bin\\bash.exe",
+			})
+			expect(getShell()).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
+		})
+
+		it("falls through to VS Code default when Zoo profile has no resolvable shell", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			vi.mocked(existsSync).mockImplementation((p) => String(p) === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+			})
+			Terminal.setTerminalProfile("Unresolvable")
+			vi.spyOn(Terminal, "getProfileShell").mockReturnValue(undefined)
+			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+		})
+	})
+
+	// --------------------------------------------------------------------------
+	// Explicit execa shell path takes highest precedence
+	// --------------------------------------------------------------------------
+	describe("Execa shell path override", () => {
+		it("uses explicit execa shell path over VS Code config", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			vi.mocked(existsSync).mockReturnValue(true)
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
+			})
+			BaseTerminal.setExecaShellPath("C:\\Program Files\\Git\\bin\\bash.exe")
+			expect(getShell()).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
+		})
+
+		it("uses explicit execa shell path over Zoo profile override", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			mockVsCodeConfig("linux", null, {})
+			Terminal.setTerminalProfile("fish")
+			vi.spyOn(Terminal, "getProfileShell").mockReturnValue({
+				shellPath: "/usr/bin/fish",
+			})
+			BaseTerminal.setExecaShellPath("/bin/zsh")
+			expect(getShell()).toBe("/bin/zsh")
+		})
+
+		it("falls through to VS Code config when execa shell path is not set", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			vi.mocked(existsSync).mockImplementation((p) => String(p) === "/usr/bin/fish")
+			mockVsCodeConfig("linux", "fish", {
+				fish: { path: "/usr/bin/fish" },
+			})
+			expect(getShell()).toBe("/usr/bin/fish")
+		})
+
+		it("rejects non-allowlisted execa shell path and uses fallback", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			mockVsCodeConfig("linux", null, {})
+			BaseTerminal.setExecaShellPath("/opt/evil/shell")
 			expect(getShell()).toBe("/bin/bash")
 		})
 	})

--- a/src/utils/__tests__/shell.spec.ts
+++ b/src/utils/__tests__/shell.spec.ts
@@ -4,24 +4,20 @@ import { existsSync } from "fs"
 import { userInfo } from "os"
 import { getShell } from "../shell"
 
-// Mock vscode module
 vi.mock("vscode", () => ({
 	workspace: {
 		getConfiguration: vi.fn(),
 	},
 }))
 
-// Mock the os module
 vi.mock("os", () => ({
 	userInfo: vi.fn(() => ({ shell: null })),
 }))
 
-// Mock the fs module — getWindowsShellFromVSCode probes for PowerShell 7 (pwsh.exe).
 vi.mock("fs", () => ({
 	existsSync: vi.fn(() => false),
 }))
 
-// Mock path module for testing
 vi.mock("path", async () => {
 	const actual = await vi.importActual("path")
 	return {
@@ -35,40 +31,49 @@ describe("Shell Detection Tests", () => {
 	let originalEnv: NodeJS.ProcessEnv
 	let originalGetConfig: any
 
-	// Helper to mock VS Code configuration
-	function mockVsCodeConfig(platformKey: string, defaultProfileName: string | null, profiles: Record<string, any>) {
-		vscode.workspace.getConfiguration = () =>
-			({
-				get: (key: string) => {
-					if (key === `defaultProfile.${platformKey}`) {
-						return defaultProfileName
-					}
-					if (key === `profiles.${platformKey}`) {
-						return profiles
-					}
-					return undefined
-				},
-			}) as any
+	/**
+	 * Stubs VS Code config using inspect() on the correct section names, matching
+	 * how Terminal.getConfiguredDefaultProfileName and Terminal.getConfiguredProfiles
+	 * read config (globalValue only — workspace excluded per APPLICATION scope).
+	 */
+	function mockVsCodeConfig(_platformKey: string, defaultProfileName: string | null, profiles: Record<string, any>) {
+		vscode.workspace.getConfiguration = (section?: string) => {
+			if (section === "terminal.integrated") {
+				return {
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: defaultProfileName ?? undefined,
+					}),
+					get: () => undefined,
+				} as any
+			}
+			if (section === "terminal.integrated.profiles") {
+				return {
+					inspect: (_key: string) => ({
+						defaultValue: undefined,
+						globalValue: profiles,
+					}),
+					get: () => undefined,
+				} as any
+			}
+			return { get: () => undefined, inspect: () => undefined } as any
+		}
 	}
 
 	beforeEach(() => {
-		// Store original references
 		originalPlatform = process.platform
 		originalEnv = { ...process.env }
 		originalGetConfig = vscode.workspace.getConfiguration
 
-		// Clear environment variables for a clean test
 		delete process.env.SHELL
 		delete process.env.COMSPEC
 
-		// Reset userInfo mock to default
 		vi.mocked(userInfo).mockReturnValue({ shell: null } as any)
 		// Default: PowerShell 7 is not installed, so the probe falls back to legacy.
 		vi.mocked(existsSync).mockReturnValue(false)
 	})
 
 	afterEach(() => {
-		// Restore everything
 		Object.defineProperty(process, "platform", { value: originalPlatform })
 		process.env = originalEnv
 		vscode.workspace.getConfiguration = originalGetConfig
@@ -84,6 +89,7 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("uses explicit PowerShell 7 path from VS Code config (profile path)", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
 			})
@@ -91,65 +97,33 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("should handle array path from VSCode terminal profile", () => {
-			// Mock VSCode configuration with array path
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return "PowerShell"
-					if (key === "profiles.windows") {
-						return {
-							PowerShell: {
-								// VSCode API may return path as an array
-								path: ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "pwsh.exe"],
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			const result = getShell()
-			// Should use the first element of the array
-			expect(result).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "pwsh.exe"] },
+			})
+			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
-		it("should handle empty array path and fall back to defaults", () => {
-			// Mock VSCode configuration with empty array path
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return "Custom"
-					if (key === "profiles.windows") {
-						return {
-							Custom: {
-								path: [], // Empty array
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			// Mock environment variable
+		it("falls through to COMSPEC when profile has an empty array path", () => {
+			mockVsCodeConfig("windows", "Custom", {
+				Custom: { path: [] },
+			})
 			process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe"
-
-			const result = getShell()
-			// Should fall back to cmd.exe
-			expect(result).toBe("C:\\Windows\\System32\\cmd.exe")
+			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("uses PowerShell 7 path if source is 'PowerShell' but no explicit path", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { source: "PowerShell" },
 			})
 			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
-		it("falls back to legacy PowerShell if profile includes 'powershell' but no path/source", () => {
+		it("falls back to legacy PowerShell if source is 'PowerShell' but PS7 is absent", () => {
+			vi.mocked(existsSync).mockReturnValue(false)
 			mockVsCodeConfig("windows", "PowerShell", {
-				PowerShell: {},
+				PowerShell: { source: "PowerShell" },
 			})
 			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
@@ -161,57 +135,48 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).toBe("/bin/bash")
 		})
 
-		it("uses WSL bash when profile name includes 'wsl'", () => {
-			mockVsCodeConfig("windows", "Ubuntu WSL", {
-				"Ubuntu WSL": {},
-			})
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		it("defaults to cmd.exe if no special profile is matched", () => {
+		it("falls through to COMSPEC when profile has no path and no source", () => {
+			// A profile entry with no path and no recognised source is unresolvable;
+			// getShell falls through to env/fallback rather than guessing cmd.exe.
 			mockVsCodeConfig("windows", "CommandPrompt", {
 				CommandPrompt: {},
 			})
+			process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe"
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
-		it("handles undefined profile gracefully", () => {
-			// Mock a case where defaultProfileName exists but the profile doesn't
+		it("falls through to COMSPEC when configured profile is missing from profiles map", () => {
 			mockVsCodeConfig("windows", "NonexistentProfile", {})
+			process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe"
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("defaults to PowerShell 7 when no profile is configured and pwsh.exe is installed", () => {
-			// Modern VS Code launches PowerShell by default on Windows (issue #82) and
-			// prefers PS7 when present, so getShell() should report pwsh.exe.
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			// Modern VS Code prefers PS7 on Windows when no profile is explicitly set.
+			mockVsCodeConfig("windows", null, {})
 			vi.mocked(existsSync).mockReturnValue(true)
-
 			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
 		it("falls back to Windows PowerShell 5.1 when no profile is configured and PS7 is absent", () => {
-			// Without PS7 installed, the probe falls back to the always-present legacy
-			// PowerShell rather than cmd.exe.
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("windows", null, {})
 			vi.mocked(existsSync).mockReturnValue(false)
-
 			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
 		it("falls back to safe shell when the configured profile path is non-allowlisted", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Custom\\evil.exe")
 			mockVsCodeConfig("windows", "Custom", {
 				Custom: { path: "C:\\Custom\\evil.exe" },
 			})
-
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("uses cmd.exe when a Command Prompt profile is explicitly configured", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Windows\\System32\\cmd.exe")
 			mockVsCodeConfig("windows", "Command Prompt", {
 				"Command Prompt": { path: "C:\\Windows\\System32\\cmd.exe" },
 			})
-
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 	})
@@ -225,6 +190,7 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("uses VS Code profile path if available", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/local/bin/fish")
 			mockVsCodeConfig("osx", "MyCustomShell", {
 				MyCustomShell: { path: "/usr/local/bin/fish" },
 			})
@@ -232,42 +198,27 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("should handle array path from VSCode terminal profile", () => {
-			// Mock VSCode configuration with array path
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return "zsh"
-					if (key === "profiles.osx") {
-						return {
-							zsh: {
-								path: ["/opt/homebrew/bin/zsh", "/bin/zsh"],
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			const result = getShell()
-			// Should use the first element of the array
-			expect(result).toBe("/opt/homebrew/bin/zsh")
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/opt/homebrew/bin/zsh")
+			mockVsCodeConfig("osx", "zsh", {
+				zsh: { path: ["/opt/homebrew/bin/zsh", "/bin/zsh"] },
+			})
+			expect(getShell()).toBe("/opt/homebrew/bin/zsh")
 		})
 
 		it("falls back to userInfo().shell if no VS Code config is available", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("osx", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: "/opt/homebrew/bin/zsh" } as any)
 			expect(getShell()).toBe("/opt/homebrew/bin/zsh")
 		})
 
 		it("falls back to SHELL env var if no userInfo shell is found", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("osx", null, {})
 			process.env.SHELL = "/usr/local/bin/zsh"
 			expect(getShell()).toBe("/usr/local/bin/zsh")
 		})
 
 		it("falls back to /bin/zsh if no config, userInfo, or env variable is set", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("osx", null, {})
 			expect(getShell()).toBe("/bin/zsh")
 		})
 	})
@@ -281,6 +232,7 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("uses VS Code profile path if available", () => {
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/bin/fish")
 			mockVsCodeConfig("linux", "CustomProfile", {
 				CustomProfile: { path: "/usr/bin/fish" },
 			})
@@ -288,42 +240,27 @@ describe("Shell Detection Tests", () => {
 		})
 
 		it("should handle array path from VSCode terminal profile", () => {
-			// Mock VSCode configuration with array path
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return "bash"
-					if (key === "profiles.linux") {
-						return {
-							bash: {
-								path: ["/usr/local/bin/bash", "/bin/bash"],
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			const result = getShell()
-			// Should use the first element of the array
-			expect(result).toBe("/usr/local/bin/bash")
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/local/bin/bash")
+			mockVsCodeConfig("linux", "bash", {
+				bash: { path: ["/usr/local/bin/bash", "/bin/bash"] },
+			})
+			expect(getShell()).toBe("/usr/local/bin/bash")
 		})
 
 		it("falls back to userInfo().shell if no VS Code config is available", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: "/usr/bin/zsh" } as any)
 			expect(getShell()).toBe("/usr/bin/zsh")
 		})
 
 		it("falls back to SHELL env var if no userInfo shell is found", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			process.env.SHELL = "/usr/bin/fish"
 			expect(getShell()).toBe("/usr/bin/fish")
 		})
 
 		it("falls back to /bin/bash if nothing is set", () => {
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			expect(getShell()).toBe("/bin/bash")
 		})
 	})
@@ -334,7 +271,7 @@ describe("Shell Detection Tests", () => {
 	describe("Unknown Platform / Error Handling", () => {
 		it("falls back to /bin/bash for unknown platforms", () => {
 			Object.defineProperty(process, "platform", { value: "sunos" })
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			expect(getShell()).toBe("/bin/bash")
 		})
 
@@ -349,7 +286,7 @@ describe("Shell Detection Tests", () => {
 
 		it("handles userInfo errors gracefully, falling back to environment variable if present", () => {
 			Object.defineProperty(process, "platform", { value: "darwin" })
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("osx", null, {})
 			vi.mocked(userInfo).mockImplementation(() => {
 				throw new Error("userInfo error")
 			})
@@ -368,77 +305,79 @@ describe("Shell Detection Tests", () => {
 			delete process.env.SHELL
 			expect(getShell()).toBe("/bin/bash")
 		})
+
+		it("handles inspect() returning undefined gracefully", () => {
+			Object.defineProperty(process, "platform", { value: "linux" })
+			vscode.workspace.getConfiguration = () =>
+				({
+					inspect: () => undefined,
+					get: () => undefined,
+				}) as any
+			expect(getShell()).toBe("/bin/bash")
+		})
 	})
 
 	// --------------------------------------------------------------------------
-	// getTerminalConfig Behavior (tested via getShell)
+	// Scope isolation — workspace values must not influence getShell()
 	// --------------------------------------------------------------------------
-	describe("getTerminalConfig", () => {
-		it("returns defaultProfileName and matching profile for Windows", () => {
+	describe("Scope isolation (workspace values ignored)", () => {
+		it("Windows: ignores a workspace-scoped default profile", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-			mockVsCodeConfig("windows", "Command Prompt", {
-				"Command Prompt": { path: "C:\\Windows\\System32\\cmd.exe" },
-			})
-			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
-		})
-
-		it("returns defaultProfileName and matching profile for macOS", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			mockVsCodeConfig("osx", "fish", {
-				fish: { path: "/usr/local/bin/fish" },
-			})
-			expect(getShell()).toBe("/usr/local/bin/fish")
-		})
-
-		it("returns defaultProfileName and matching profile for Linux", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			mockVsCodeConfig("linux", "zsh", {
-				zsh: { path: "/usr/bin/zsh" },
-			})
-			expect(getShell()).toBe("/usr/bin/zsh")
-		})
-
-		it("returns null defaultProfileName when config value is undefined", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return undefined
-					if (key === "profiles.linux") return { bash: { path: "/bin/bash" } }
-					return undefined
-				}),
+			vi.mocked(existsSync).mockReturnValue(false)
+			// globalValue is undefined; only workspaceValue is set
+			vscode.workspace.getConfiguration = (section?: string) => {
+				if (section === "terminal.integrated") {
+					return {
+						inspect: (_key: string) => ({
+							defaultValue: undefined,
+							globalValue: undefined,
+							workspaceValue: "PowerShell",
+						}),
+						get: () => undefined,
+					} as any
+				}
+				if (section === "terminal.integrated.profiles") {
+					return {
+						inspect: (_key: string) => ({
+							defaultValue: undefined,
+							globalValue: undefined,
+							workspaceValue: { PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" } },
+						}),
+						get: () => undefined,
+					} as any
+				}
+				return { get: () => undefined, inspect: () => undefined } as any
 			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			expect(getShell()).toBe("/bin/bash")
+			// No global profile → falls back to PS legacy (existsSync returns false for PS7)
+			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
-		it("returns empty profiles when profiles config is null", () => {
+		it("Linux: ignores a workspace-scoped default profile", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return "bash"
-					if (key === "profiles.linux") return null
-					return undefined
-				}),
+			vscode.workspace.getConfiguration = (section?: string) => {
+				if (section === "terminal.integrated") {
+					return {
+						inspect: (_key: string) => ({
+							defaultValue: undefined,
+							globalValue: undefined,
+							workspaceValue: "CustomShell",
+						}),
+						get: () => undefined,
+					} as any
+				}
+				if (section === "terminal.integrated.profiles") {
+					return {
+						inspect: (_key: string) => ({
+							defaultValue: undefined,
+							globalValue: undefined,
+							workspaceValue: { CustomShell: { path: "/usr/bin/fish" } },
+						}),
+						get: () => undefined,
+					} as any
+				}
+				return { get: () => undefined, inspect: () => undefined } as any
 			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		it("returns fallback when getConfiguration throws", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			vi.mocked(vscode.workspace.getConfiguration).mockImplementation(() => {
-				throw new Error("config error")
-			})
-			expect(getShell()).toBe("/bin/zsh")
-		})
-
-		it("returns fallback when config.get throws", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-				get: () => {
-					throw new Error("get error")
-				},
-			} as any)
+			// No global profile → falls through to /bin/bash
 			expect(getShell()).toBe("/bin/bash")
 		})
 	})
@@ -447,212 +386,26 @@ describe("Shell Detection Tests", () => {
 	// Non-string defaultProfileName Handling
 	// --------------------------------------------------------------------------
 	describe("Non-string defaultProfileName handling", () => {
-		it("Windows: handles numeric defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "win32" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return 1
-					if (key === "profiles.windows") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			vi.mocked(existsSync).mockReturnValue(false)
+		// Terminal.getConfiguredDefaultProfileName returns inspect().globalValue as-is.
+		// If VS Code somehow stores a non-string, it will be undefined (inspect returns
+		// typed as string | undefined), so getShell falls through to userInfo/env/fallback.
 
+		it("Windows: handles undefined defaultProfileName (no profile set)", () => {
+			Object.defineProperty(process, "platform", { value: "win32" })
+			mockVsCodeConfig("windows", null, {})
+			vi.mocked(existsSync).mockReturnValue(false)
 			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
 		})
 
-		it("Windows: handles boolean defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "win32" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return true
-					if (key === "profiles.windows") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			vi.mocked(existsSync).mockReturnValue(false)
-
-			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
-		})
-
-		it("Windows: handles array defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "win32" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return ["PowerShell"]
-					if (key === "profiles.windows") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			vi.mocked(existsSync).mockReturnValue(false)
-
-			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
-		})
-
-		it("Windows: handles object defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "win32" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return { name: "PowerShell" }
-					if (key === "profiles.windows") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-			vi.mocked(existsSync).mockReturnValue(false)
-
-			expect(getShell()).toBe("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
-		})
-
-		it("macOS: handles numeric defaultProfileName without TypeError", () => {
+		it("macOS: returns fallback when no profile is configured", () => {
 			Object.defineProperty(process, "platform", { value: "darwin" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return 1
-					if (key === "profiles.osx") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
+			mockVsCodeConfig("osx", null, {})
 			expect(getShell()).toBe("/bin/zsh")
 		})
 
-		it("macOS: handles boolean defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return true
-					if (key === "profiles.osx") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/zsh")
-		})
-
-		it("macOS: handles array defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return ["zsh"]
-					if (key === "profiles.osx") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/zsh")
-		})
-
-		it("macOS: handles object defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return {}
-					if (key === "profiles.osx") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/zsh")
-		})
-
-		// Mutation-resistant: without the typeof guard, profiles[1] === profiles["1"] in JS,
-		// so a numeric key that matches a real profile would return its path instead of falling back.
-		it("macOS: ignores numeric defaultProfileName even when it matches a profile key", () => {
-			Object.defineProperty(process, "platform", { value: "darwin" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.osx") return 1
-					// Profile keyed as "1" — would be reached by profiles[1] if the guard were absent
-					if (key === "profiles.osx") return { "1": { path: "/usr/local/bin/zsh" } }
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			// Guard treats 1 as null → getMacShellFromVSCode returns null → fallback to /bin/zsh
-			// Without the guard it would return /usr/local/bin/zsh
-			expect(getShell()).toBe("/bin/zsh")
-		})
-
-		it("Linux: handles numeric defaultProfileName without TypeError", () => {
+		it("Linux: returns fallback when no profile is configured", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return 1
-					if (key === "profiles.linux") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		it("Linux: handles boolean defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return true
-					if (key === "profiles.linux") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		it("Linux: handles array defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return ["bash"]
-					if (key === "profiles.linux") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		it("Linux: handles object defaultProfileName without TypeError", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return {}
-					if (key === "profiles.linux") return {}
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			expect(getShell()).toBe("/bin/bash")
-		})
-
-		// Mutation-resistant: same pattern as macOS — numeric key matches profile "1" only if unguarded.
-		it("Linux: ignores numeric defaultProfileName even when it matches a profile key", () => {
-			Object.defineProperty(process, "platform", { value: "linux" })
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.linux") return 1
-					// Profile keyed as "1" — would be reached by profiles[1] if the guard were absent
-					if (key === "profiles.linux") return { "1": { path: "/usr/bin/fish" } }
-					return undefined
-				}),
-			}
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			// Guard treats 1 as null → getLinuxShellFromVSCode returns null → fallback to /bin/bash
-			// Without the guard it would return /usr/bin/fish
+			mockVsCodeConfig("linux", null, {})
 			expect(getShell()).toBe("/bin/bash")
 		})
 	})
@@ -663,6 +416,7 @@ describe("Shell Detection Tests", () => {
 	describe("Shell Validation", () => {
 		it("should allow common Windows shells", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { path: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" },
 			})
@@ -671,6 +425,7 @@ describe("Shell Detection Tests", () => {
 
 		it("should allow common Unix shells", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/bin/fish")
 			mockVsCodeConfig("linux", "CustomProfile", {
 				CustomProfile: { path: "/usr/bin/fish" },
 			})
@@ -679,6 +434,7 @@ describe("Shell Detection Tests", () => {
 
 		it("should handle case-insensitive matching on Windows", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "c:\\windows\\system32\\cmd.exe")
 			mockVsCodeConfig("windows", "PowerShell", {
 				PowerShell: { path: "c:\\windows\\system32\\cmd.exe" },
 			})
@@ -687,90 +443,54 @@ describe("Shell Detection Tests", () => {
 
 		it("should reject unknown shells and use fallback", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/bin/malicious-shell")
 			mockVsCodeConfig("linux", "CustomProfile", {
 				CustomProfile: { path: "/usr/bin/malicious-shell" },
 			})
 			expect(getShell()).toBe("/bin/bash")
 		})
 
-		it("should validate array shell paths and use first allowed", () => {
+		it("should validate array shell paths and use first allowlisted path", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return "PowerShell"
-					if (key === "profiles.windows") {
-						return {
-							PowerShell: {
-								path: ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "pwsh"],
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			const result = getShell()
-			// Should return the first allowed shell from the array
-			expect(result).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\Program Files\\PowerShell\\7\\pwsh.exe")
+			mockVsCodeConfig("windows", "PowerShell", {
+				PowerShell: { path: ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "pwsh"] },
+			})
+			expect(getShell()).toBe("C:\\Program Files\\PowerShell\\7\\pwsh.exe")
 		})
 
 		it("should reject non-allowed shell paths and fall back to safe defaults", () => {
 			Object.defineProperty(process, "platform", { value: "win32" })
-
-			const mockConfig = {
-				get: vi.fn((key: string) => {
-					if (key === "defaultProfile.windows") return "Malicious"
-					if (key === "profiles.windows") {
-						return {
-							Malicious: {
-								path: "C:\\malicious\\shell.exe",
-							},
-						}
-					}
-					return undefined
-				}),
-			}
-
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(mockConfig as any)
-
-			// Mock environment to provide a fallback
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "C:\\malicious\\shell.exe")
+			mockVsCodeConfig("windows", "Malicious", {
+				Malicious: { path: "C:\\malicious\\shell.exe" },
+			})
 			process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe"
-
-			const result = getShell()
-			// Should fall back to safe default (cmd.exe)
-			expect(result).toBe("C:\\Windows\\System32\\cmd.exe")
+			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
 		it("should validate shells from VS Code config", () => {
 			Object.defineProperty(process, "platform", { value: "darwin" })
+			vi.mocked(existsSync).mockImplementation((p: any) => p === "/usr/local/bin/custom-shell")
 			mockVsCodeConfig("osx", "MyCustomShell", {
 				MyCustomShell: { path: "/usr/local/bin/custom-shell" },
 			})
-
-			const result = getShell()
-			expect(result).toBe("/bin/zsh") // macOS fallback
+			expect(getShell()).toBe("/bin/zsh") // not in allowlist → macOS fallback
 		})
 
 		it("should validate shells from userInfo", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: "/usr/bin/evil-shell" } as any)
-
-			const result = getShell()
-			expect(result).toBe("/bin/bash") // Linux fallback
+			expect(getShell()).toBe("/bin/bash")
 		})
 
 		it("should validate shells from environment variables", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: null } as any)
 			process.env.SHELL = "/opt/custom/shell"
-
-			const result = getShell()
-			expect(result).toBe("/bin/bash") // Linux fallback
+			expect(getShell()).toBe("/bin/bash")
 		})
 
 		it("should handle WSL bash correctly", () => {
@@ -778,19 +498,15 @@ describe("Shell Detection Tests", () => {
 			mockVsCodeConfig("windows", "WSL", {
 				WSL: { source: "WSL" },
 			})
-
-			const result = getShell()
-			expect(result).toBe("/bin/bash") // Should be allowed
+			expect(getShell()).toBe("/bin/bash")
 		})
 
 		it("should handle empty or null shell paths", () => {
 			Object.defineProperty(process, "platform", { value: "linux" })
-			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
+			mockVsCodeConfig("linux", null, {})
 			vi.mocked(userInfo).mockReturnValue({ shell: "" } as any)
 			delete process.env.SHELL
-
-			const result = getShell()
-			expect(result).toBe("/bin/bash") // Should fall back to safe default
+			expect(getShell()).toBe("/bin/bash")
 		})
 	})
 })

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -127,6 +127,10 @@ const SHELL_PATHS = {
  *
  * Returns null when no profile is configured or the profile has no resolvable path.
  */
+function preferredWindowsPowerShell(): string {
+	return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
+}
+
 function getShellFromVSCode(): string | null {
 	try {
 		const profileName = Terminal.getConfiguredDefaultProfileName()
@@ -136,7 +140,7 @@ function getShellFromVSCode(): string | null {
 			// auto-detects and prefers PowerShell 7 when installed. Mirror that so
 			// the system prompt matches what VS Code will actually open. (issue #82)
 			if (process.platform === "win32") {
-				return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
+				return preferredWindowsPowerShell()
 			}
 			return null
 		}
@@ -156,7 +160,7 @@ function getShellFromVSCode(): string | null {
 		// source-only PowerShell profiles (e.g. { source: "PowerShell" }) have no
 		// path but we can still identify the shell type from the source field.
 		if (typeof profile.source === "string" && profile.source.toLowerCase().includes("powershell")) {
-			return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
+			return preferredWindowsPowerShell()
 		}
 
 		// source-only WSL profiles

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -3,6 +3,8 @@ import { existsSync } from "fs"
 import { userInfo } from "os"
 import * as path from "path"
 
+import { Terminal } from "../integrations/terminal/Terminal"
+
 // Security: Allowlist of approved shell executables to prevent arbitrary command execution
 const SHELL_ALLOWLIST = new Set<string>([
 	// Windows PowerShell variants
@@ -113,143 +115,59 @@ const SHELL_PATHS = {
 	FALLBACK: "/bin/sh",
 } as const
 
-interface MacTerminalProfile {
-	path?: string | string[]
-}
-
-type MacTerminalProfiles = Record<string, MacTerminalProfile>
-
-interface WindowsTerminalProfile {
-	path?: string | string[]
-	source?: "PowerShell" | "WSL"
-}
-
-type WindowsTerminalProfiles = Record<string, WindowsTerminalProfile>
-
-interface LinuxTerminalProfile {
-	path?: string | string[]
-}
-
-type LinuxTerminalProfiles = Record<string, LinuxTerminalProfile>
-
 // -----------------------------------------------------
-// 1) VS Code Terminal Configuration Helpers
+// 1) VS Code Terminal Configuration Helper
 // -----------------------------------------------------
-
-type PlatformProfilesMap = {
-	windows: WindowsTerminalProfiles
-	osx: MacTerminalProfiles
-	linux: LinuxTerminalProfiles
-}
 
 /**
- * Reads the VS Code terminal profile configuration for the given platform.
+ * Attempts to retrieve the configured default shell path from VS Code's terminal
+ * profile settings, using the same trusted-scope reads as Terminal (inspect()
+ * globalValue/defaultValue only — workspace scope excluded per APPLICATION scope
+ * restriction on terminal.integrated.defaultProfile.*).
  *
- * The key must be one of `"windows"`, `"osx"`, or `"linux"` — the exact strings
- * VS Code uses in `terminal.integrated.defaultProfile.<key>` and
- * `terminal.integrated.profiles.<key>`. Passing any other value is a compile-time
- * error, which prevents silent mismatches such as `"darwin"` returning empty config.
- *
- * The return type (`defaultProfileName` and `profiles`) is inferred from `K` via
- * `PlatformProfilesMap`, so callers don't need an explicit type parameter.
- *
- * Returns `{ defaultProfileName: null, profiles: {} }` on any VS Code API error.
+ * Returns null when no profile is configured or the profile has no resolvable path.
  */
-function getTerminalConfig<K extends keyof PlatformProfilesMap>(
-	platformKey: K,
-): { defaultProfileName: string | null; profiles: PlatformProfilesMap[K] } {
+function getShellFromVSCode(): string | null {
 	try {
-		const config = vscode.workspace.getConfiguration("terminal.integrated")
-		const rawProfileName = config.get<string>(`defaultProfile.${platformKey}`)
-		const defaultProfileName = typeof rawProfileName === "string" ? rawProfileName : null
-		const profiles = config.get<PlatformProfilesMap[K]>(`profiles.${platformKey}`) ?? ({} as PlatformProfilesMap[K])
-		return { defaultProfileName, profiles }
-	} catch {
-		return { defaultProfileName: null, profiles: {} as PlatformProfilesMap[K] }
-	}
-}
+		const profileName = Terminal.getConfiguredDefaultProfileName()
 
-// -----------------------------------------------------
-// 2) Platform-Specific VS Code Shell Retrieval
-// -----------------------------------------------------
-
-/**
- * Normalizes a path that can be either a string or an array of strings.
- * If it's an array, returns the first element. Otherwise returns the string.
- */
-function normalizeShellPath(path: string | string[] | undefined): string | null {
-	if (!path) return null
-	if (Array.isArray(path)) {
-		return path.length > 0 ? path[0] : null
-	}
-	return path
-}
-
-/** Attempts to retrieve a shell path from VS Code config on Windows. */
-function getWindowsShellFromVSCode(): string | null {
-	const { defaultProfileName, profiles } = getTerminalConfig("windows")
-	if (!defaultProfileName) {
-		// No explicit Windows terminal profile is configured. VS Code auto-detects
-		// the default on modern Windows and prefers PowerShell 7 (pwsh.exe) when it
-		// is installed, otherwise the always-present Windows PowerShell 5.1. Mirror
-		// that here so the system prompt advertises the real shell instead of falling
-		// through to COMSPEC (cmd.exe). See issue #82.
-		return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
-	}
-
-	const profile = profiles[defaultProfileName]
-
-	// If the profile name indicates PowerShell, do version-based detection.
-	// In testing it was found these typically do not have a path, and this
-	// implementation manages to deductively get the correct version of PowerShell
-	if (defaultProfileName.toLowerCase().includes("powershell")) {
-		const normalizedPath = normalizeShellPath(profile?.path)
-		if (normalizedPath) {
-			// If there's an explicit PowerShell path, return that
-			return normalizedPath
-		} else if (profile?.source === "PowerShell") {
-			// If the profile is sourced from PowerShell, assume the newest
-			return SHELL_PATHS.POWERSHELL_7
+		if (!profileName) {
+			// No profile configured at user/default scope. On Windows, VS Code
+			// auto-detects and prefers PowerShell 7 when installed. Mirror that so
+			// the system prompt matches what VS Code will actually open. (issue #82)
+			if (process.platform === "win32") {
+				return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
+			}
+			return null
 		}
-		// Otherwise, assume legacy Windows PowerShell
-		return SHELL_PATHS.POWERSHELL_LEGACY
-	}
 
-	// If there's a specific path, return that immediately
-	const normalizedPath = normalizeShellPath(profile?.path)
-	if (normalizedPath) {
-		return normalizedPath
-	}
+		const profiles = Terminal.getConfiguredProfiles()
+		const profile = profiles[profileName] as { path?: unknown; source?: unknown } | null | undefined
 
-	// If the profile indicates WSL
-	if (profile?.source === "WSL" || defaultProfileName.toLowerCase().includes("wsl")) {
-		return SHELL_PATHS.WSL_BASH
-	}
+		if (!profile) {
+			return null
+		}
 
-	// If nothing special detected, we assume cmd
-	return SHELL_PATHS.CMD
-}
+		const resolved = Terminal.resolveProfilePath(profile.path)
+		if (resolved) {
+			return resolved
+		}
 
-/** Attempts to retrieve a shell path from VS Code config on macOS. */
-function getMacShellFromVSCode(): string | null {
-	const { defaultProfileName, profiles } = getTerminalConfig("osx")
-	if (!defaultProfileName) {
+		// source-only PowerShell profiles (e.g. { source: "PowerShell" }) have no
+		// path but we can still identify the shell type from the source field.
+		if (typeof profile.source === "string" && profile.source.toLowerCase().includes("powershell")) {
+			return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
+		}
+
+		// source-only WSL profiles
+		if (typeof profile.source === "string" && profile.source.toLowerCase().includes("wsl")) {
+			return SHELL_PATHS.WSL_BASH
+		}
+
+		return null
+	} catch {
 		return null
 	}
-
-	const profile = profiles[defaultProfileName]
-	return normalizeShellPath(profile?.path)
-}
-
-/** Attempts to retrieve a shell path from VS Code config on Linux. */
-function getLinuxShellFromVSCode(): string | null {
-	const { defaultProfileName, profiles } = getTerminalConfig("linux")
-	if (!defaultProfileName) {
-		return null
-	}
-
-	const profile = profiles[defaultProfileName]
-	return normalizeShellPath(profile?.path)
 }
 
 // -----------------------------------------------------
@@ -340,17 +258,8 @@ function getSafeFallbackShell(): string {
 export function getShell(): string {
 	let shell: string | null = null
 
-	// 1. Check VS Code config first.
-	if (process.platform === "win32") {
-		// Special logic for Windows
-		shell = getWindowsShellFromVSCode()
-	} else if (process.platform === "darwin") {
-		// macOS from VS Code
-		shell = getMacShellFromVSCode()
-	} else if (process.platform === "linux") {
-		// Linux from VS Code
-		shell = getLinuxShellFromVSCode()
-	}
+	// 1. Check VS Code config first (trusted scopes only — workspace excluded).
+	shell = getShellFromVSCode()
 
 	// 2. If no shell from VS Code, try userInfo()
 	if (!shell) {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs"
 import { userInfo } from "os"
 import * as path from "path"
 
+import { BaseTerminal } from "../integrations/terminal/BaseTerminal"
 import { Terminal } from "../integrations/terminal/Terminal"
 
 // Security: Allowlist of approved shell executables to prevent arbitrary command execution
@@ -119,20 +120,27 @@ const SHELL_PATHS = {
 // 1) VS Code Terminal Configuration Helper
 // -----------------------------------------------------
 
-/**
- * Attempts to retrieve the configured default shell path from VS Code's terminal
- * profile settings, using the same trusted-scope reads as Terminal (inspect()
- * globalValue/defaultValue only — workspace scope excluded per APPLICATION scope
- * restriction on terminal.integrated.defaultProfile.*).
- *
- * Returns null when no profile is configured or the profile has no resolvable path.
- */
 function preferredWindowsPowerShell(): string {
 	return existsSync(SHELL_PATHS.POWERSHELL_7) ? SHELL_PATHS.POWERSHELL_7 : SHELL_PATHS.POWERSHELL_LEGACY
 }
 
+/**
+ * Resolves the shell that VS Code's integrated terminal will use, matching the
+ * priority order from Terminal constructor: Zoo profile override first, then
+ * VS Code's configured default profile (trusted scopes only — workspace scope
+ * excluded per APPLICATION scope restriction).
+ *
+ * Returns null when no profile is configured or the profile has no resolvable path.
+ */
 function getShellFromVSCode(): string | null {
 	try {
+		// Zoo profile override takes precedence — this is the same path
+		// Terminal constructor uses to set shellPath on createTerminal().
+		const profileShell = Terminal.getProfileShell()
+		if (profileShell?.shellPath) {
+			return profileShell.shellPath
+		}
+
 		const profileName = Terminal.getConfiguredDefaultProfileName()
 
 		if (!profileName) {
@@ -262,25 +270,31 @@ function getSafeFallbackShell(): string {
 export function getShell(): string {
 	let shell: string | null = null
 
-	// 1. Check VS Code config first (trusted scopes only — workspace excluded).
-	shell = getShellFromVSCode()
+	// 1. Explicit execa shell path — when set, execa uses this exact executable
+	//    regardless of VS Code profile settings.
+	shell = BaseTerminal.getExecaShellPath() ?? null
 
-	// 2. If no shell from VS Code, try userInfo()
+	// 2. VS Code profile config (Zoo override first, then default profile).
+	if (!shell) {
+		shell = getShellFromVSCode()
+	}
+
+	// 3. If no shell from VS Code, try userInfo()
 	if (!shell) {
 		shell = getShellFromUserInfo()
 	}
 
-	// 3. If still nothing, try environment variable
+	// 4. If still nothing, try environment variable
 	if (!shell) {
 		shell = getShellFromEnv()
 	}
 
-	// 4. Finally, fall back to a default
+	// 5. Finally, fall back to a default
 	if (!shell) {
 		shell = getSafeFallbackShell()
 	}
 
-	// 5. Validate the shell against allowlist
+	// 6. Validate the shell against allowlist
 	if (!isShellAllowed(shell)) {
 		shell = getSafeFallbackShell()
 	}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #634

### Description

**Root cause:** On Windows, `getShell()` (used to build the system prompt) called `config.get("defaultProfile.windows")` which merges all VS Code scopes including workspace. `Terminal.getConfiguredDefaultProfileName()` (used when actually opening a terminal) calls `config.inspect().globalValue` — intentionally excluding workspace scope, because `terminal.integrated.defaultProfile.*` is an APPLICATION-scoped setting. A workspace `.vscode/settings.json` can contain the key, VS Code accepts it, but the terminal ignores it for security. The result: the system prompt told the model "you have PowerShell" while the terminal opened cmd.exe (or whatever VS Code autodetected), causing every shell command to fail.

**Fix:** Deleted the parallel implementation in `shell.ts` (`getTerminalConfig`, `normalizeShellPath`, `getWindowsShellFromVSCode`, etc.) and replaced it with a single `getShellFromVSCode()` that delegates to `Terminal.getConfiguredDefaultProfileName()` and `Terminal.getConfiguredProfiles()`. Both paths now read from the same inspect()-based source of truth. Also extracted `preferredWindowsPowerShell()` to eliminate a duplicated PS7→legacy fallback expression.

**Tests:**
- Rewrote `shell.spec.ts` stubs to use `inspect()` (matching the new implementation) and added a "Scope isolation" section asserting workspace-scoped profiles are ignored.
- Added `shell-system-prompt-divergence.spec.ts` as a regression anchor: confirms `Terminal` ignores workspace-scoped profiles, verifies both paths agree when a profile is set at global scope, and verifies convergence after the fix (workspace-only profile → both return the Windows no-profile fallback).

### Test Procedure

Unit tests:
```
pnpm exec vitest run utils/__tests__/shell.spec.ts integrations/terminal/__tests__/shell-system-prompt-divergence.spec.ts
```

E2E mock suite (76 passing, 3 pre-existing xAI failures unrelated to this change):
```
pnpm --filter @roo-code/vscode-e2e test:ci:mock
```

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Visual Snapshot** (UI changes only): N/A — no UI changes.
- [x] **Documentation Impact**: No documentation updates required.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Additional Notes

The 3 failing E2E tests are all in the xAI provider suite and fail with a 403 "credits exhausted" error — pre-existing and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shell detection across Windows, macOS, and Linux.
  * Workspace-only terminal profile settings are now handled consistently and no longer incorrectly override applicable defaults.
  * Explicitly configured shell paths and Zoo profile settings now take precedence appropriately, with reliable fallbacks when unavailable.
  * Improved fallback behavior for PowerShell, WSL, user-configured shells, and environment settings.
  * Enhanced validation safely rejects invalid or unsupported shell paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->