### PR TITLE
[Improve] Strengthen managed binary installation

### DIFF
--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1499,11 +1499,6 @@
 			"count": 3
 		}
 	},
-	"services/code-index/semble/semble-downloader.ts": {
-		"@typescript-eslint/no-explicit-any": {
-			"count": 1
-		}
-	},
 	"services/code-index/shared/__tests__/validation-helpers.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
 			"count": 4

--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -263,12 +263,14 @@ describe("semble-downloader", () => {
 				)
 				// Version file should be written
 				expect(fs.writeFile).toHaveBeenCalledWith(
-					path.join("/storage", "semble", ".semble-version"),
+					path.join("/storage", "semble.new", ".semble-version"),
 					"v0.4.1",
 					"utf-8",
 				)
 				// Archive should be cleaned up (version-prefixed local cache path)
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "v0.4.1-semble-linux-x64-fast.tar.gz"))
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "v0.4.1-semble-linux-x64-fast.tar.gz"), {
+					force: true,
+				})
 			} finally {
 				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform)
 				if (originalArch) Object.defineProperty(process, "arch", originalArch)
@@ -325,7 +327,9 @@ describe("semble-downloader", () => {
 
 			try {
 				await expect(downloadSemble("/storage")).rejects.toThrow("Failed to download semble")
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "v0.4.1-semble-linux-arm64-fast.tar.gz"))
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "v0.4.1-semble-linux-arm64-fast.tar.gz"), {
+					force: true,
+				})
 				// Should clean up staging directory, not the original
 				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "semble.new"), {
 					recursive: true,
@@ -589,7 +593,7 @@ describe("semble-downloader", () => {
 			})
 
 			// Archive cleanup fails but should not throw (only archive removal after extraction)
-			;(fs.unlink as any).mockRejectedValue(new Error("unlink cleanup failed"))
+			;(fs.rm as any).mockRejectedValueOnce(new Error("archive cleanup failed"))
 
 			try {
 				const result = await downloadSemble("/storage")
@@ -641,7 +645,7 @@ describe("semble-downloader", () => {
 				expect(https.get).toHaveBeenCalledWith(expect.stringContaining("v0.4.1"), expect.any(Function))
 				// Should write the new version file
 				expect(fs.writeFile).toHaveBeenCalledWith(
-					path.join("/storage", "semble", ".semble-version"),
+					path.join("/storage", "semble.new", ".semble-version"),
 					"v0.4.1",
 					"utf-8",
 				)
@@ -700,19 +704,23 @@ describe("semble-downloader", () => {
 				)
 				// The stale archive is removed before the fresh download to guarantee
 				// a clean package is verified against the new checksum.
-				expect(fs.unlink).toHaveBeenCalledWith(versionedArchive)
+				expect(fs.rm).toHaveBeenCalledWith(versionedArchive, { force: true })
 				// The prior-version archive (v0.4.0-*) is swept by cleanupStaleArchives
 				// after a successful install, so a version upgrade doesn't accumulate
 				// orphaned packages on disk.
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "v0.4.0-semble-linux-x64-fast.tar.gz"))
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "v0.4.0-semble-linux-x64-fast.tar.gz"), {
+					force: true,
+				})
 				// The legacy unversioned archive (pre-v0.4.0 cache layout) is also
 				// swept, covering the v0.3.1 → v0.4.1 upgrade path.
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "semble-linux-x64-fast.tar.gz"))
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "semble-linux-x64-fast.tar.gz"), {
+					force: true,
+				})
 				// Unrelated files in the storage dir must not be touched.
 				expect(fs.unlink).not.toHaveBeenCalledWith(path.join("/storage", "unrelated-file.txt"))
 				// The new version file is recorded
 				expect(fs.writeFile).toHaveBeenCalledWith(
-					path.join("/storage", "semble", ".semble-version"),
+					path.join("/storage", "semble.new", ".semble-version"),
 					"v0.4.1",
 					"utf-8",
 				)
@@ -789,7 +797,7 @@ describe("semble-downloader", () => {
 				)
 				// Should write version file again
 				expect(fs.writeFile).toHaveBeenCalledWith(
-					path.join("/storage", "semble", ".semble-version"),
+					path.join("/storage", "semble.new", ".semble-version"),
 					"v0.4.1",
 					"utf-8",
 				)
@@ -831,7 +839,7 @@ describe("semble-downloader", () => {
 				)
 				// Should write version file
 				expect(fs.writeFile).toHaveBeenCalledWith(
-					path.join("/storage", "semble", ".semble-version"),
+					path.join("/storage", "semble.new", ".semble-version"),
 					"v0.4.1",
 					"utf-8",
 				)
@@ -903,8 +911,12 @@ describe("semble-downloader", () => {
 
 				const currentArchive = path.join("/storage", "v0.4.1-semble-linux-x64-fast.tar.gz")
 				// Stale versioned + legacy unversioned archives are swept
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "v0.4.0-semble-linux-x64-fast.tar.gz"))
-				expect(fs.unlink).toHaveBeenCalledWith(path.join("/storage", "semble-linux-x64-fast.tar.gz"))
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "v0.4.0-semble-linux-x64-fast.tar.gz"), {
+					force: true,
+				})
+				expect(fs.rm).toHaveBeenCalledWith(path.join("/storage", "semble-linux-x64-fast.tar.gz"), {
+					force: true,
+				})
 				// The current archive is never swept by cleanupStaleArchives (it is
 				// excluded by the currentArchivePath guard). It is unlinked only by
 				// the pre-download partial-archive cleanup and the post-install
@@ -913,8 +925,8 @@ describe("semble-downloader", () => {
 				// Sanity: the current archive path is never passed to the stale sweep.
 				// It is unlinked exactly twice (pre-download cleanup + post-install
 				// archive cleanup), never via cleanupStaleArchives.
-				const currentUnlinks = (fs.unlink as any).mock.calls.filter((c: any[]) => c[0] === currentArchive)
-				expect(currentUnlinks.length).toBe(2)
+				const currentRemovals = (fs.rm as any).mock.calls.filter((c: any[]) => c[0] === currentArchive)
+				expect(currentRemovals.length).toBe(2)
 			} finally {
 				if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform)
 				if (originalArch) Object.defineProperty(process, "arch", originalArch)

--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -32,6 +32,10 @@ vi.mock("fs/promises", () => ({
 	readdir: vi.fn().mockResolvedValue([]),
 }))
 
+vi.mock("proper-lockfile", () => ({
+	lock: vi.fn().mockResolvedValue(vi.fn().mockResolvedValue(undefined)),
+}))
+
 // Mock fs (createWriteStream and createReadStream for checksum verification)
 const mockWriteStream = {
 	on: vi.fn(),
@@ -717,7 +721,7 @@ describe("semble-downloader", () => {
 					force: true,
 				})
 				// Unrelated files in the storage dir must not be touched.
-				expect(fs.unlink).not.toHaveBeenCalledWith(path.join("/storage", "unrelated-file.txt"))
+				expect(fs.rm).not.toHaveBeenCalledWith(path.join("/storage", "unrelated-file.txt"), expect.anything())
 				// The new version file is recorded
 				expect(fs.writeFile).toHaveBeenCalledWith(
 					path.join("/storage", "semble.new", ".semble-version"),

--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -37,9 +37,14 @@ vi.mock("proper-lockfile", () => ({
 }))
 
 // Mock fs (createWriteStream and createReadStream for checksum verification)
+let closeHandler: (() => void) | undefined
 const mockWriteStream = {
 	on: vi.fn(),
 	close: vi.fn(),
+}
+const onWriteStreamEvent = (event: string, callback: () => void) => {
+	if (event === "finish") setImmediate(callback)
+	if (event === "close") closeHandler = callback
 }
 vi.mock("fs", () => ({
 	createWriteStream: vi.fn(() => mockWriteStream),
@@ -107,8 +112,9 @@ describe("SEMBLE_SHA256 checksum fixture", () => {
 describe("semble-downloader", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
-		mockWriteStream.on = vi.fn()
-		mockWriteStream.close = vi.fn()
+		closeHandler = undefined
+		mockWriteStream.on = vi.fn(onWriteStreamEvent)
+		mockWriteStream.close = vi.fn(() => closeHandler?.())
 
 		// Restore the default https.get mock so tests that override it don't leak
 		;(https.get as any).mockImplementation((_url: string, callback: (res: any) => void) => {
@@ -226,13 +232,6 @@ describe("semble-downloader", () => {
 			;(fs.access as any).mockResolvedValue(undefined)
 			// No version file exists
 			;(fs.readFile as any).mockRejectedValue(new Error("ENOENT"))
-
-			// Simulate successful download: pipe is called, then "finish" fires
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
 
 			try {
 				const result = await downloadSemble("/storage")
@@ -382,12 +381,6 @@ describe("semble-downloader", () => {
 			})
 
 			// Simulate successful download on the second response
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -550,12 +543,6 @@ describe("semble-downloader", () => {
 			;(fs.readFile as any).mockRejectedValue(new Error("ENOENT"))
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -590,12 +577,6 @@ describe("semble-downloader", () => {
 			;(fs.readFile as any).mockRejectedValue(new Error("ENOENT"))
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			// Archive cleanup fails but should not throw (only archive removal after extraction)
 			;(fs.rm as any).mockRejectedValueOnce(new Error("archive cleanup failed"))
 
@@ -625,12 +606,6 @@ describe("semble-downloader", () => {
 			;(fs.access as any).mockResolvedValue(undefined)
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -681,12 +656,6 @@ describe("semble-downloader", () => {
 			;(fs.access as any).mockResolvedValue(undefined)
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -781,12 +750,6 @@ describe("semble-downloader", () => {
 			})
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -824,12 +787,6 @@ describe("semble-downloader", () => {
 			;(fs.access as any).mockResolvedValue(undefined)
 
 			// Simulate successful download
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -868,12 +825,6 @@ describe("semble-downloader", () => {
 			// readdir rejects — exercises the catch block in cleanupStaleArchives
 			;(fs.readdir as any).mockRejectedValue(new Error("EACCES"))
 
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
-
 			try {
 				const result = await downloadSemble("/storage")
 
@@ -903,12 +854,6 @@ describe("semble-downloader", () => {
 				"semble-linux-x64-fast.tar.gz",
 				"unrelated.txt",
 			])
-
-			mockWriteStream.on.mockImplementation((event: string, cb: () => void) => {
-				if (event === "finish") {
-					setImmediate(cb)
-				}
-			})
 
 			try {
 				await downloadSemble("/storage")

--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -925,7 +925,7 @@ describe("semble-downloader", () => {
 				// excluded by the currentArchivePath guard). It is unlinked only by
 				// the pre-download partial-archive cleanup and the post-install
 				// archive cleanup steps. unrelated.txt is never touched.
-				expect(fs.unlink).not.toHaveBeenCalledWith(path.join("/storage", "unrelated.txt"))
+				expect(fs.rm).not.toHaveBeenCalledWith(path.join("/storage", "unrelated.txt"), expect.anything())
 				// Sanity: the current archive path is never passed to the stale sweep.
 				// It is unlinked exactly twice (pre-download cleanup + post-install
 				// archive cleanup), never via cleanupStaleArchives.

--- a/src/services/code-index/semble/semble-downloader.ts
+++ b/src/services/code-index/semble/semble-downloader.ts
@@ -1,10 +1,9 @@
 import * as fs from "fs/promises"
 import * as path from "path"
-import * as https from "https"
-import { createWriteStream } from "fs"
-import { createHash } from "crypto"
-import { createReadStream } from "fs"
-import { spawn } from "child_process"
+
+import { extractTarGzArchive, extractZipArchive } from "../../managed-binary/archive"
+import { downloadBinaryFile, verifySha256Checksum } from "../../managed-binary/download"
+import { ensureManagedBinaryInstalled, getManagedBinaryPaths } from "../../managed-binary/install"
 
 /**
  * Supported platform/arch combinations for the semble standalone executable.
@@ -47,19 +46,14 @@ export const SEMBLE_SHA256: Record<string, string> = {
  * Throws if the checksum does not match.
  */
 export async function verifyChecksum(filePath: string, expected: string): Promise<void> {
-	const hash = createHash("sha256")
-	await new Promise<void>((resolve, reject) => {
-		const stream = createReadStream(filePath)
-		stream.on("data", (chunk) => hash.update(chunk))
-		stream.on("end", resolve)
-		stream.on("error", reject)
-	})
-	const actual = hash.digest("hex")
-	if (actual !== expected) {
-		throw new Error(
-			`Checksum mismatch for ${path.basename(filePath)}: expected ${expected.slice(0, 12)}…, got ${actual.slice(0, 12)}…`,
-		)
-	}
+	await verifySha256Checksum(
+		filePath,
+		expected,
+		(actual) =>
+			new Error(
+				`Checksum mismatch for ${path.basename(filePath)}: expected ${expected.slice(0, 12)}…, got ${actual.slice(0, 12)}…`,
+			),
+	)
 }
 
 /**
@@ -88,64 +82,6 @@ function getArchiveInfo(platform?: string, arch?: string): { archive: string; bi
 }
 
 /**
- * Reads the locally installed version from the version metadata file.
- * Returns undefined if no version file exists (first install or legacy).
- */
-async function getInstalledVersion(storageDir: string): Promise<string | undefined> {
-	try {
-		const versionPath = path.join(storageDir, "semble", VERSION_FILE)
-		const version = (await fs.readFile(versionPath, "utf-8")).trim()
-		return version || undefined
-	} catch {
-		return undefined
-	}
-}
-
-/**
- * Writes the version metadata file after a successful download.
- */
-async function writeInstalledVersion(storageDir: string, version: string): Promise<void> {
-	const versionPath = path.join(storageDir, "semble", VERSION_FILE)
-	await fs.writeFile(versionPath, version, "utf-8")
-}
-
-/**
- * Best-effort removal of archive files left over from previous semble versions.
- *
- * Because the local archive cache path is version-prefixed (see `downloadSemble`),
- * upgrading SEMBLE_VERSION leaves the prior version's archive orphaned on disk.
- * This sweeps those stale packages so a version upgrade doesn't accumulate them.
- *
- * Matches both the version-prefixed cache names (`${version}-${archiveName}`,
- * used since v0.4.0) and the legacy unversioned cache name (`${archiveName}`,
- * used before v0.4.0), so a v0.3.1 → v0.4.1 upgrade also clears the legacy file.
- * The current archive path is always preserved.
- *
- * Errors are swallowed since this is purely cosmetic cleanup.
- */
-async function cleanupStaleArchives(
-	storageDir: string,
-	archiveName: string,
-	currentArchivePath: string,
-): Promise<void> {
-	try {
-		const entries = await fs.readdir(storageDir)
-		const suffix = `-${archiveName}`
-		await Promise.all(
-			entries
-				.filter(
-					(name) =>
-						(name === archiveName || name.endsWith(suffix)) &&
-						path.join(storageDir, name) !== currentArchivePath,
-				)
-				.map((name) => fs.unlink(path.join(storageDir, name)).catch(() => {})),
-		)
-	} catch {
-		// ignore — storage dir may not be listable yet
-	}
-}
-
-/**
  * Downloads and extracts the semble archive for the current platform.
  *
  * Compares the hardcoded SEMBLE_VERSION against the version stored on disk.
@@ -164,130 +100,48 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 		return undefined
 	}
 
-	// Ensure storage directory exists
-	await fs.mkdir(storageDir, { recursive: true })
-
-	const extractDir = path.join(storageDir, "semble")
-	const binaryPath = path.join(extractDir, info.binary)
-
-	// Check if already downloaded at the correct version
-	const installedVersion = await getInstalledVersion(storageDir)
-
-	if (installedVersion === SEMBLE_VERSION) {
-		try {
-			await fs.access(binaryPath)
-			// Binary exists and version matches — nothing to do
-			if (process.platform !== "win32") {
-				await fs.chmod(binaryPath, 0o755)
-			}
-			return binaryPath
-		} catch {
-			// Binary missing despite version file — re-download below
-		}
-	}
-
-	// Version mismatch — use staging directory to avoid leaving user without binary
-	if (installedVersion && installedVersion !== SEMBLE_VERSION) {
-		console.log(`[SembleDownloader] Version changed from ${installedVersion} to ${SEMBLE_VERSION}, updating...`)
-	}
-
 	const url = `${DOWNLOAD_BASE_URL}/${info.archive}`
-	// Version-prefix the local archive cache path so a stale archive left over
-	// from a previous semble version can never be reused or verified against the
-	// new checksum. The release asset URL keeps the unversioned asset name
-	// (info.archive); only the on-disk cache path is versioned. This guarantees a
-	// fresh download immediately after a version upgrade.
-	const archivePath = path.join(storageDir, `${SEMBLE_VERSION}-${info.archive}`)
-	// Stage the new installation in a temporary directory. The old binary stays
-	// intact until the new one is fully verified, preventing broken state on failure.
-	const stagingDir = extractDir + ".new"
-	const stagedBinaryPath = path.join(stagingDir, info.binary)
+	const paths = getManagedBinaryPaths({
+		storageDir,
+		id: "semble",
+		version: SEMBLE_VERSION,
+		versionFile: VERSION_FILE,
+		archiveName: info.archive,
+		binaryName: info.binary,
+	})
 	console.log(`[SembleDownloader] Downloading semble ${SEMBLE_VERSION} from ${url}`)
 
-	try {
-		// Clean any leftover staging directory from a previous failed attempt
-		try {
-			await fs.rm(stagingDir, { recursive: true, force: true })
-		} catch {
-			// ignore
-		}
-
-		// Remove any stale/partial archive from a previous attempt so we always
-		// download a fresh package. This is critical immediately after a version
-		// upgrade, where a corrupt leftover would otherwise fail checksum
-		// verification against the new SEMBLE_SHA256 on first launch.
-		try {
-			await fs.unlink(archivePath)
-		} catch {
-			// ignore — may not exist
-		}
-
-		await downloadFile(url, archivePath)
-
-		// Verify archive integrity before extraction
-		const platformKey = `${process.platform}-${process.arch}`
-		const expectedChecksum = SEMBLE_SHA256[platformKey]
-		if (!expectedChecksum) {
-			throw new Error(`No checksum configured for platform ${platformKey} at ${SEMBLE_VERSION}`)
-		}
-		await verifyChecksum(archivePath, expectedChecksum)
-
-		// Extract to staging directory
-		await fs.mkdir(stagingDir, { recursive: true })
-
-		if (info.archive.endsWith(".tar.gz")) {
-			await extractTarGz(archivePath, stagingDir)
-		} else if (info.archive.endsWith(".zip")) {
-			await extractZip(archivePath, stagingDir)
-		}
-
-		// Make binary executable on unix platforms
-		if (process.platform !== "win32") {
-			await fs.chmod(stagedBinaryPath, 0o755)
-		}
-
-		// Verify the staged binary exists before swapping
-		await fs.access(stagedBinaryPath)
-
-		// Atomic swap: remove old installation, rename staging → final
-		try {
-			await fs.rm(extractDir, { recursive: true, force: true })
-		} catch {
-			// ignore — may not exist on first install
-		}
-		await fs.rename(stagingDir, extractDir)
-
-		// Record the installed version
-		await writeInstalledVersion(storageDir, SEMBLE_VERSION)
-
-		// Clean up the archive file
-		try {
-			await fs.unlink(archivePath)
-		} catch {
-			// ignore cleanup errors
-		}
-
-		// Best-effort: remove orphaned archives left by previous semble versions
-		// so a version upgrade doesn't accumulate stale packages on disk.
-		await cleanupStaleArchives(storageDir, info.archive, archivePath)
-
-		console.log(`[SembleDownloader] Successfully installed semble ${SEMBLE_VERSION} to ${binaryPath}`)
-		return binaryPath
-	} catch (error: any) {
-		// Clean up partial download/staging — leave old installation intact
-		try {
-			await fs.unlink(archivePath)
-		} catch {
-			// ignore cleanup errors
-		}
-		try {
-			await fs.rm(stagingDir, { recursive: true, force: true })
-		} catch {
-			// ignore cleanup errors
-		}
-		console.error(`[SembleDownloader] Failed to download semble: ${error?.message || error}`)
-		throw new Error(`Failed to download semble: ${error?.message || error}`)
+	const platformKey = `${process.platform}-${process.arch}`
+	const expectedChecksum = SEMBLE_SHA256[platformKey]
+	if (!expectedChecksum) {
+		throw new Error(`No checksum configured for platform ${platformKey} at ${SEMBLE_VERSION}`)
 	}
+	const result = await ensureManagedBinaryInstalled({
+		storageDir,
+		id: "semble",
+		version: SEMBLE_VERSION,
+		versionFile: VERSION_FILE,
+		archiveName: info.archive,
+		binaryName: info.binary,
+		errorPrefix: "Failed to download semble",
+		download: (archivePath) =>
+			downloadBinaryFile(url, archivePath, {
+				name: "Semble",
+				trustedDomains: TRUSTED_DOWNLOAD_DOMAINS,
+				timeoutMs: 120_000,
+			}),
+		verifyArchive: (archivePath) => verifyChecksum(archivePath, expectedChecksum),
+		extractArchive: async (archivePath, stagingDir) => {
+			if (info.archive.endsWith(".tar.gz")) {
+				await extractTarGzArchive(archivePath, stagingDir)
+			} else if (info.archive.endsWith(".zip")) {
+				await extractZipArchive(archivePath, stagingDir)
+			}
+		},
+	})
+
+	console.log(`[SembleDownloader] Successfully installed semble ${SEMBLE_VERSION} to ${paths.binaryPath}`)
+	return result
 }
 
 /**
@@ -310,173 +164,7 @@ export async function getSembleBinaryPath(storageDir: string): Promise<string | 
 }
 
 /**
- * Extracts a .tar.gz archive into the destination directory using the system `tar` command.
- * Uses --no-same-owner to avoid issues with permission elevation,
- * strips absolute paths and blocks directory overwrites to prevent path traversal attacks.
- */
-function extractTarGz(archivePath: string, destDir: string): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const args = ["-xzf", archivePath, "-C", destDir, "--no-same-owner"]
-		// GNU tar: --no-overwrite-dir adds defense-in-depth against ../relative traversal.
-		// macOS bsdtar strips absolute paths by default.
-		if (process.platform === "linux") {
-			args.push("--no-overwrite-dir")
-		}
-		const child = spawn("tar", args, {
-			shell: false,
-			stdio: ["ignore", "pipe", "pipe"],
-		})
-
-		let stderr = ""
-		child.stderr?.on("data", (data: Buffer) => {
-			stderr += data.toString()
-		})
-
-		child.on("error", (err) => reject(err))
-		child.on("close", (code) => {
-			if (code === 0) {
-				resolve()
-			} else {
-				reject(new Error(`tar extraction failed (code ${code}): ${stderr.trim()}`))
-			}
-		})
-	})
-}
-
-/**
- * Escapes a string for use inside a PowerShell single-quoted literal.
- * In PowerShell, the only special character in a single-quoted string is the
- * apostrophe itself, which is escaped by doubling it.
- */
-function escapePowerShellLiteral(value: string): string {
-	return value.replace(/'/g, "''")
-}
-
-/**
- * Extracts a .zip archive into the destination directory.
- * Uses PowerShell on Windows, unzip on other platforms.
- */
-function extractZip(archivePath: string, destDir: string): Promise<void> {
-	return new Promise((resolve, reject) => {
-		let child
-
-		if (process.platform === "win32") {
-			child = spawn(
-				"powershell",
-				[
-					"-NoProfile",
-					"-Command",
-					`Expand-Archive -Path '${escapePowerShellLiteral(archivePath)}' -DestinationPath '${escapePowerShellLiteral(destDir)}' -Force`,
-				],
-				{ shell: false, stdio: ["ignore", "pipe", "pipe"] },
-			)
-		} else {
-			child = spawn("unzip", ["-o", archivePath, "-d", destDir], {
-				shell: false,
-				stdio: ["ignore", "pipe", "pipe"],
-			})
-		}
-
-		let stderr = ""
-		child.stderr?.on("data", (data: Buffer) => {
-			stderr += data.toString()
-		})
-
-		child.on("error", (err) => reject(err))
-		child.on("close", (code) => {
-			if (code === 0) {
-				resolve()
-			} else {
-				reject(new Error(`zip extraction failed (code ${code}): ${stderr.trim()}`))
-			}
-		})
-	})
-}
-
-/**
  * Trusted domains for following redirects during semble binary download.
  * GitHub releases redirect to objects.githubusercontent.com for the actual download.
  */
 const TRUSTED_DOWNLOAD_DOMAINS = ["github.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com"]
-
-/**
- * Validates that a URL belongs to a trusted domain.
- * Uses domain-boundary aware matching to prevent suffix-based bypasses
- * (e.g. "evilgithub.com" does NOT match "github.com").
- */
-function isTrustedDownloadUrl(url: string): boolean {
-	try {
-		const parsed = new URL(url)
-		const h = parsed.hostname
-		return parsed.protocol === "https:" && TRUSTED_DOWNLOAD_DOMAINS.some((d) => h === d || h.endsWith("." + d))
-	} catch {
-		return false
-	}
-}
-
-/**
- * Downloads a file from the given URL to the destination path.
- * Follows redirects (GitHub releases use 302 redirects to CDN).
- * Only follows redirects to trusted domains to prevent redirect-based attacks.
- */
-function downloadFile(url: string, destPath: string, maxRedirects = 5): Promise<void> {
-	return new Promise((resolve, reject) => {
-		if (maxRedirects <= 0) {
-			reject(new Error("Too many redirects"))
-			return
-		}
-
-		const request = https.get(url, (response) => {
-			// Follow redirects
-			if (
-				response.statusCode &&
-				response.statusCode >= 300 &&
-				response.statusCode < 400 &&
-				response.headers.location
-			) {
-				response.destroy()
-				const redirectUrl = response.headers.location
-				if (!isTrustedDownloadUrl(redirectUrl)) {
-					reject(
-						new Error(
-							`Redirect to untrusted domain blocked: ${redirectUrl}. Only ${TRUSTED_DOWNLOAD_DOMAINS.join(", ")} are allowed.`,
-						),
-					)
-					return
-				}
-				downloadFile(redirectUrl, destPath, maxRedirects - 1)
-					.then(resolve)
-					.catch(reject)
-				return
-			}
-
-			if (response.statusCode !== 200) {
-				response.destroy()
-				reject(new Error(`HTTP ${response.statusCode}: Failed to download ${url}`))
-				return
-			}
-
-			const file = createWriteStream(destPath)
-			response.pipe(file)
-
-			file.on("finish", () => {
-				file.close()
-				resolve()
-			})
-
-			file.on("error", (err) => {
-				file.close()
-				reject(err)
-			})
-		})
-
-		request.on("error", reject)
-		request.on("timeout", () => {
-			request.destroy()
-			reject(new Error("Download timed out"))
-		})
-
-		// 2 minute timeout for download
-		request.setTimeout(120_000)
-	})
-}

--- a/src/services/code-index/semble/semble-downloader.ts
+++ b/src/services/code-index/semble/semble-downloader.ts
@@ -26,6 +26,7 @@ const SEMBLE_ARCHIVES: Record<string, { archive: string; binary: string }> = {
 export const SEMBLE_VERSION = "v0.4.1"
 const DOWNLOAD_BASE_URL = `https://github.com/Zoo-Code-Org/sembleexec/releases/download/${SEMBLE_VERSION}`
 const VERSION_FILE = ".semble-version"
+const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024
 
 /**
  * SHA-256 checksums for each platform archive at SEMBLE_VERSION.
@@ -121,6 +122,7 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 				name: "Semble",
 				trustedDomains: TRUSTED_DOWNLOAD_DOMAINS,
 				timeoutMs: 120_000,
+				maxBytes: MAX_ARCHIVE_BYTES,
 			}),
 		verifyArchive: (archivePath) => verifyChecksum(archivePath, expectedChecksum),
 		extractArchive: async (archivePath, stagingDir) => {
@@ -128,6 +130,8 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 				await extractTarGzArchive(archivePath, stagingDir)
 			} else if (info.archive.endsWith(".zip")) {
 				await extractZipArchive(archivePath, stagingDir)
+			} else {
+				throw new Error(`Unsupported semble archive format: ${info.archive}`)
 			}
 		},
 	})

--- a/src/services/code-index/semble/semble-downloader.ts
+++ b/src/services/code-index/semble/semble-downloader.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 
 import { extractTarGzArchive, extractZipArchive } from "../../managed-binary/archive"
 import { downloadBinaryFile, verifySha256Checksum } from "../../managed-binary/download"
-import { ensureManagedBinaryInstalled, getManagedBinaryPaths } from "../../managed-binary/install"
+import { ensureManagedBinaryInstalled } from "../../managed-binary/install"
 
 /**
  * Supported platform/arch combinations for the semble standalone executable.
@@ -101,14 +101,6 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 	}
 
 	const url = `${DOWNLOAD_BASE_URL}/${info.archive}`
-	const paths = getManagedBinaryPaths({
-		storageDir,
-		id: "semble",
-		version: SEMBLE_VERSION,
-		versionFile: VERSION_FILE,
-		archiveName: info.archive,
-		binaryName: info.binary,
-	})
 	console.log(`[SembleDownloader] Downloading semble ${SEMBLE_VERSION} from ${url}`)
 
 	const platformKey = `${process.platform}-${process.arch}`
@@ -140,7 +132,7 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 		},
 	})
 
-	console.log(`[SembleDownloader] Successfully installed semble ${SEMBLE_VERSION} to ${paths.binaryPath}`)
+	console.log(`[SembleDownloader] Successfully installed semble ${SEMBLE_VERSION} to ${result}`)
 	return result
 }
 

--- a/src/services/managed-binary/__tests__/archive.spec.ts
+++ b/src/services/managed-binary/__tests__/archive.spec.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from "events"
+import { PassThrough } from "stream"
+
+import { spawn } from "child_process"
+
+import {
+	escapePowerShellLiteral,
+	extractSingleFileTarXzArchive,
+	extractSingleFileZipArchive,
+	extractTarGzArchive,
+	runProcess,
+} from "../archive"
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }))
+
+const mockSpawn = vi.mocked(spawn)
+
+function createChild() {
+	return Object.assign(new EventEmitter(), {
+		stdout: new PassThrough(),
+		stderr: new PassThrough(),
+		kill: vi.fn(),
+	})
+}
+
+describe("managed binary archive utilities", () => {
+	beforeEach(() => mockSpawn.mockReset())
+
+	it("runs processes without a shell and returns their output", async () => {
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const processResult = runProcess("tool", ["--version"])
+		child.stdout.write("1.2.3")
+		child.emit("close", 0)
+
+		await expect(processResult).resolves.toEqual({ stdout: "1.2.3", stderr: "" })
+		expect(mockSpawn).toHaveBeenCalledWith("tool", ["--version"], {
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+	})
+
+	it("escapes PowerShell single-quoted literals", () => {
+		expect(escapePowerShellLiteral("C:\\it's\\archive.zip")).toBe("C:\\it''s\\archive.zip")
+	})
+
+	it("extracts tar.gz archives with hardened flags", async () => {
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const extraction = extractTarGzArchive("/tmp/archive.tar.gz", "/tmp/output")
+		child.emit("close", 0)
+		await extraction
+
+		expect(mockSpawn).toHaveBeenCalledWith(
+			"tar",
+			expect.arrayContaining(["-xzf", "/tmp/archive.tar.gz", "-C", "/tmp/output", "--no-same-owner"]),
+			expect.objectContaining({ shell: false }),
+		)
+	})
+
+	it("validates a single-file tar.xz layout before extraction", async () => {
+		const listing = createChild()
+		const extraction = createChild()
+		mockSpawn.mockReturnValueOnce(listing as unknown as ReturnType<typeof spawn>)
+		mockSpawn.mockReturnValueOnce(extraction as unknown as ReturnType<typeof spawn>)
+		const result = extractSingleFileTarXzArchive("/tmp/archive.tar.xz", "/tmp/output", "binary", "Tool")
+		listing.stdout.write("./binary\n")
+		listing.emit("close", 0)
+		await new Promise<void>((resolve) => setImmediate(resolve))
+		extraction.emit("close", 0)
+		await result
+
+		expect(mockSpawn).toHaveBeenNthCalledWith(
+			2,
+			"tar",
+			["-xJf", "/tmp/archive.tar.xz", "-C", "/tmp/output", "binary"],
+			expect.any(Object),
+		)
+	})
+
+	it("builds a single-entry-validated PowerShell ZIP extraction", async () => {
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const extraction = extractSingleFileZipArchive("C:\\archive.zip", "C:\\output", "binary.exe", "Tool")
+		child.emit("close", 0)
+		await extraction
+
+		const script = mockSpawn.mock.calls[0][1][3]
+		expect(script).toContain("$entries.Count -ne 1")
+		expect(script).toContain("binary.exe")
+		expect(script).toContain("Tool archive has an unexpected layout")
+	})
+})

--- a/src/services/managed-binary/__tests__/archive.spec.ts
+++ b/src/services/managed-binary/__tests__/archive.spec.ts
@@ -44,15 +44,18 @@ describe("managed binary archive utilities", () => {
 
 	it("kills a process that exceeds its timeout", async () => {
 		vi.useFakeTimers()
-		const child = createChild()
-		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
-		const processResult = runProcess("tool", [], 100)
-		const assertion = expect(processResult).rejects.toThrow("tool timed out")
+		try {
+			const child = createChild()
+			mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+			const processResult = runProcess("tool", [], 100)
+			const assertion = expect(processResult).rejects.toThrow("tool timed out")
 
-		await vi.advanceTimersByTimeAsync(100)
-		await assertion
-		expect(child.kill).toHaveBeenCalledWith("SIGKILL")
-		vi.useRealTimers()
+			await vi.advanceTimersByTimeAsync(100)
+			await assertion
+			expect(child.kill).toHaveBeenCalledWith("SIGKILL")
+		} finally {
+			vi.useRealTimers()
+		}
 	})
 
 	it("extracts tar.gz archives with hardened flags", async () => {
@@ -112,7 +115,7 @@ describe("managed binary archive utilities", () => {
 		mockSpawn.mockReturnValueOnce(listing as unknown as ReturnType<typeof spawn>)
 		mockSpawn.mockReturnValueOnce(extraction as unknown as ReturnType<typeof spawn>)
 		const result = extractSingleFileTarXzArchive("/tmp/archive.tar.xz", "/tmp/output", "binary", "Tool")
-		listing.stdout.write("./binary\n")
+		listing.stdout.write("-rwxr-xr-x user/group 1 2026-01-01 00:00 ./binary\n")
 		listing.emit("close", 0)
 		await new Promise<void>((resolve) => setImmediate(resolve))
 		extraction.emit("close", 0)
@@ -121,9 +124,34 @@ describe("managed binary archive utilities", () => {
 		expect(mockSpawn).toHaveBeenNthCalledWith(
 			2,
 			"tar",
-			["-xJf", "/tmp/archive.tar.xz", "-C", "/tmp/output", "./binary"],
+			[
+				"-xJf",
+				"/tmp/archive.tar.xz",
+				"-C",
+				"/tmp/output",
+				"--no-same-owner",
+				...(process.platform === "linux" ? ["--no-overwrite-dir"] : []),
+				"./binary",
+			],
 			expect.any(Object),
 		)
+	})
+
+	it.each([
+		["-rwxr-xr-x user/group 1 2026-01-01 00:00 ./other\n", "an unexpected filename"],
+		[
+			"-rwxr-xr-x user/group 1 2026-01-01 00:00 ./binary\n-rwxr-xr-x user/group 1 2026-01-01 00:00 ./other\n",
+			"multiple entries",
+		],
+		["lrwxrwxrwx user/group 0 2026-01-01 00:00 ./binary\n", "a non-regular entry"],
+	])("rejects a tar.xz archive with %s", async (listingOutput) => {
+		const listing = createChild()
+		mockSpawn.mockReturnValue(listing as unknown as ReturnType<typeof spawn>)
+		const result = extractSingleFileTarXzArchive("/tmp/archive.tar.xz", "/tmp/output", "binary", "Tool")
+		listing.stdout.write(listingOutput)
+		listing.emit("close", 0)
+
+		await expect(result).rejects.toThrow("Tool archive has an unexpected layout")
 	})
 
 	it("builds a single-entry-validated PowerShell ZIP extraction", async () => {

--- a/src/services/managed-binary/__tests__/archive.spec.ts
+++ b/src/services/managed-binary/__tests__/archive.spec.ts
@@ -1,13 +1,15 @@
 import { EventEmitter } from "events"
+import * as path from "path"
 import { PassThrough } from "stream"
 
 import { spawn } from "child_process"
 
 import {
-	escapePowerShellLiteral,
 	extractSingleFileTarXzArchive,
 	extractSingleFileZipArchive,
 	extractTarGzArchive,
+	extractTarXzArchive,
+	extractZipArchive,
 	runProcess,
 } from "../archive"
 
@@ -40,8 +42,17 @@ describe("managed binary archive utilities", () => {
 		})
 	})
 
-	it("escapes PowerShell single-quoted literals", () => {
-		expect(escapePowerShellLiteral("C:\\it's\\archive.zip")).toBe("C:\\it''s\\archive.zip")
+	it("kills a process that exceeds its timeout", async () => {
+		vi.useFakeTimers()
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const processResult = runProcess("tool", [], 100)
+		const assertion = expect(processResult).rejects.toThrow("tool timed out")
+
+		await vi.advanceTimersByTimeAsync(100)
+		await assertion
+		expect(child.kill).toHaveBeenCalledWith("SIGKILL")
+		vi.useRealTimers()
 	})
 
 	it("extracts tar.gz archives with hardened flags", async () => {
@@ -56,6 +67,43 @@ describe("managed binary archive utilities", () => {
 			expect.arrayContaining(["-xzf", "/tmp/archive.tar.gz", "-C", "/tmp/output", "--no-same-owner"]),
 			expect.objectContaining({ shell: false }),
 		)
+	})
+
+	it("extracts tar.xz archives with hardened flags", async () => {
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const extraction = extractTarXzArchive("/tmp/archive.tar.xz", "/tmp/output")
+		child.emit("close", 0)
+		await extraction
+
+		const expectedArgs = ["-xJf", "/tmp/archive.tar.xz", "-C", "/tmp/output", "--no-same-owner"]
+		if (process.platform === "linux") expectedArgs.push("--no-overwrite-dir")
+		expect(mockSpawn).toHaveBeenCalledWith("tar", expectedArgs, {
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+	})
+
+	it("extracts ZIP archives with platform-safe process arguments", async () => {
+		const child = createChild()
+		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+		const extraction = extractZipArchive("/tmp/archive.zip", "/tmp/output")
+		child.emit("close", 0)
+		await extraction
+
+		if (process.platform === "win32") {
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"powershell",
+				["-NoProfile", "-NonInteractive", "-Command", expect.any(String), "/tmp/archive.zip", "/tmp/output"],
+				expect.objectContaining({ shell: false }),
+			)
+		} else {
+			expect(mockSpawn).toHaveBeenCalledWith(
+				"unzip",
+				["-o", "/tmp/archive.zip", "-d", "/tmp/output"],
+				expect.objectContaining({ shell: false }),
+			)
+		}
 	})
 
 	it("validates a single-file tar.xz layout before extraction", async () => {
@@ -73,7 +121,7 @@ describe("managed binary archive utilities", () => {
 		expect(mockSpawn).toHaveBeenNthCalledWith(
 			2,
 			"tar",
-			["-xJf", "/tmp/archive.tar.xz", "-C", "/tmp/output", "binary"],
+			["-xJf", "/tmp/archive.tar.xz", "-C", "/tmp/output", "./binary"],
 			expect.any(Object),
 		)
 	})
@@ -85,9 +133,10 @@ describe("managed binary archive utilities", () => {
 		child.emit("close", 0)
 		await extraction
 
-		const script = mockSpawn.mock.calls[0][1][3]
+		const args = mockSpawn.mock.calls[0][1]
+		const script = args[3]
 		expect(script).toContain("$entries.Count -ne 1")
-		expect(script).toContain("binary.exe")
-		expect(script).toContain("Tool archive has an unexpected layout")
+		expect(script).not.toContain("C:\\archive.zip")
+		expect(args.slice(4)).toEqual(["C:\\archive.zip", path.join("C:\\output", "binary.exe"), "binary.exe", "Tool"])
 	})
 })

--- a/src/services/managed-binary/__tests__/archive.spec.ts
+++ b/src/services/managed-binary/__tests__/archive.spec.ts
@@ -157,14 +157,25 @@ describe("managed binary archive utilities", () => {
 	it("builds a single-entry-validated PowerShell ZIP extraction", async () => {
 		const child = createChild()
 		mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>)
-		const extraction = extractSingleFileZipArchive("C:\\archive.zip", "C:\\output", "binary.exe", "Tool")
-		child.emit("close", 0)
-		await extraction
+		const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true })
+		try {
+			const extraction = extractSingleFileZipArchive("C:\\archive.zip", "C:\\output", "binary.exe", "Tool")
+			child.emit("close", 0)
+			await extraction
 
-		const args = mockSpawn.mock.calls[0][1]
-		const script = args[3]
-		expect(script).toContain("$entries.Count -ne 1")
-		expect(script).not.toContain("C:\\archive.zip")
-		expect(args.slice(4)).toEqual(["C:\\archive.zip", path.join("C:\\output", "binary.exe"), "binary.exe", "Tool"])
+			const args = mockSpawn.mock.calls[0][1]
+			const script = args[3]
+			expect(script).toContain("$entries.Count -ne 1")
+			expect(script).not.toContain("C:\\archive.zip")
+			expect(args.slice(4)).toEqual([
+				"C:\\archive.zip",
+				path.join("C:\\output", "binary.exe"),
+				"binary.exe",
+				"Tool",
+			])
+		} finally {
+			if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform)
+		}
 	})
 })

--- a/src/services/managed-binary/__tests__/download.spec.ts
+++ b/src/services/managed-binary/__tests__/download.spec.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from "events"
+import { createReadStream, createWriteStream } from "fs"
+import { get } from "https"
+import type { IncomingMessage, RequestOptions } from "http"
+
+import {
+	assertSizeWithinLimit,
+	downloadBinaryFile,
+	isTrustedHttpsUrl,
+	resolveTrustedRedirect,
+	verifySha256Checksum,
+} from "../download"
+
+vi.mock("crypto", () => ({
+	createHash: vi.fn(() => ({
+		update: vi.fn(),
+		digest: vi.fn(() => "actual-checksum"),
+	})),
+}))
+
+vi.mock("fs", () => ({
+	createReadStream: vi.fn(),
+	createWriteStream: vi.fn(),
+}))
+
+vi.mock("https", () => ({ get: vi.fn() }))
+
+const trustedDomains = ["github.com", "objects.githubusercontent.com"]
+const mockGet = vi.mocked(get)
+const mockCreateReadStream = vi.mocked(createReadStream)
+const mockCreateWriteStream = vi.mocked(createWriteStream)
+
+function createRequest(): EventEmitter & { setTimeout: ReturnType<typeof vi.fn>; destroy: ReturnType<typeof vi.fn> } {
+	return Object.assign(new EventEmitter(), { setTimeout: vi.fn(), destroy: vi.fn() })
+}
+
+function createResponse(statusCode: number, headers: Record<string, string> = {}) {
+	return Object.assign(new EventEmitter(), {
+		statusCode,
+		headers,
+		destroy: vi.fn(),
+		pipe: vi.fn(),
+	})
+}
+
+describe("managed binary downloads", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("validates HTTPS URLs against hostname boundaries", () => {
+		expect(isTrustedHttpsUrl("https://github.com/release", trustedDomains)).toBe(true)
+		expect(isTrustedHttpsUrl("https://cdn.objects.githubusercontent.com/release", trustedDomains)).toBe(true)
+		expect(isTrustedHttpsUrl("http://github.com/release", trustedDomains)).toBe(false)
+		expect(isTrustedHttpsUrl("https://evilgithub.com/release", trustedDomains)).toBe(false)
+		expect(isTrustedHttpsUrl("not a URL", trustedDomains)).toBe(false)
+	})
+
+	it("resolves relative redirects and rejects unsafe or exhausted redirects", () => {
+		const options = { name: "Example", trustedDomains }
+		expect(resolveTrustedRedirect("https://github.com/release", "/asset", 5, options)).toBe(
+			"https://github.com/asset",
+		)
+		expect(() =>
+			resolveTrustedRedirect("https://github.com/release", "https://example.com/asset", 5, options),
+		).toThrow("Example download redirected to an untrusted host")
+		expect(() => resolveTrustedRedirect("https://github.com/release", "/asset", 0, options)).toThrow(
+			"Too many Example download redirects",
+		)
+	})
+
+	it("enforces configurable archive size limits", () => {
+		expect(() => assertSizeWithinLimit(10, 10, "Example")).not.toThrow()
+		expect(() => assertSizeWithinLimit(11, 10, "Example")).toThrow(
+			"Example archive exceeds the download size limit",
+		)
+	})
+
+	it("reports the actual SHA-256 value through a caller-defined mismatch error", async () => {
+		const input = new EventEmitter()
+		mockCreateReadStream.mockReturnValue(input as ReturnType<typeof createReadStream>)
+		const verification = verifySha256Checksum(
+			"/tmp/archive",
+			"expected-checksum",
+			(actual) => new Error(`checksum mismatch: ${actual}`),
+		)
+		input.emit("data", Buffer.from("archive"))
+		input.emit("end")
+		await expect(verification).rejects.toThrow("checksum mismatch: actual-checksum")
+	})
+
+	it("follows a trusted redirect and applies destination security options", async () => {
+		const requestOne = createRequest()
+		const requestTwo = createRequest()
+		const redirect = createResponse(302, { location: "/asset" })
+		const success = createResponse(200, { "content-length": "7" })
+		const output = Object.assign(new EventEmitter(), { close: vi.fn() })
+		mockCreateWriteStream.mockReturnValue(output as unknown as ReturnType<typeof createWriteStream>)
+
+		mockGet
+			.mockImplementationOnce((_url, optionsOrCallback, optionalCallback) => {
+				const callback =
+					typeof optionsOrCallback === "function"
+						? optionsOrCallback
+						: (optionalCallback as ((response: IncomingMessage) => void) | undefined)
+				setImmediate(() => callback?.(redirect as unknown as IncomingMessage))
+				return requestOne as unknown as ReturnType<typeof get>
+			})
+			.mockImplementationOnce((_url, optionsOrCallback, optionalCallback) => {
+				const callback =
+					typeof optionsOrCallback === "function"
+						? optionsOrCallback
+						: (optionalCallback as ((response: IncomingMessage) => void) | undefined)
+				setImmediate(() => callback?.(success as unknown as IncomingMessage))
+				return requestTwo as unknown as ReturnType<typeof get>
+			})
+
+		const download = downloadBinaryFile("https://github.com/release", "/tmp/archive", {
+			name: "Example",
+			trustedDomains,
+			timeoutMs: 1_000,
+			maxBytes: 10,
+			exclusiveDestination: true,
+		})
+		await new Promise<void>((resolve) => setImmediate(resolve))
+		await new Promise<void>((resolve) => setImmediate(resolve))
+		output.emit("finish")
+		await download
+
+		expect(mockGet).toHaveBeenNthCalledWith(2, "https://github.com/asset", expect.any(Function))
+		expect(mockCreateWriteStream).toHaveBeenCalledWith("/tmp/archive", { flags: "wx", mode: 0o600 })
+		expect(requestOne.setTimeout).toHaveBeenCalledWith(1_000, expect.any(Function))
+		expect(requestTwo.setTimeout).toHaveBeenCalledWith(1_000, expect.any(Function))
+	})
+
+	it("rejects an oversized declared response before opening the destination", async () => {
+		const request = createRequest()
+		const response = createResponse(200, { "content-length": "11" })
+		mockGet.mockImplementation(
+			(
+				_url: string | URL,
+				optionsOrCallback: RequestOptions | ((response: IncomingMessage) => void),
+				optionalCallback?: (response: IncomingMessage) => void,
+			) => {
+				const callback = typeof optionsOrCallback === "function" ? optionsOrCallback : optionalCallback
+				setImmediate(() => callback?.(response as unknown as IncomingMessage))
+				return request as unknown as ReturnType<typeof get>
+			},
+		)
+
+		await expect(
+			downloadBinaryFile("https://github.com/release", "/tmp/archive", {
+				name: "Example",
+				trustedDomains,
+				timeoutMs: 1_000,
+				maxBytes: 10,
+			}),
+		).rejects.toThrow("Example archive exceeds the download size limit")
+		expect(mockCreateWriteStream).not.toHaveBeenCalled()
+	})
+})

--- a/src/services/managed-binary/__tests__/download.spec.ts
+++ b/src/services/managed-binary/__tests__/download.spec.ts
@@ -149,7 +149,14 @@ describe("managed binary downloads", () => {
 		})
 		await new Promise<void>((resolve) => setImmediate(resolve))
 		await new Promise<void>((resolve) => setImmediate(resolve))
+		let resolved = false
+		void download.then(() => {
+			resolved = true
+		})
 		output.emit("finish")
+		await Promise.resolve()
+		expect(resolved).toBe(false)
+		output.emit("close")
 		await download
 
 		expect(mockGet).toHaveBeenNthCalledWith(2, "https://github.com/asset", expect.any(Function))

--- a/src/services/managed-binary/__tests__/download.spec.ts
+++ b/src/services/managed-binary/__tests__/download.spec.ts
@@ -104,6 +104,16 @@ describe("managed binary downloads", () => {
 		await expect(verification).rejects.toThrow("checksum mismatch: actual-checksum")
 	})
 
+	it("accepts a matching SHA-256 checksum", async () => {
+		const input = new EventEmitter()
+		mockCreateReadStream.mockReturnValue(input as ReturnType<typeof createReadStream>)
+		const verification = verifySha256Checksum("/tmp/archive", "actual-checksum", () => new Error("should not fail"))
+		input.emit("data", Buffer.from("archive"))
+		input.emit("end")
+
+		await expect(verification).resolves.toBeUndefined()
+	})
+
 	it("follows a trusted redirect and applies destination security options", async () => {
 		const requestOne = createRequest()
 		const requestTwo = createRequest()

--- a/src/services/managed-binary/__tests__/download.spec.ts
+++ b/src/services/managed-binary/__tests__/download.spec.ts
@@ -40,6 +40,7 @@ function createResponse(statusCode: number, headers: Record<string, string> = {}
 		headers,
 		destroy: vi.fn(),
 		pipe: vi.fn(),
+		unpipe: vi.fn(),
 	})
 }
 
@@ -67,6 +68,20 @@ describe("managed binary downloads", () => {
 		expect(() => resolveTrustedRedirect("https://github.com/release", "/asset", 0, options)).toThrow(
 			"Too many Example download redirects",
 		)
+		expect(() => resolveTrustedRedirect("https://github.com/release", undefined, 5, options)).toThrow(
+			"Example download redirect is missing a Location header",
+		)
+	})
+
+	it("distinguishes an untrusted initial URL from an unsafe redirect", async () => {
+		await expect(
+			downloadBinaryFile("http://github.com/release", "/tmp/archive", {
+				name: "Example",
+				trustedDomains,
+				timeoutMs: 1_000,
+			}),
+		).rejects.toThrow("Example download URL is not a trusted HTTPS host")
+		expect(mockGet).not.toHaveBeenCalled()
 	})
 
 	it("enforces configurable archive size limits", () => {
@@ -157,5 +172,32 @@ describe("managed binary downloads", () => {
 			}),
 		).rejects.toThrow("Example archive exceeds the download size limit")
 		expect(mockCreateWriteStream).not.toHaveBeenCalled()
+	})
+
+	it("unpipes and destroys the destination when streamed bytes exceed the limit", async () => {
+		const request = createRequest()
+		const response = createResponse(200)
+		const output = Object.assign(new EventEmitter(), { close: vi.fn(), destroy: vi.fn() })
+		mockCreateWriteStream.mockReturnValue(output as unknown as ReturnType<typeof createWriteStream>)
+		mockGet.mockImplementation((_url, optionsOrCallback, optionalCallback) => {
+			const callback = typeof optionsOrCallback === "function" ? optionsOrCallback : optionalCallback
+			setImmediate(() => callback?.(response as unknown as IncomingMessage))
+			return request as unknown as ReturnType<typeof get>
+		})
+
+		const download = downloadBinaryFile("https://github.com/release", "/tmp/archive", {
+			name: "Example",
+			trustedDomains,
+			timeoutMs: 1_000,
+			maxBytes: 10,
+		})
+		await new Promise<void>((resolve) => setImmediate(resolve))
+		response.emit("data", Buffer.alloc(11))
+
+		await expect(download).rejects.toThrow("Example archive exceeds the download size limit")
+		expect(response.unpipe).toHaveBeenCalledWith(output)
+		expect(output.destroy).toHaveBeenCalledOnce()
+		expect(response.destroy).toHaveBeenCalledOnce()
+		expect(request.destroy).toHaveBeenCalledOnce()
 	})
 })

--- a/src/services/managed-binary/__tests__/install.spec.ts
+++ b/src/services/managed-binary/__tests__/install.spec.ts
@@ -1,0 +1,88 @@
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import * as path from "path"
+
+import { ensureManagedBinaryInstalled, getManagedBinaryPaths, type ManagedBinaryInstallOptions } from "../install"
+
+describe("managed binary installation", () => {
+	let tempDir: string
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(path.join(tmpdir(), "managed-binary-"))
+	})
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true })
+	})
+
+	function createOptions(overrides: Partial<ManagedBinaryInstallOptions> = {}): ManagedBinaryInstallOptions {
+		return {
+			storageDir: tempDir,
+			id: "example",
+			version: "v1.2.3",
+			versionFile: ".example-version",
+			archiveName: "example.tar.gz",
+			binaryName: "example",
+			download: vi.fn(),
+			verifyArchive: vi.fn(),
+			extractArchive: vi.fn(),
+			...overrides,
+		}
+	}
+
+	it("derives one consistent mutable installation layout", () => {
+		expect(getManagedBinaryPaths(createOptions())).toEqual({
+			installRoot: path.join(tempDir, "example"),
+			binaryPath: path.join(tempDir, "example", "example"),
+			versionPath: path.join(tempDir, "example", ".example-version"),
+			stagingDir: path.join(tempDir, "example.new"),
+			stagedBinaryPath: path.join(tempDir, "example.new", "example"),
+			archivePath: path.join(tempDir, "v1.2.3-example.tar.gz"),
+		})
+	})
+
+	it("reuses a current executable without invoking update callbacks", async () => {
+		const options = createOptions()
+		const paths = getManagedBinaryPaths(options)
+		await mkdir(paths.installRoot, { recursive: true })
+		await writeFile(paths.binaryPath, "current")
+		await writeFile(paths.versionPath, options.version)
+		if (process.platform !== "win32") await chmod(paths.binaryPath, 0o600)
+
+		await expect(ensureManagedBinaryInstalled(options)).resolves.toBe(paths.binaryPath)
+		expect(options.download).not.toHaveBeenCalled()
+	})
+
+	it("deduplicates concurrent installations", () => {
+		const options = createOptions({ download: () => new Promise<void>(() => {}) })
+		expect(ensureManagedBinaryInstalled(options)).toBe(ensureManagedBinaryInstalled(options))
+	})
+
+	it("coordinates update, metadata promotion, and cleanup", async () => {
+		const calls: string[] = []
+		const options = createOptions({
+			download: async (archivePath) => {
+				calls.push("download")
+				await writeFile(archivePath, "archive")
+			},
+			verifyArchive: async () => {
+				calls.push("verify")
+			},
+			extractArchive: async (_archivePath, stagingDir) => {
+				calls.push("extract")
+				await writeFile(path.join(stagingDir, "example"), "binary")
+			},
+			validateBinary: async () => {
+				calls.push("validate")
+			},
+		})
+		const paths = getManagedBinaryPaths(options)
+
+		await expect(ensureManagedBinaryInstalled(options)).resolves.toBe(paths.binaryPath)
+		expect(calls).toEqual(["download", "verify", "extract", "validate"])
+		expect(await readFile(paths.binaryPath, "utf8")).toBe("binary")
+		expect(await readFile(paths.versionPath, "utf8")).toBe(options.version)
+		await expect(access(paths.archivePath)).rejects.toThrow()
+		await expect(access(paths.stagingDir)).rejects.toThrow()
+	})
+})

--- a/src/services/managed-binary/__tests__/install.spec.ts
+++ b/src/services/managed-binary/__tests__/install.spec.ts
@@ -23,6 +23,7 @@ describe("managed binary installation", () => {
 			versionFile: ".example-version",
 			archiveName: "example.tar.gz",
 			binaryName: "example",
+			errorPrefix: "Failed to install example",
 			download: vi.fn(),
 			verifyArchive: vi.fn(),
 			extractArchive: vi.fn(),
@@ -53,9 +54,22 @@ describe("managed binary installation", () => {
 		expect(options.download).not.toHaveBeenCalled()
 	})
 
-	it("deduplicates concurrent installations", () => {
-		const options = createOptions({ download: () => new Promise<void>(() => {}) })
-		expect(ensureManagedBinaryInstalled(options)).toBe(ensureManagedBinaryInstalled(options))
+	it("deduplicates concurrent installations", async () => {
+		let finishDownload: (() => void) | undefined
+		const download = vi.fn(() => new Promise<void>((resolve) => (finishDownload = resolve)))
+		const options = createOptions({
+			download,
+			extractArchive: async (_archivePath, stagingDir) => {
+				await writeFile(path.join(stagingDir, "example"), "binary")
+			},
+		})
+		const first = ensureManagedBinaryInstalled(options)
+		const second = ensureManagedBinaryInstalled(options)
+		expect(first).toBe(second)
+		await vi.waitFor(() => expect(download).toHaveBeenCalledOnce())
+		finishDownload?.()
+		await Promise.all([first, second])
+		expect(download).toHaveBeenCalledOnce()
 	})
 
 	it("coordinates update, metadata promotion, and cleanup", async () => {
@@ -84,5 +98,41 @@ describe("managed binary installation", () => {
 		expect(await readFile(paths.versionPath, "utf8")).toBe(options.version)
 		await expect(access(paths.archivePath)).rejects.toThrow()
 		await expect(access(paths.stagingDir)).rejects.toThrow()
+		await expect(access(path.join(tempDir, ".example.install.lock"))).rejects.toThrow()
+	})
+
+	it("cleans up partial artifacts when downloading fails", async () => {
+		const options = createOptions({
+			download: async (archivePath) => {
+				await writeFile(archivePath, "partial")
+				throw new Error("network failure")
+			},
+		})
+		const paths = getManagedBinaryPaths(options)
+
+		await expect(ensureManagedBinaryInstalled(options)).rejects.toThrow(
+			"Failed to install example: network failure",
+		)
+		await expect(access(paths.archivePath)).rejects.toThrow()
+		await expect(access(paths.stagingDir)).rejects.toThrow()
+		await expect(access(paths.binaryPath)).rejects.toThrow()
+	})
+
+	it("removes stale versioned archives without touching unrelated files", async () => {
+		const options = createOptions({
+			download: async (archivePath) => writeFile(archivePath, "archive"),
+			extractArchive: async (_archivePath, stagingDir) => {
+				await writeFile(path.join(stagingDir, "example"), "binary")
+			},
+		})
+		const staleArchive = path.join(tempDir, "v1.2.2-example.tar.gz")
+		const unrelated = path.join(tempDir, "notes.txt")
+		await writeFile(staleArchive, "stale")
+		await writeFile(unrelated, "keep")
+
+		await ensureManagedBinaryInstalled(options)
+
+		await expect(access(staleArchive)).rejects.toThrow()
+		await expect(readFile(unrelated, "utf8")).resolves.toBe("keep")
 	})
 })

--- a/src/services/managed-binary/__tests__/install.spec.ts
+++ b/src/services/managed-binary/__tests__/install.spec.ts
@@ -68,7 +68,10 @@ describe("managed binary installation", () => {
 		expect(first).toBe(second)
 		await vi.waitFor(() => expect(download).toHaveBeenCalledOnce())
 		finishDownload?.()
-		await Promise.all([first, second])
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			getManagedBinaryPaths(options).binaryPath,
+			getManagedBinaryPaths(options).binaryPath,
+		])
 		expect(download).toHaveBeenCalledOnce()
 	})
 

--- a/src/services/managed-binary/archive.ts
+++ b/src/services/managed-binary/archive.ts
@@ -1,0 +1,105 @@
+import { spawn } from "child_process"
+import * as path from "path"
+
+export interface ProcessResult {
+	stdout: string
+	stderr: string
+}
+
+export function runProcess(executable: string, args: string[], timeoutMs = 30_000): Promise<ProcessResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(executable, args, { shell: false, stdio: ["ignore", "pipe", "pipe"] })
+		let stdout = ""
+		let stderr = ""
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL")
+			reject(new Error(`${path.basename(executable)} timed out`))
+		}, timeoutMs)
+		child.stdout?.on("data", (chunk: Buffer) => (stdout += chunk.toString()))
+		child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()))
+		child.on("error", (error) => {
+			clearTimeout(timer)
+			reject(error)
+		})
+		child.on("close", (code) => {
+			clearTimeout(timer)
+			if (code === 0) {
+				resolve({ stdout, stderr })
+			} else {
+				reject(new Error(stderr.trim() || `Process exited with code ${code}`))
+			}
+		})
+	})
+}
+
+export function escapePowerShellLiteral(value: string): string {
+	return value.replace(/'/g, "''")
+}
+
+export async function extractTarGzArchive(archivePath: string, destination: string): Promise<void> {
+	const args = ["-xzf", archivePath, "-C", destination, "--no-same-owner"]
+	if (process.platform === "linux") {
+		args.push("--no-overwrite-dir")
+	}
+	await runProcess("tar", args)
+}
+
+export async function extractTarXzArchive(archivePath: string, destination: string): Promise<void> {
+	const args = ["-xJf", archivePath, "-C", destination, "--no-same-owner"]
+	if (process.platform === "linux") {
+		args.push("--no-overwrite-dir")
+	}
+	await runProcess("tar", args)
+}
+
+export async function extractZipArchive(archivePath: string, destination: string): Promise<void> {
+	if (process.platform === "win32") {
+		await runProcess("powershell", [
+			"-NoProfile",
+			"-Command",
+			`Expand-Archive -Path '${escapePowerShellLiteral(archivePath)}' -DestinationPath '${escapePowerShellLiteral(destination)}' -Force`,
+		])
+		return
+	}
+
+	await runProcess("unzip", ["-o", archivePath, "-d", destination])
+}
+
+export async function extractSingleFileZipArchive(
+	archivePath: string,
+	destination: string,
+	expectedFile: string,
+	archiveName: string,
+): Promise<void> {
+	const outputPath = path.join(destination, expectedFile)
+	const script = [
+		"$ErrorActionPreference = 'Stop'",
+		"Add-Type -AssemblyName System.IO.Compression.FileSystem",
+		`$archive = [System.IO.Compression.ZipFile]::OpenRead('${escapePowerShellLiteral(archivePath)}')`,
+		"try {",
+		"  $entries = @($archive.Entries | Where-Object { -not [string]::IsNullOrEmpty($_.Name) })",
+		`  if ($entries.Count -ne 1 -or $entries[0].FullName -ne '${escapePowerShellLiteral(expectedFile)}') { throw '${escapePowerShellLiteral(archiveName)} archive has an unexpected layout' }`,
+		`  [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entries[0], '${escapePowerShellLiteral(outputPath)}', $false)`,
+		"} finally { $archive.Dispose() }",
+	].join("; ")
+
+	await runProcess("powershell", ["-NoProfile", "-NonInteractive", "-Command", script])
+}
+
+export async function extractSingleFileTarXzArchive(
+	archivePath: string,
+	destination: string,
+	expectedFile: string,
+	archiveName: string,
+): Promise<void> {
+	const listing = await runProcess("tar", ["-tJf", archivePath])
+	const entries = listing.stdout
+		.split(/\r?\n/)
+		.map((entry) => entry.trim().replace(/^\.\//, ""))
+		.filter(Boolean)
+	if (entries.length !== 1 || entries[0] !== expectedFile) {
+		throw new Error(`${archiveName} archive has an unexpected layout`)
+	}
+
+	await runProcess("tar", ["-xJf", archivePath, "-C", destination, expectedFile])
+}

--- a/src/services/managed-binary/archive.ts
+++ b/src/services/managed-binary/archive.ts
@@ -70,7 +70,10 @@ export async function extractSingleFileZipArchive(
 	expectedFile: string,
 	archiveName: string,
 ): Promise<void> {
-	// This deliberately uses PowerShell because it is only called for Windows release archives.
+	if (process.platform !== "win32") {
+		throw new Error("Single-file ZIP extraction is only supported on Windows")
+	}
+
 	const script = [
 		"$ErrorActionPreference = 'Stop'",
 		"$archivePath = $args[0]",

--- a/src/services/managed-binary/archive.ts
+++ b/src/services/managed-binary/archive.ts
@@ -70,6 +70,7 @@ export async function extractSingleFileZipArchive(
 	expectedFile: string,
 	archiveName: string,
 ): Promise<void> {
+	// This deliberately uses PowerShell because it is only called for Windows release archives.
 	const script = [
 		"$ErrorActionPreference = 'Stop'",
 		"$archivePath = $args[0]",
@@ -103,15 +104,21 @@ export async function extractSingleFileTarXzArchive(
 	expectedFile: string,
 	archiveName: string,
 ): Promise<void> {
-	const listing = await runProcess("tar", ["-tJf", archivePath])
+	const listing = await runProcess("tar", ["-tvJf", archivePath])
 	const entries = listing.stdout
 		.split(/\r?\n/)
 		.map((entry) => entry.trim())
 		.filter(Boolean)
 	const archiveEntry = entries[0]
-	if (entries.length !== 1 || archiveEntry.replace(/^\.\//, "") !== expectedFile) {
+	const entryName = archiveEntry?.split(/\s+/).at(-1)
+	if (entries.length !== 1 || !archiveEntry.startsWith("-") || entryName?.replace(/^\.\//, "") !== expectedFile) {
 		throw new Error(`${archiveName} archive has an unexpected layout`)
 	}
 
-	await runProcess("tar", ["-xJf", archivePath, "-C", destination, archiveEntry])
+	const args = ["-xJf", archivePath, "-C", destination, "--no-same-owner"]
+	if (process.platform === "linux") {
+		args.push("--no-overwrite-dir")
+	}
+	args.push(entryName)
+	await runProcess("tar", args)
 }

--- a/src/services/managed-binary/archive.ts
+++ b/src/services/managed-binary/archive.ts
@@ -112,9 +112,17 @@ export async function extractSingleFileTarXzArchive(
 		.split(/\r?\n/)
 		.map((entry) => entry.trim())
 		.filter(Boolean)
+	if (entries.length !== 1) {
+		throw new Error(`${archiveName} archive has an unexpected layout`)
+	}
 	const archiveEntry = entries[0]
 	const entryName = archiveEntry?.split(/\s+/).at(-1)
-	if (entries.length !== 1 || !archiveEntry.startsWith("-") || entryName?.replace(/^\.\//, "") !== expectedFile) {
+	if (
+		!archiveEntry ||
+		!entryName ||
+		!archiveEntry.startsWith("-") ||
+		entryName.replace(/^\.\//, "") !== expectedFile
+	) {
 		throw new Error(`${archiveName} archive has an unexpected layout`)
 	}
 

--- a/src/services/managed-binary/archive.ts
+++ b/src/services/managed-binary/archive.ts
@@ -32,10 +32,6 @@ export function runProcess(executable: string, args: string[], timeoutMs = 30_00
 	})
 }
 
-export function escapePowerShellLiteral(value: string): string {
-	return value.replace(/'/g, "''")
-}
-
 export async function extractTarGzArchive(archivePath: string, destination: string): Promise<void> {
 	const args = ["-xzf", archivePath, "-C", destination, "--no-same-owner"]
 	if (process.platform === "linux") {
@@ -56,8 +52,11 @@ export async function extractZipArchive(archivePath: string, destination: string
 	if (process.platform === "win32") {
 		await runProcess("powershell", [
 			"-NoProfile",
+			"-NonInteractive",
 			"-Command",
-			`Expand-Archive -Path '${escapePowerShellLiteral(archivePath)}' -DestinationPath '${escapePowerShellLiteral(destination)}' -Force`,
+			"$archivePath = $args[0]; $destination = $args[1]; Expand-Archive -LiteralPath $archivePath -DestinationPath $destination -Force",
+			archivePath,
+			destination,
 		])
 		return
 	}
@@ -71,19 +70,31 @@ export async function extractSingleFileZipArchive(
 	expectedFile: string,
 	archiveName: string,
 ): Promise<void> {
-	const outputPath = path.join(destination, expectedFile)
 	const script = [
 		"$ErrorActionPreference = 'Stop'",
+		"$archivePath = $args[0]",
+		"$outputPath = $args[1]",
+		"$expectedFile = $args[2]",
+		"$archiveName = $args[3]",
 		"Add-Type -AssemblyName System.IO.Compression.FileSystem",
-		`$archive = [System.IO.Compression.ZipFile]::OpenRead('${escapePowerShellLiteral(archivePath)}')`,
+		"$archive = [System.IO.Compression.ZipFile]::OpenRead($archivePath)",
 		"try {",
 		"  $entries = @($archive.Entries | Where-Object { -not [string]::IsNullOrEmpty($_.Name) })",
-		`  if ($entries.Count -ne 1 -or $entries[0].FullName -ne '${escapePowerShellLiteral(expectedFile)}') { throw '${escapePowerShellLiteral(archiveName)} archive has an unexpected layout' }`,
-		`  [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entries[0], '${escapePowerShellLiteral(outputPath)}', $false)`,
+		'  if ($entries.Count -ne 1 -or $entries[0].FullName -ne $expectedFile) { throw "$archiveName archive has an unexpected layout" }',
+		"  [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entries[0], $outputPath, $false)",
 		"} finally { $archive.Dispose() }",
 	].join("; ")
 
-	await runProcess("powershell", ["-NoProfile", "-NonInteractive", "-Command", script])
+	await runProcess("powershell", [
+		"-NoProfile",
+		"-NonInteractive",
+		"-Command",
+		script,
+		archivePath,
+		path.join(destination, expectedFile),
+		expectedFile,
+		archiveName,
+	])
 }
 
 export async function extractSingleFileTarXzArchive(
@@ -95,11 +106,12 @@ export async function extractSingleFileTarXzArchive(
 	const listing = await runProcess("tar", ["-tJf", archivePath])
 	const entries = listing.stdout
 		.split(/\r?\n/)
-		.map((entry) => entry.trim().replace(/^\.\//, ""))
+		.map((entry) => entry.trim())
 		.filter(Boolean)
-	if (entries.length !== 1 || entries[0] !== expectedFile) {
+	const archiveEntry = entries[0]
+	if (entries.length !== 1 || archiveEntry.replace(/^\.\//, "") !== expectedFile) {
 		throw new Error(`${archiveName} archive has an unexpected layout`)
 	}
 
-	await runProcess("tar", ["-xJf", archivePath, "-C", destination, expectedFile])
+	await runProcess("tar", ["-xJf", archivePath, "-C", destination, archiveEntry])
 }

--- a/src/services/managed-binary/download.ts
+++ b/src/services/managed-binary/download.ts
@@ -1,0 +1,149 @@
+import { createHash } from "crypto"
+import { createReadStream, createWriteStream } from "fs"
+import * as https from "https"
+
+export interface BinaryDownloadOptions {
+	name: string
+	trustedDomains: readonly string[]
+	timeoutMs: number
+	maxBytes?: number
+	maxRedirects?: number
+	exclusiveDestination?: boolean
+}
+
+export function isTrustedHttpsUrl(url: string, trustedDomains: readonly string[]): boolean {
+	try {
+		const parsed = new URL(url)
+		return (
+			parsed.protocol === "https:" &&
+			trustedDomains.some((domain) => parsed.hostname === domain || parsed.hostname.endsWith(`.${domain}`))
+		)
+	} catch {
+		return false
+	}
+}
+
+export function resolveTrustedRedirect(
+	url: string,
+	location: string | undefined,
+	redirectsRemaining: number,
+	options: Pick<BinaryDownloadOptions, "name" | "trustedDomains">,
+): string {
+	if (redirectsRemaining <= 0 || !location) {
+		throw new Error(`Too many ${options.name} download redirects`)
+	}
+
+	const nextUrl = new URL(location, url).toString()
+	if (!isTrustedHttpsUrl(nextUrl, options.trustedDomains)) {
+		throw new Error(`${options.name} download redirected to an untrusted host (untrusted domain)`)
+	}
+
+	return nextUrl
+}
+
+export function assertSizeWithinLimit(size: number, maxBytes: number, name: string): void {
+	if (size > maxBytes) {
+		throw new Error(`${name} archive exceeds the download size limit`)
+	}
+}
+
+export async function verifySha256Checksum(
+	filePath: string,
+	expected: string,
+	createMismatchError: (actual: string) => Error,
+): Promise<void> {
+	const hash = createHash("sha256")
+	await new Promise<void>((resolve, reject) => {
+		const input = createReadStream(filePath)
+		input.on("data", (chunk) => hash.update(chunk))
+		input.on("end", resolve)
+		input.on("error", reject)
+	})
+
+	const actual = hash.digest("hex")
+	if (actual !== expected) {
+		throw createMismatchError(actual)
+	}
+}
+
+export function downloadBinaryFile(url: string, destination: string, options: BinaryDownloadOptions): Promise<void> {
+	return downloadBinaryFileWithRedirects(url, destination, options, options.maxRedirects ?? 5)
+}
+
+function downloadBinaryFileWithRedirects(
+	url: string,
+	destination: string,
+	options: BinaryDownloadOptions,
+	redirectsRemaining: number,
+): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (!isTrustedHttpsUrl(url, options.trustedDomains)) {
+			reject(new Error(`${options.name} download redirected to an untrusted host (untrusted domain)`))
+			return
+		}
+
+		const request = https.get(url, (response) => {
+			const status = response.statusCode ?? 0
+			if ([301, 302, 303, 307, 308].includes(status)) {
+				response.destroy()
+				let nextUrl: string
+				try {
+					nextUrl = resolveTrustedRedirect(url, response.headers.location, redirectsRemaining, options)
+				} catch (error) {
+					reject(error)
+					return
+				}
+				downloadBinaryFileWithRedirects(nextUrl, destination, options, redirectsRemaining - 1).then(
+					resolve,
+					reject,
+				)
+				return
+			}
+
+			if (status !== 200) {
+				response.destroy()
+				reject(new Error(`${options.name} download failed with HTTP ${status}`))
+				return
+			}
+
+			const declaredSize = Number(response.headers["content-length"] ?? 0)
+			if (options.maxBytes !== undefined) {
+				try {
+					assertSizeWithinLimit(declaredSize, options.maxBytes, options.name)
+				} catch (error) {
+					response.destroy()
+					reject(error)
+					return
+				}
+			}
+
+			let received = 0
+			const output = createWriteStream(
+				destination,
+				options.exclusiveDestination ? { flags: "wx", mode: 0o600 } : undefined,
+			)
+			response.on("data", (chunk: Buffer) => {
+				received += chunk.length
+				if (options.maxBytes !== undefined) {
+					try {
+						assertSizeWithinLimit(received, options.maxBytes, options.name)
+					} catch (error) {
+						response.destroy()
+						request.destroy(error as Error)
+						reject(error)
+					}
+				}
+			})
+			response.on("error", reject)
+			response.pipe(output)
+			output.on("finish", () => {
+				output.close()
+				resolve()
+			})
+			output.on("error", reject)
+		})
+
+		request.setTimeout(options.timeoutMs, () => request.destroy(new Error(`${options.name} download timed out`)))
+		request.on("error", reject)
+	})
+}

--- a/src/services/managed-binary/download.ts
+++ b/src/services/managed-binary/download.ts
@@ -125,27 +125,30 @@ function downloadBinaryFileWithRedirects(
 				destination,
 				options.exclusiveDestination ? { flags: "wx", mode: 0o600 } : undefined,
 			)
+			const abort = (error: Error) => {
+				response.unpipe(output)
+				output.destroy()
+				response.destroy()
+				request.destroy()
+				reject(error)
+			}
 			response.on("data", (chunk: Buffer) => {
 				received += chunk.length
 				if (options.maxBytes !== undefined) {
 					try {
 						assertSizeWithinLimit(received, options.maxBytes, options.name)
 					} catch (error) {
-						response.unpipe(output)
-						output.destroy()
-						response.destroy()
-						request.destroy()
-						reject(error)
+						abort(error instanceof Error ? error : new Error(String(error)))
 					}
 				}
 			})
-			response.on("error", reject)
+			response.on("error", abort)
 			response.pipe(output)
 			output.on("finish", () => {
 				output.close()
 				resolve()
 			})
-			output.on("error", reject)
+			output.on("error", abort)
 		})
 
 		request.setTimeout(options.timeoutMs, () => request.destroy(new Error(`${options.name} download timed out`)))

--- a/src/services/managed-binary/download.ts
+++ b/src/services/managed-binary/download.ts
@@ -144,10 +144,8 @@ function downloadBinaryFileWithRedirects(
 			})
 			response.on("error", abort)
 			response.pipe(output)
-			output.on("finish", () => {
-				output.close()
-				resolve()
-			})
+			output.on("finish", () => output.close())
+			output.on("close", resolve)
 			output.on("error", abort)
 		})
 

--- a/src/services/managed-binary/download.ts
+++ b/src/services/managed-binary/download.ts
@@ -29,8 +29,11 @@ export function resolveTrustedRedirect(
 	redirectsRemaining: number,
 	options: Pick<BinaryDownloadOptions, "name" | "trustedDomains">,
 ): string {
-	if (redirectsRemaining <= 0 || !location) {
+	if (redirectsRemaining <= 0) {
 		throw new Error(`Too many ${options.name} download redirects`)
+	}
+	if (!location) {
+		throw new Error(`${options.name} download redirect is missing a Location header`)
 	}
 
 	const nextUrl = new URL(location, url).toString()
@@ -78,7 +81,7 @@ function downloadBinaryFileWithRedirects(
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
 		if (!isTrustedHttpsUrl(url, options.trustedDomains)) {
-			reject(new Error(`${options.name} download redirected to an untrusted host (untrusted domain)`))
+			reject(new Error(`${options.name} download URL is not a trusted HTTPS host (untrusted domain)`))
 			return
 		}
 
@@ -128,8 +131,10 @@ function downloadBinaryFileWithRedirects(
 					try {
 						assertSizeWithinLimit(received, options.maxBytes, options.name)
 					} catch (error) {
+						response.unpipe(output)
+						output.destroy()
 						response.destroy()
-						request.destroy(error as Error)
+						request.destroy()
 						reject(error)
 					}
 				}

--- a/src/services/managed-binary/install.ts
+++ b/src/services/managed-binary/install.ts
@@ -1,0 +1,131 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+
+const installationPromises = new Map<string, Promise<string>>()
+
+export interface ManagedBinaryInstallOptions {
+	storageDir: string
+	id: string
+	version: string
+	versionFile: string
+	archiveName: string
+	binaryName: string
+	download: (archivePath: string) => Promise<void>
+	verifyArchive: (archivePath: string) => Promise<void>
+	extractArchive: (archivePath: string, stagingDir: string) => Promise<void>
+	validateBinary?: (stagedBinaryPath: string) => Promise<void>
+	errorPrefix?: string
+}
+
+export interface ManagedBinaryPaths {
+	installRoot: string
+	binaryPath: string
+	versionPath: string
+	stagingDir: string
+	stagedBinaryPath: string
+	archivePath: string
+}
+
+export function getManagedBinaryPaths(
+	options: Pick<
+		ManagedBinaryInstallOptions,
+		"storageDir" | "id" | "version" | "versionFile" | "archiveName" | "binaryName"
+	>,
+): ManagedBinaryPaths {
+	const installRoot = path.join(options.storageDir, options.id)
+	const stagingDir = path.join(options.storageDir, `${options.id}.new`)
+	return {
+		installRoot,
+		binaryPath: path.join(installRoot, options.binaryName),
+		versionPath: path.join(installRoot, options.versionFile),
+		stagingDir,
+		stagedBinaryPath: path.join(stagingDir, options.binaryName),
+		archivePath: path.join(options.storageDir, `${options.version}-${options.archiveName}`),
+	}
+}
+
+async function readInstalledVersion(versionPath: string): Promise<string | undefined> {
+	try {
+		const version = (await fs.readFile(versionPath, "utf8")).trim()
+		return version || undefined
+	} catch {
+		return undefined
+	}
+}
+
+async function makeExecutable(binaryPath: string): Promise<void> {
+	await fs.access(binaryPath)
+	if (process.platform !== "win32") {
+		await fs.chmod(binaryPath, 0o755)
+	}
+}
+
+async function cleanupStaleArchives(options: ManagedBinaryInstallOptions, currentArchivePath: string): Promise<void> {
+	try {
+		const entries = await fs.readdir(options.storageDir)
+		const suffix = `-${options.archiveName}`
+		await Promise.all(
+			entries
+				.filter(
+					(name) =>
+						(name === options.archiveName || name.endsWith(suffix)) &&
+						path.join(options.storageDir, name) !== currentArchivePath,
+				)
+				.map((name) => fs.rm(path.join(options.storageDir, name), { force: true }).catch(() => {})),
+		)
+	} catch {
+		// Archive cleanup is cosmetic and must not invalidate a successful installation.
+	}
+}
+
+async function installManagedBinary(options: ManagedBinaryInstallOptions): Promise<string> {
+	const paths = getManagedBinaryPaths(options)
+	await fs.mkdir(options.storageDir, { recursive: true })
+	const installedVersion = await readInstalledVersion(paths.versionPath)
+	if (installedVersion === options.version) {
+		try {
+			await makeExecutable(paths.binaryPath)
+			return paths.binaryPath
+		} catch {
+			// The installation is absent or incomplete, so rebuild it below.
+		}
+	}
+
+	await fs.rm(paths.archivePath, { force: true }).catch(() => {})
+	await fs.rm(paths.stagingDir, { recursive: true, force: true }).catch(() => {})
+	await fs.mkdir(paths.stagingDir, { recursive: true })
+
+	try {
+		await options.download(paths.archivePath)
+		await options.verifyArchive(paths.archivePath)
+		await options.extractArchive(paths.archivePath, paths.stagingDir)
+		await makeExecutable(paths.stagedBinaryPath)
+		await options.validateBinary?.(paths.stagedBinaryPath)
+		await fs.writeFile(path.join(paths.stagingDir, options.versionFile), options.version, "utf-8")
+		await fs.rm(paths.installRoot, { recursive: true, force: true })
+		await fs.rename(paths.stagingDir, paths.installRoot)
+		await cleanupStaleArchives(options, paths.archivePath)
+		return paths.binaryPath
+	} catch (error) {
+		if (!options.errorPrefix) {
+			throw error
+		}
+		const message = error instanceof Error ? error.message : String(error)
+		throw new Error(`${options.errorPrefix}: ${message}`)
+	} finally {
+		await fs.rm(paths.archivePath, { force: true }).catch(() => {})
+		await fs.rm(paths.stagingDir, { recursive: true, force: true }).catch(() => {})
+	}
+}
+
+export function ensureManagedBinaryInstalled(options: ManagedBinaryInstallOptions): Promise<string> {
+	const key = path.join(options.storageDir, options.id)
+	const existing = installationPromises.get(key)
+	if (existing) {
+		return existing
+	}
+
+	const installation = installManagedBinary(options).finally(() => installationPromises.delete(key))
+	installationPromises.set(key, installation)
+	return installation
+}

--- a/src/services/managed-binary/install.ts
+++ b/src/services/managed-binary/install.ts
@@ -124,6 +124,9 @@ async function installManagedBinaryWithLock(options: ManagedBinaryInstallOptions
 		stale: 5 * 60_000,
 		update: 30_000,
 		retries: { retries: 10, factor: 1.5, minTimeout: 100, maxTimeout: 1_000 },
+		onCompromised: (error) => {
+			throw error
+		},
 	})
 	try {
 		return await installManagedBinary(options)

--- a/src/services/managed-binary/install.ts
+++ b/src/services/managed-binary/install.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises"
 import * as path from "path"
+import * as lockfile from "proper-lockfile"
 
 const installationPromises = new Map<string, Promise<string>>()
 
@@ -14,7 +15,7 @@ export interface ManagedBinaryInstallOptions {
 	verifyArchive: (archivePath: string) => Promise<void>
 	extractArchive: (archivePath: string, stagingDir: string) => Promise<void>
 	validateBinary?: (stagedBinaryPath: string) => Promise<void>
-	errorPrefix?: string
+	errorPrefix: string
 }
 
 export interface ManagedBinaryPaths {
@@ -107,14 +108,27 @@ async function installManagedBinary(options: ManagedBinaryInstallOptions): Promi
 		await cleanupStaleArchives(options, paths.archivePath)
 		return paths.binaryPath
 	} catch (error) {
-		if (!options.errorPrefix) {
-			throw error
-		}
 		const message = error instanceof Error ? error.message : String(error)
-		throw new Error(`${options.errorPrefix}: ${message}`)
+		throw new Error(`${options.errorPrefix}: ${message}`, { cause: error })
 	} finally {
 		await fs.rm(paths.archivePath, { force: true }).catch(() => {})
 		await fs.rm(paths.stagingDir, { recursive: true, force: true }).catch(() => {})
+	}
+}
+
+async function installManagedBinaryWithLock(options: ManagedBinaryInstallOptions): Promise<string> {
+	await fs.mkdir(options.storageDir, { recursive: true })
+	const lockTarget = path.join(options.storageDir, `.${options.id}.install`)
+	const release = await lockfile.lock(lockTarget, {
+		realpath: false,
+		stale: 5 * 60_000,
+		update: 30_000,
+		retries: { retries: 10, factor: 1.5, minTimeout: 100, maxTimeout: 1_000 },
+	})
+	try {
+		return await installManagedBinary(options)
+	} finally {
+		await release()
 	}
 }
 
@@ -125,7 +139,7 @@ export function ensureManagedBinaryInstalled(options: ManagedBinaryInstallOption
 		return existing
 	}
 
-	const installation = installManagedBinary(options).finally(() => installationPromises.delete(key))
+	const installation = installManagedBinaryWithLock(options).finally(() => installationPromises.delete(key))
 	installationPromises.set(key, installation)
 	return installation
 }


### PR DESCRIPTION
## What changed

Adds tighter managed-binary safeguards: bounded Semble downloads, stricter archive layout validation, stream cleanup on download failures, and regression coverage for successful verification and installation cleanup.

## Why this change was made

The shared installer underpins the DCG rollout and must reject malformed archives or unbounded downloads without leaving partial files or open connections. Closes #1055.

## Impact

Binary-backed services install more safely and consistently without changing Semble's user-facing workflow.

## Related PRs

- [DCG binary service](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1060)
- [DCG setting](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1061)
- [DCG command integration](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1062)
- [DCG documentation](https://github.com/Zoo-Code-Org/Zoo-Code-Docs/pull/20)