### PR TITLE
fix(openai-compatible): add max reasoning effort option

### DIFF
--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -453,6 +453,27 @@ describe("OpenAiHandler", () => {
 			expect(callArgs.reasoning_effort).toBe("high")
 		})
 
+		it("should pass through max reasoning_effort when configured by an OpenAI-compatible model", async () => {
+			const reasoningOptions: ApiHandlerOptions = {
+				...mockOptions,
+				enableReasoningEffort: true,
+				openAiCustomModelInfo: {
+					contextWindow: 128_000,
+					supportsPromptCache: false,
+					supportsReasoningEffort: ["low", "medium", "high", "xhigh", "max"],
+					reasoningEffort: "max",
+				},
+			}
+			const reasoningHandler = new OpenAiHandler(reasoningOptions)
+			const stream = reasoningHandler.createMessage(systemPrompt, messages)
+			for await (const _chunk of stream) {
+			}
+
+			expect(mockCreate).toHaveBeenCalled()
+			const callArgs = mockCreate.mock.calls[0][0]
+			expect(callArgs.reasoning_effort).toBe("max")
+		})
+
 		it("should not include reasoning_effort when reasoning effort is disabled", async () => {
 			const noReasoningOptions: ApiHandlerOptions = {
 				...mockOptions,

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -6,7 +6,7 @@ import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import {
 	type ProviderSettings,
 	type ModelInfo,
-	type ReasoningEffort,
+	type ReasoningEffortExtended,
 	type OrganizationAllowList,
 	type ExtensionMessage,
 	azureOpenAiDefaultApiVersion,
@@ -266,13 +266,13 @@ export const OpenAICompatible = ({
 
 								setApiConfigurationField("openAiCustomModelInfo", {
 									...openAiCustomModelInfo,
-									reasoningEffort: value as ReasoningEffort,
+									reasoningEffort: value as ReasoningEffortExtended,
 								})
 							}
 						}}
 						modelInfo={{
 							...(apiConfiguration.openAiCustomModelInfo || openAiModelInfoSaneDefaults),
-							supportsReasoningEffort: ["low", "medium", "high", "xhigh"],
+							supportsReasoningEffort: ["low", "medium", "high", "xhigh", "max"],
 						}}
 					/>
 				)}

--- a/webview-ui/src/components/settings/providers/__tests__/OpenAICompatible.spec.tsx
+++ b/webview-ui/src/components/settings/providers/__tests__/OpenAICompatible.spec.tsx
@@ -76,8 +76,13 @@ vi.mock("../../R1FormatSetting", () => ({
 	R1FormatSetting: () => <div data-testid="r1-format-setting">R1 Format Setting</div>,
 }))
 
+const { mockThinkingBudget } = vi.hoisted(() => ({ mockThinkingBudget: vi.fn() }))
+
 vi.mock("../../ThinkingBudget", () => ({
-	ThinkingBudget: () => <div data-testid="thinking-budget">Thinking Budget</div>,
+	ThinkingBudget: (props: any) => {
+		mockThinkingBudget(props)
+		return <div data-testid="thinking-budget">Thinking Budget</div>
+	},
 }))
 
 // Mock react-use
@@ -310,6 +315,41 @@ describe("OpenAICompatible Component - includeMaxTokens checkbox", () => {
 			// Check that the description has the correct styling classes
 			const description = screen.getByText("settings:includeMaxOutputTokensDescription")
 			expect(description).toHaveClass("text-sm", "text-vscode-descriptionForeground", "ml-6")
+		})
+	})
+	describe("reasoning effort", () => {
+		it("should expose and persist the max reasoning-effort value", () => {
+			const apiConfiguration: Partial<ProviderSettings> = {
+				enableReasoningEffort: true,
+				openAiCustomModelInfo: {
+					contextWindow: 128_000,
+					supportsPromptCache: false,
+				},
+			}
+
+			render(
+				<OpenAICompatible
+					apiConfiguration={apiConfiguration as ProviderSettings}
+					setApiConfigurationField={mockSetApiConfigurationField}
+					organizationAllowList={mockOrganizationAllowList}
+				/>,
+			)
+
+			const thinkingBudgetProps = mockThinkingBudget.mock.calls[0][0]
+			expect(thinkingBudgetProps.modelInfo.supportsReasoningEffort).toEqual([
+				"low",
+				"medium",
+				"high",
+				"xhigh",
+				"max",
+			])
+
+			thinkingBudgetProps.setApiConfigurationField("reasoningEffort", "max")
+
+			expect(mockSetApiConfigurationField).toHaveBeenCalledWith("openAiCustomModelInfo", {
+				...apiConfiguration.openAiCustomModelInfo,
+				reasoningEffort: "max",
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Adds a UI compatibility option for OpenAI-compatible providers to set maximum reasoning effort.
- Persists the selected value and forwards it to compatible API requests.

## Focused tests
- `cd src && npx vitest run api/providers/__tests__/openai.spec.ts` — 1 file / 64 tests passed.
- `cd webview-ui && npx vitest run src/components/settings/providers/__tests__/OpenAICompatible.spec.tsx` — 1 file / 11 tests passed.

Closes: #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **“max” reasoning effort** option in OpenAI-compatible provider settings.
  * Selected “max” reasoning effort is now preserved when configuring supported models.

* **Tests**
  * Added coverage confirming the “max” option appears in settings and is passed through correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->