### PR TITLE
fix(telemetry): record tool usage once centrally, sanitize raw tool names

### DIFF
--- a/packages/types/src/tool.ts
+++ b/packages/types/src/tool.ts
@@ -46,6 +46,7 @@ export const toolNames = [
 	"skill",
 	"generate_image",
 	"custom_tool",
+	"invalid_tool_call",
 ] as const
 
 export const toolNamesSchema = z.enum(toolNames)

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-custom-tool.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-custom-tool.spec.ts
@@ -23,6 +23,17 @@ vi.mock("@roo-code/core", () => ({
 	},
 }))
 
+// presentAssistantMessage records tool usage through TelemetryService.instance.
+vi.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			captureToolUsage: vi.fn(),
+			captureConsecutiveMistakeError: vi.fn(),
+			captureEvent: vi.fn(),
+		},
+	},
+}))
+
 import { customToolRegistry } from "@roo-code/core"
 
 describe("presentAssistantMessage - Custom Tool Recording", () => {

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
@@ -15,14 +15,17 @@ vi.mock("../../../shared/modes", async (importOriginal) => {
 		getModeBySlug: vi.fn(actual.getModeBySlug),
 	}
 })
-vi.mock("../../tools/validateToolUse", () => ({
-	validateToolUse: vi.fn(),
-	isValidToolName: vi.fn((toolName: string) =>
-		["read_file", "write_to_file", "ask_followup_question", "attempt_completion", "use_mcp_tool"].includes(
-			toolName,
-		),
-	),
-}))
+// isValidToolName is left as the real implementation (only validateToolUse is
+// mocked): it has its own independent mcp_ prefix carve-out, and a hand-rolled
+// mock allowlist here would mask a regression in toTelemetryToolName's
+// ordering relative to isValidToolName.
+vi.mock("../../tools/validateToolUse", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../tools/validateToolUse")>()
+	return {
+		...actual,
+		validateToolUse: vi.fn(),
+	}
+})
 
 vi.mock("@roo-code/core", () => ({
 	customToolRegistry: {

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
@@ -1,0 +1,221 @@
+// npx vitest src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
+
+import type { Anthropic } from "@anthropic-ai/sdk"
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { presentAssistantMessage } from "../presentAssistantMessage"
+import { validateToolUse } from "../../tools/validateToolUse"
+import type { Task } from "../../task/Task"
+
+vi.mock("../../task/Task")
+vi.mock("../../tools/validateToolUse", () => ({
+	validateToolUse: vi.fn(),
+	isValidToolName: vi.fn((toolName: string) =>
+		["read_file", "write_to_file", "ask_followup_question", "attempt_completion", "use_mcp_tool"].includes(
+			toolName,
+		),
+	),
+}))
+
+vi.mock("@roo-code/core", () => ({
+	customToolRegistry: {
+		has: vi.fn(() => false),
+		get: vi.fn(),
+	},
+}))
+
+vi.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			captureToolUsage: vi.fn(),
+			captureConsecutiveMistakeError: vi.fn(),
+			captureEvent: vi.fn(),
+		},
+	},
+}))
+
+import { TelemetryService } from "@roo-code/telemetry"
+
+interface MockTask {
+	taskId: string
+	instanceId: string
+	abort: boolean
+	presentAssistantMessageLocked: boolean
+	presentAssistantMessageHasPendingUpdates: boolean
+	currentStreamingContentIndex: number
+	assistantMessageContent: unknown[]
+	userMessageContent: Anthropic.ToolResultBlockParam[]
+	didCompleteReadingStream: boolean
+	didRejectTool: boolean
+	didAlreadyUseTool: boolean
+	consecutiveMistakeCount: number
+	clineMessages: unknown[]
+	api: { getModel: () => { id: string; info: Record<string, unknown> } }
+	recordToolUsage: ReturnType<typeof vi.fn>
+	recordToolError: ReturnType<typeof vi.fn>
+	toolRepetitionDetector: { check: ReturnType<typeof vi.fn> }
+	providerRef: { deref: () => { getState: ReturnType<typeof vi.fn> } }
+	say: ReturnType<typeof vi.fn>
+	ask: ReturnType<typeof vi.fn>
+	pushToolResultToUserContent: ReturnType<typeof vi.fn>
+}
+
+describe("presentAssistantMessage - tool usage attribution", () => {
+	let mockTask: MockTask
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(validateToolUse).mockImplementation(() => undefined)
+
+		mockTask = {
+			taskId: "test-task-id",
+			instanceId: "test-instance",
+			abort: false,
+			presentAssistantMessageLocked: false,
+			presentAssistantMessageHasPendingUpdates: false,
+			currentStreamingContentIndex: 0,
+			assistantMessageContent: [],
+			userMessageContent: [],
+			didCompleteReadingStream: false,
+			didRejectTool: false,
+			didAlreadyUseTool: false,
+			consecutiveMistakeCount: 0,
+			clineMessages: [],
+			api: {
+				getModel: () => ({ id: "test-model", info: {} }),
+			},
+			recordToolUsage: vi.fn(),
+			recordToolError: vi.fn(),
+			toolRepetitionDetector: {
+				check: vi.fn().mockReturnValue({ allowExecution: true }),
+			},
+			providerRef: {
+				deref: () => ({
+					getState: vi.fn().mockResolvedValue({
+						mode: "code",
+						customModes: [],
+					}),
+				}),
+			},
+			say: vi.fn().mockResolvedValue(undefined),
+			ask: vi.fn().mockResolvedValue({ response: "yesButtonClicked" }),
+			pushToolResultToUserContent: vi.fn(),
+		}
+
+		mockTask.pushToolResultToUserContent = vi
+			.fn()
+			.mockImplementation((toolResult: Anthropic.ToolResultBlockParam) => {
+				const existingResult = mockTask.userMessageContent.find(
+					(block) => block.type === "tool_result" && block.tool_use_id === toolResult.tool_use_id,
+				)
+				if (existingResult) {
+					return false
+				}
+				mockTask.userMessageContent.push(toolResult)
+				return true
+			})
+	})
+
+	it("records exactly one attempt for a normal static tool", async () => {
+		mockTask.assistantMessageContent = [
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "read_file",
+				params: { path: "test.txt" },
+				nativeArgs: { path: "test.txt" },
+				partial: false,
+			},
+		]
+
+		await presentAssistantMessage(mockTask as unknown as Task)
+
+		expect(mockTask.recordToolUsage).toHaveBeenCalledTimes(1)
+		expect(mockTask.recordToolUsage).toHaveBeenCalledWith("read_file")
+		expect(TelemetryService.instance.captureToolUsage).toHaveBeenCalledTimes(1)
+		expect(TelemetryService.instance.captureToolUsage).toHaveBeenCalledWith(mockTask.taskId, "read_file")
+	})
+
+	it("records a valid dynamic mcp_ tool name as use_mcp_tool", async () => {
+		mockTask.assistantMessageContent = [
+			{
+				type: "tool_use",
+				id: "call_mcp",
+				name: "mcp_my_server_do_thing",
+				params: {},
+				nativeArgs: {},
+				partial: false,
+			},
+		]
+
+		await presentAssistantMessage(mockTask as unknown as Task)
+
+		expect(mockTask.recordToolUsage).toHaveBeenCalledWith("use_mcp_tool")
+		expect(TelemetryService.instance.captureToolUsage).toHaveBeenCalledWith(mockTask.taskId, "use_mcp_tool")
+	})
+
+	it("records a malformed mcp_ tool name as use_mcp_tool, not the raw name", async () => {
+		mockTask.assistantMessageContent = [
+			{
+				type: "tool_use",
+				id: "call_mcp_bad",
+				name: "mcp_",
+				params: {},
+				nativeArgs: {},
+				partial: false,
+			},
+		]
+
+		await presentAssistantMessage(mockTask as unknown as Task)
+
+		expect(mockTask.recordToolUsage).toHaveBeenCalledWith("use_mcp_tool")
+		expect(mockTask.recordToolUsage).not.toHaveBeenCalledWith("mcp_")
+	})
+
+	it("records a safe failure key without leaking the raw tool name when validation fails", async () => {
+		vi.mocked(validateToolUse).mockImplementation(() => {
+			throw new Error('Tool "read_file" is not allowed in this mode.')
+		})
+
+		mockTask.assistantMessageContent = [
+			{
+				type: "tool_use",
+				id: "call_bad_mode",
+				name: "read_file",
+				params: { path: "test.txt" },
+				nativeArgs: { path: "test.txt" },
+				partial: false,
+			},
+		]
+
+		await presentAssistantMessage(mockTask as unknown as Task)
+
+		// A known static tool that fails validation still maps to its own name
+		// (it's a real, recognized tool - just disallowed here), never left raw/unmapped.
+		expect(mockTask.recordToolError).toHaveBeenCalledWith("read_file", expect.any(String))
+		// No success attempt should be recorded for a validation failure.
+		expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
+	})
+
+	it("records invalid_tool_call, not the raw name, when an arbitrary unknown tool fails validation", async () => {
+		vi.mocked(validateToolUse).mockImplementation(() => {
+			throw new Error('Unknown tool "totally_made_up_tool". This tool does not exist.')
+		})
+
+		mockTask.assistantMessageContent = [
+			{
+				type: "tool_use",
+				id: "call_unknown",
+				name: "totally_made_up_tool",
+				params: {},
+				nativeArgs: {},
+				partial: false,
+			},
+		]
+
+		await presentAssistantMessage(mockTask as unknown as Task)
+
+		expect(mockTask.recordToolError).toHaveBeenCalledWith("invalid_tool_call", expect.any(String))
+		expect(mockTask.recordToolError).not.toHaveBeenCalledWith("totally_made_up_tool", expect.anything())
+		expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
@@ -245,6 +245,12 @@ describe("presentAssistantMessage - tool usage attribution", () => {
 					}),
 					getMcpHub: () => ({
 						findServerNameBySanitizedName: () => "my_server",
+						getAllServers: () => [
+							{
+								name: "my_server",
+								tools: [{ name: "do_thing", enabledForPrompt: true }],
+							},
+						],
 					}),
 				}),
 			}

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-tool-usage-attribution.spec.ts
@@ -4,9 +4,17 @@ import type { Anthropic } from "@anthropic-ai/sdk"
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { presentAssistantMessage } from "../presentAssistantMessage"
 import { validateToolUse } from "../../tools/validateToolUse"
+import { getModeBySlug } from "../../../shared/modes"
 import type { Task } from "../../task/Task"
 
 vi.mock("../../task/Task")
+vi.mock("../../../shared/modes", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../shared/modes")>()
+	return {
+		...actual,
+		getModeBySlug: vi.fn(actual.getModeBySlug),
+	}
+})
 vi.mock("../../tools/validateToolUse", () => ({
 	validateToolUse: vi.fn(),
 	isValidToolName: vi.fn((toolName: string) =>
@@ -53,7 +61,12 @@ interface MockTask {
 	recordToolUsage: ReturnType<typeof vi.fn>
 	recordToolError: ReturnType<typeof vi.fn>
 	toolRepetitionDetector: { check: ReturnType<typeof vi.fn> }
-	providerRef: { deref: () => { getState: ReturnType<typeof vi.fn> } }
+	providerRef: {
+		deref: () => {
+			getState: ReturnType<typeof vi.fn>
+			getMcpHub?: () => { findServerNameBySanitizedName: (name: string) => string | undefined }
+		}
+	}
 	say: ReturnType<typeof vi.fn>
 	ask: ReturnType<typeof vi.fn>
 	pushToolResultToUserContent: ReturnType<typeof vi.fn>
@@ -217,5 +230,81 @@ describe("presentAssistantMessage - tool usage attribution", () => {
 		expect(mockTask.recordToolError).toHaveBeenCalledWith("invalid_tool_call", expect.any(String))
 		expect(mockTask.recordToolError).not.toHaveBeenCalledWith("totally_made_up_tool", expect.anything())
 		expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
+	})
+
+	describe("native mcp_tool_use block", () => {
+		it("records exactly one attempt once the MCP tool's own validation passes", async () => {
+			mockTask.providerRef = {
+				deref: () => ({
+					getState: vi.fn().mockResolvedValue({
+						mode: "code",
+						customModes: [],
+					}),
+					getMcpHub: () => ({
+						findServerNameBySanitizedName: () => "my_server",
+					}),
+				}),
+			}
+
+			mockTask.assistantMessageContent = [
+				{
+					type: "mcp_tool_use",
+					id: "call_native_mcp",
+					name: "mcp_my_server_do_thing",
+					serverName: "my_server",
+					toolName: "do_thing",
+					arguments: {},
+					partial: false,
+				},
+			]
+
+			await presentAssistantMessage(mockTask as unknown as Task)
+
+			expect(mockTask.recordToolUsage).toHaveBeenCalledTimes(1)
+			expect(mockTask.recordToolUsage).toHaveBeenCalledWith("use_mcp_tool")
+			expect(TelemetryService.instance.captureToolUsage).toHaveBeenCalledTimes(1)
+			expect(TelemetryService.instance.captureToolUsage).toHaveBeenCalledWith(mockTask.taskId, "use_mcp_tool")
+		})
+
+		it("records no attempt when the MCP server is not on the mode's allow-list", async () => {
+			vi.mocked(getModeBySlug).mockReturnValueOnce({
+				slug: "code",
+				name: "Code",
+				roleDefinition: "",
+				groups: [],
+				allowedMcpServers: ["some-other-server"],
+			})
+
+			mockTask.providerRef = {
+				deref: () => ({
+					getState: vi.fn().mockResolvedValue({
+						mode: "code",
+						customModes: [],
+					}),
+					getMcpHub: () => ({
+						findServerNameBySanitizedName: () => "my_server",
+					}),
+				}),
+			}
+
+			mockTask.assistantMessageContent = [
+				{
+					type: "mcp_tool_use",
+					id: "call_native_mcp_disallowed",
+					name: "mcp_my_server_do_thing",
+					serverName: "my_server",
+					toolName: "do_thing",
+					arguments: {},
+					partial: false,
+				},
+			]
+
+			await presentAssistantMessage(mockTask as unknown as Task)
+
+			// The server is disallowed, so the call never reaches onValidated:
+			// no success attempt is recorded for a call that was never permitted to execute.
+			expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
+			expect(TelemetryService.instance.captureToolUsage).not.toHaveBeenCalled()
+		})
 	})
 })

--- a/src/core/assistant-message/__tests__/presentAssistantMessage-unknown-tool.spec.ts
+++ b/src/core/assistant-message/__tests__/presentAssistantMessage-unknown-tool.spec.ts
@@ -101,9 +101,10 @@ describe("presentAssistantMessage - Unknown Tool Handling", () => {
 		// Verify consecutiveMistakeCount was incremented
 		expect(mockTask.consecutiveMistakeCount).toBe(1)
 
-		// Verify recordToolError was called
+		// Verify recordToolError was called with a safe static key, never the
+		// raw model-controlled tool name.
 		expect(mockTask.recordToolError).toHaveBeenCalledWith(
-			"nonexistent_tool",
+			"invalid_tool_call",
 			expect.stringContaining("Unknown tool"),
 		)
 
@@ -135,8 +136,9 @@ describe("presentAssistantMessage - Unknown Tool Handling", () => {
 		// Verify consecutiveMistakeCount was incremented
 		expect(mockTask.consecutiveMistakeCount).toBe(1)
 
-		// Verify recordToolError was called
-		expect(mockTask.recordToolError).toHaveBeenCalled()
+		// Verify recordToolError was called with a safe static key, never the
+		// raw model-reported tool name ("fake_tool_that_does_not_exist").
+		expect(mockTask.recordToolError).toHaveBeenCalledWith("invalid_tool_call", expect.anything())
 
 		// Verify error message was shown to user
 		expect(mockTask.say).toHaveBeenCalledWith("error", expect.anything())

--- a/src/core/assistant-message/__tests__/toTelemetryToolName.spec.ts
+++ b/src/core/assistant-message/__tests__/toTelemetryToolName.spec.ts
@@ -1,0 +1,43 @@
+// npx vitest src/core/assistant-message/__tests__/toTelemetryToolName.spec.ts
+
+import { describe, it, expect, vi } from "vitest"
+
+vi.mock("../../tools/validateToolUse", () => ({
+	validateToolUse: vi.fn(),
+	isValidToolName: vi.fn((toolName: string) =>
+		["read_file", "write_to_file", "ask_followup_question", "attempt_completion", "use_mcp_tool"].includes(
+			toolName,
+		),
+	),
+}))
+
+import { toTelemetryToolName } from "../presentAssistantMessage"
+
+describe("toTelemetryToolName", () => {
+	it("maps a known static tool to its own name", () => {
+		expect(toTelemetryToolName("read_file", false, undefined)).toBe("read_file")
+	})
+
+	it("maps a registered custom tool to custom_tool", () => {
+		expect(toTelemetryToolName("my_custom_tool", true, undefined)).toBe("custom_tool")
+	})
+
+	it("maps a valid dynamic mcp_ tool name to use_mcp_tool", () => {
+		expect(toTelemetryToolName("mcp_my_server_do_thing", false, undefined)).toBe("use_mcp_tool")
+	})
+
+	it("maps a malformed mcp_ tool name to use_mcp_tool", () => {
+		expect(toTelemetryToolName("mcp_", false, undefined)).toBe("use_mcp_tool")
+	})
+
+	it("maps an arbitrary unknown tool name to invalid_tool_call", () => {
+		expect(toTelemetryToolName("drop_table_users", false, undefined)).toBe("invalid_tool_call")
+	})
+
+	it("never returns the raw name for an unrecognized tool", () => {
+		const raw = "'; DROP TABLE users; --"
+		const result = toTelemetryToolName(raw, false, undefined)
+		expect(result).not.toBe(raw)
+		expect(result).toBe("invalid_tool_call")
+	})
+})

--- a/src/core/assistant-message/__tests__/toTelemetryToolName.spec.ts
+++ b/src/core/assistant-message/__tests__/toTelemetryToolName.spec.ts
@@ -2,14 +2,18 @@
 
 import { describe, it, expect, vi } from "vitest"
 
-vi.mock("../../tools/validateToolUse", () => ({
-	validateToolUse: vi.fn(),
-	isValidToolName: vi.fn((toolName: string) =>
-		["read_file", "write_to_file", "ask_followup_question", "attempt_completion", "use_mcp_tool"].includes(
-			toolName,
-		),
-	),
-}))
+// Only validateToolUse itself needs mocking (unused by toTelemetryToolName,
+// but imported by the same module). isValidToolName is left as the real
+// implementation: it has its own independent mcp_ prefix carve-out, and a
+// hand-rolled mock allowlist here would mask a regression where
+// toTelemetryToolName's ordering relative to isValidToolName changes.
+vi.mock("../../tools/validateToolUse", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../tools/validateToolUse")>()
+	return {
+		...actual,
+		validateToolUse: vi.fn(),
+	}
+})
 
 import { toTelemetryToolName } from "../presentAssistantMessage"
 
@@ -39,5 +43,12 @@ describe("toTelemetryToolName", () => {
 		const result = toTelemetryToolName(raw, false, undefined)
 		expect(result).not.toBe(raw)
 		expect(result).toBe("invalid_tool_call")
+	})
+
+	it("maps mcp_ names to use_mcp_tool against the real isValidToolName, not a mock allowlist", () => {
+		// isValidToolName is unmocked in this file (see the vi.mock factory above),
+		// so this exercises the real mcp_ prefix carve-out ordering rather than one
+		// a hand-rolled mock could silently keep agreeing with after a regression.
+		expect(toTelemetryToolName("mcp_my_server_do_thing", false, undefined)).toBe("use_mcp_tool")
 	})
 })

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -258,10 +258,6 @@ export async function presentAssistantMessage(cline: Task) {
 				pushToolResult(formatResponse.toolError(errorString))
 			}
 
-			if (!mcpBlock.partial) {
-				cline.recordToolUsage("use_mcp_tool") // Record as use_mcp_tool for analytics
-			}
-
 			// Resolve sanitized server name back to original server name
 			// The serverName from parsing is sanitized (e.g., "my_server" from "my server")
 			// We need the original name to find the actual MCP connection
@@ -297,6 +293,12 @@ export async function presentAssistantMessage(cline: Task) {
 				askApproval,
 				handleError,
 				pushToolResult,
+				onValidated: mcpBlock.partial
+					? undefined
+					: () => {
+							cline.recordToolUsage("use_mcp_tool")
+							TelemetryService.instance.captureToolUsage(cline.taskId, "use_mcp_tool")
+						},
 			})
 			break
 		}

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -42,6 +42,31 @@ import { formatResponse } from "../prompts/responses"
 import { sanitizeToolUseId } from "../../utils/tool-id"
 
 /**
+ * Maps a raw, potentially model-controlled tool name to a safe analytics key.
+ * Never returns the raw name unless it is a known static tool, so an
+ * arbitrary model-supplied string can never become a `toolsUsed` property key.
+ */
+export function toTelemetryToolName(
+	toolName: string,
+	isCustomTool: boolean,
+	experiments?: Record<string, boolean>,
+): ToolName {
+	if (isCustomTool) {
+		return "custom_tool"
+	}
+
+	if (toolName.startsWith("mcp_")) {
+		return "use_mcp_tool"
+	}
+
+	if (isValidToolName(toolName, experiments)) {
+		return toolName
+	}
+
+	return "invalid_tool_call"
+}
+
+/**
  * Processes and presents assistant message content to the user interface.
  *
  * This function is the core message handling system that:
@@ -301,14 +326,10 @@ export async function presentAssistantMessage(cline: Task) {
 			if (!toolCallId) {
 				const errorMessage =
 					"Invalid tool call: missing tool_use.id. XML tool calls are no longer supported. Remove any XML tool markup (e.g. <read_file>...</read_file>) and use native tool calling instead."
-				// Record a tool error for visibility/telemetry. Use the reported tool name if present.
+				// Record a safe, static analytics key. Never key telemetry on the
+				// model-reported tool name, which is untrusted here.
 				try {
-					if (
-						typeof (cline as any).recordToolError === "function" &&
-						typeof (block as any).name === "string"
-					) {
-						;(cline as any).recordToolError((block as any).name as ToolName, errorMessage)
-					}
+					cline.recordToolError("invalid_tool_call", errorMessage)
 				} catch {
 					// Best-effort only
 				}
@@ -424,7 +445,7 @@ export async function presentAssistantMessage(cline: Task) {
 
 					cline.consecutiveMistakeCount++
 					try {
-						cline.recordToolError(block.name as ToolName, errorMessage)
+						cline.recordToolError(toTelemetryToolName(block.name, false, stateExperiments), errorMessage)
 					} catch {
 						// Best-effort only
 					}
@@ -552,22 +573,6 @@ export async function presentAssistantMessage(cline: Task) {
 				pushToolResult(formatResponse.toolError(errorString))
 			}
 
-			if (!block.partial) {
-				// Check if this is a custom tool - if so, record as "custom_tool" (like MCP tools)
-				const isCustomTool = stateExperiments?.customTools && customToolRegistry.has(block.name)
-				const recordName = isCustomTool ? "custom_tool" : block.name
-				cline.recordToolUsage(recordName)
-
-				// Track legacy format usage for read_file tool (for migration monitoring)
-				if (block.name === "read_file" && block.usedLegacyFormat) {
-					const modelInfo = cline.api.getModel()
-					TelemetryService.instance.captureEvent(TelemetryEventName.READ_FILE_LEGACY_FORMAT_USED, {
-						taskId: cline.taskId,
-						model: modelInfo?.id,
-					})
-				}
-			}
-
 			// Validate tool use before execution - ONLY for complete (non-partial) blocks.
 			// Validating partial blocks would cause validation errors to be thrown repeatedly
 			// during streaming, pushing multiple tool_results for the same tool_use_id and
@@ -579,6 +584,8 @@ export async function presentAssistantMessage(cline: Task) {
 				const rawIncludedTools = modelInfo?.info?.includedTools
 				const { resolveToolAlias } = await import("../prompts/tools/filter-tools-for-mode")
 				const includedTools = rawIncludedTools?.map((tool) => resolveToolAlias(tool))
+
+				const isCustomTool = Boolean(stateExperiments?.customTools && customToolRegistry.has(block.name))
 
 				try {
 					const toolRequirements =
@@ -617,7 +624,29 @@ export async function presentAssistantMessage(cline: Task) {
 						is_error: true,
 					})
 
+					// Record a safe failure key. Never key telemetry on the raw,
+					// model-controlled tool name.
+					cline.recordToolError(
+						toTelemetryToolName(block.name, isCustomTool, stateExperiments),
+						error.message,
+					)
+
 					break
+				}
+
+				// Validation passed: record exactly one attempt at this single
+				// central point. Individual tool handlers must not also record
+				// usage, or the attempt would be double-counted.
+				const recordName = toTelemetryToolName(block.name, isCustomTool, stateExperiments)
+				cline.recordToolUsage(recordName)
+				TelemetryService.instance.captureToolUsage(cline.taskId, recordName)
+
+				// Track legacy format usage for read_file tool (for migration monitoring)
+				if (block.name === "read_file" && block.usedLegacyFormat) {
+					TelemetryService.instance.captureEvent(TelemetryEventName.READ_FILE_LEGACY_FORMAT_USED, {
+						taskId: cline.taskId,
+						model: modelInfo?.id,
+					})
 				}
 			}
 
@@ -901,7 +930,7 @@ export async function presentAssistantMessage(cline: Task) {
 					// Not a custom tool - handle as unknown tool error
 					const errorMessage = `Unknown tool "${block.name}". This tool does not exist. Please use one of the available tools.`
 					cline.consecutiveMistakeCount++
-					cline.recordToolError(block.name as ToolName, errorMessage)
+					cline.recordToolError("invalid_tool_call", errorMessage)
 					await cline.say("error", t("tools:unknownToolError", { toolName: block.name }))
 					// Push tool_result directly WITHOUT setting didAlreadyUseTool
 					// This prevents the stream from being interrupted with "Response interrupted by tool use result"

--- a/src/core/tools/ApplyPatchTool.ts
+++ b/src/core/tools/ApplyPatchTool.ts
@@ -131,7 +131,6 @@ export class ApplyPatchTool extends BaseTool<"apply_patch"> {
 			}
 
 			task.consecutiveMistakeCount = 0
-			task.recordToolUsage("apply_patch")
 		} catch (error) {
 			await handleError("apply patch", error as Error)
 			await task.diffViewProvider.reset()

--- a/src/core/tools/BaseTool.ts
+++ b/src/core/tools/BaseTool.ts
@@ -11,6 +11,15 @@ export interface ToolCallbacks {
 	handleError: HandleError
 	pushToolResult: PushToolResult
 	toolCallId?: string
+	/**
+	 * Optional hook invoked once a tool's own internal validation (params,
+	 * target existence, permissions) has passed, before side-effecting
+	 * execution begins. Used by callers that must defer telemetry attribution
+	 * until validation this deep can't be done from the outside (e.g. native
+	 * MCP tool calls, whose server/tool/allow-list checks live inside
+	 * UseMcpToolTool rather than the shared validateToolUse path).
+	 */
+	onValidated?: () => void
 }
 
 /**

--- a/src/core/tools/BaseTool.ts
+++ b/src/core/tools/BaseTool.ts
@@ -11,15 +11,6 @@ export interface ToolCallbacks {
 	handleError: HandleError
 	pushToolResult: PushToolResult
 	toolCallId?: string
-	/**
-	 * Optional hook invoked once a tool's own internal validation (params,
-	 * target existence, permissions) has passed, before side-effecting
-	 * execution begins. Used by callers that must defer telemetry attribution
-	 * until validation this deep can't be done from the outside (e.g. native
-	 * MCP tool calls, whose server/tool/allow-list checks live inside
-	 * UseMcpToolTool rather than the shared validateToolUse path).
-	 */
-	onValidated?: () => void
 }
 
 /**
@@ -117,9 +108,16 @@ export abstract class BaseTool<TName extends ToolName> {
 	 *
 	 * @param task - Task instance
 	 * @param block - ToolUse block from assistant message
-	 * @param callbacks - Tool execution callbacks
+	 * @param callbacks - Tool execution callbacks. Accepts any subclass-specific
+	 *   extension of ToolCallbacks (e.g. UseMcpToolCallbacks) so callers can pass
+	 *   extra fields through to a matching execute() override without widening
+	 *   the shared ToolCallbacks interface for every tool.
 	 */
-	async handle(task: Task, block: ToolUse<TName>, callbacks: ToolCallbacks): Promise<void> {
+	async handle<TCallbacks extends ToolCallbacks>(
+		task: Task,
+		block: ToolUse<TName>,
+		callbacks: TCallbacks,
+	): Promise<void> {
 		// Handle partial messages
 		if (block.partial) {
 			try {

--- a/src/core/tools/EditFileTool.ts
+++ b/src/core/tools/EditFileTool.ts
@@ -463,8 +463,6 @@ export class EditFileTool extends BaseTool<"edit_file"> {
 
 			pushToolResult(message + replacementInfo)
 
-			// Record successful tool usage and cleanup
-			task.recordToolUsage("edit_file")
 			await task.diffViewProvider.reset()
 			this.resetPartialState()
 

--- a/src/core/tools/EditTool.ts
+++ b/src/core/tools/EditTool.ts
@@ -229,8 +229,6 @@ export class EditTool extends BaseTool<"edit"> {
 			const message = await task.diffViewProvider.pushToolWriteResult(task, task.cwd, false)
 			pushToolResult(message)
 
-			// Record successful tool usage and cleanup
-			task.recordToolUsage("edit")
 			await task.diffViewProvider.reset()
 			this.resetPartialState()
 

--- a/src/core/tools/GenerateImageTool.ts
+++ b/src/core/tools/GenerateImageTool.ts
@@ -242,8 +242,6 @@ export class GenerateImageTool extends BaseTool<"generate_image"> {
 
 			task.didEditFile = true
 
-			task.recordToolUsage("generate_image")
-
 			const fullImagePath = path.join(task.cwd, finalPath)
 
 			let imageUri = provider?.convertToWebviewUri?.(fullImagePath) ?? vscode.Uri.file(fullImagePath).toString()

--- a/src/core/tools/SearchReplaceTool.ts
+++ b/src/core/tools/SearchReplaceTool.ts
@@ -225,8 +225,6 @@ export class SearchReplaceTool extends BaseTool<"search_replace"> {
 			const message = await task.diffViewProvider.pushToolWriteResult(task, task.cwd, false)
 			pushToolResult(message)
 
-			// Record successful tool usage and cleanup
-			task.recordToolUsage("search_replace")
 			await task.diffViewProvider.reset()
 			this.resetPartialState()
 

--- a/src/core/tools/UseMcpToolTool.ts
+++ b/src/core/tools/UseMcpToolTool.ts
@@ -28,7 +28,7 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 	readonly name = "use_mcp_tool" as const
 
 	async execute(params: UseMcpToolParams, task: Task, callbacks: ToolCallbacks): Promise<void> {
-		const { askApproval, handleError, pushToolResult } = callbacks
+		const { askApproval, handleError, pushToolResult, onValidated } = callbacks
 
 		try {
 			// Validate parameters
@@ -65,6 +65,10 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 
 			// Reset mistake count on successful validation
 			task.consecutiveMistakeCount = 0
+
+			// All internal validation (params, tool existence, server allow-list) has
+			// passed. Only now is it safe to attribute this as an attempted tool use.
+			onValidated?.()
 
 			// Get user approval
 			const completeMessage = JSON.stringify({

--- a/src/core/tools/UseMcpToolTool.ts
+++ b/src/core/tools/UseMcpToolTool.ts
@@ -15,6 +15,18 @@ interface UseMcpToolParams {
 	arguments?: Record<string, unknown>
 }
 
+/**
+ * Extends the shared callbacks with a hook invoked once this tool's own
+ * internal validation (params, tool existence, server allow-list) has
+ * passed, before side-effecting execution begins. Native MCP tool calls
+ * (presentAssistantMessage's mcp_tool_use branch) use this to defer telemetry
+ * attribution past validation that lives inside this class rather than the
+ * shared validateToolUse path.
+ */
+export interface UseMcpToolCallbacks extends ToolCallbacks {
+	onValidated?: () => void
+}
+
 type ValidationResult =
 	| { isValid: false }
 	| {
@@ -27,7 +39,7 @@ type ValidationResult =
 export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 	readonly name = "use_mcp_tool" as const
 
-	async execute(params: UseMcpToolParams, task: Task, callbacks: ToolCallbacks): Promise<void> {
+	async execute(params: UseMcpToolParams, task: Task, callbacks: UseMcpToolCallbacks): Promise<void> {
 		const { askApproval, handleError, pushToolResult, onValidated } = callbacks
 
 		try {

--- a/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
+++ b/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
@@ -1,0 +1,96 @@
+// npx vitest run core/tools/__tests__/applyPatchTool.execute.spec.ts
+
+import type { MockedFunction } from "vitest"
+
+import { fileExistsAtPath } from "../../../utils/fs"
+import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
+import type { Task } from "../../task/Task"
+import { ApplyPatchTool } from "../ApplyPatchTool"
+
+vi.mock("fs/promises", () => ({
+	default: {
+		readFile: vi.fn().mockResolvedValue("original file content\n"),
+		unlink: vi.fn().mockResolvedValue(undefined),
+	},
+}))
+
+vi.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock("../../../utils/pathUtils", () => ({
+	isPathOutsideWorkspace: vi.fn().mockReturnValue(false),
+}))
+
+describe("ApplyPatchTool.execute - delete file success path", () => {
+	const mockedFileExistsAtPath = fileExistsAtPath as MockedFunction<typeof fileExistsAtPath>
+	const mockedIsPathOutsideWorkspace = isPathOutsideWorkspace as MockedFunction<typeof isPathOutsideWorkspace>
+
+	let tool: ApplyPatchTool
+	let mockTask: Pick<
+		Task,
+		| "cwd"
+		| "consecutiveMistakeCount"
+		| "recordToolUsage"
+		| "recordToolError"
+		| "rooIgnoreController"
+		| "rooProtectedController"
+		| "say"
+		| "processQueuedMessages"
+		| "didEditFile"
+	>
+	let mockAskApproval: MockedFunction<(...args: unknown[]) => Promise<boolean>>
+	let mockHandleError: MockedFunction<(...args: unknown[]) => Promise<void>>
+	let mockPushToolResult: MockedFunction<(...args: unknown[]) => void>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockedFileExistsAtPath.mockResolvedValue(true)
+		mockedIsPathOutsideWorkspace.mockReturnValue(false)
+
+		mockTask = {
+			cwd: "/workspace/project",
+			consecutiveMistakeCount: 0,
+			recordToolUsage: vi.fn(),
+			recordToolError: vi.fn(),
+			rooIgnoreController: {
+				validateAccess: vi.fn().mockReturnValue(true),
+			} as unknown as Task["rooIgnoreController"],
+			rooProtectedController: {
+				isWriteProtected: vi.fn().mockReturnValue(false),
+			} as unknown as Task["rooProtectedController"],
+			say: vi.fn().mockResolvedValue(undefined),
+			processQueuedMessages: vi.fn(),
+			didEditFile: false,
+		}
+
+		mockAskApproval = vi.fn().mockResolvedValue(true)
+		mockHandleError = vi.fn().mockResolvedValue(undefined)
+		mockPushToolResult = vi.fn()
+
+		tool = new ApplyPatchTool()
+	})
+
+	it("deletes the file and records no local tool usage on success", async () => {
+		const patch = `*** Begin Patch
+*** Delete File: src/obsolete.ts
+*** End Patch`
+
+		await tool.execute({ patch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockAskApproval).toHaveBeenCalled()
+		expect(mockPushToolResult).toHaveBeenCalledWith(expect.stringContaining("Successfully deleted"))
+		expect(mockTask.didEditFile).toBe(true)
+		expect(mockHandleError).not.toHaveBeenCalled()
+
+		// Usage is recorded once at the central presentAssistantMessage
+		// attribution point, not locally by the handler.
+		expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
+		expect(mockTask.recordToolError).not.toHaveBeenCalled()
+	})
+})

--- a/src/core/tools/__tests__/editFileTool.spec.ts
+++ b/src/core/tools/__tests__/editFileTool.spec.ts
@@ -560,7 +560,9 @@ describe("editFileTool", () => {
 
 			expect(mockTask.diffViewProvider.saveChanges).toHaveBeenCalled()
 			expect(mockTask.didEditFile).toBe(true)
-			expect(mockTask.recordToolUsage).toHaveBeenCalledWith("edit_file")
+			// Usage is recorded once at the central presentAssistantMessage
+			// attribution point, not locally by the handler.
+			expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
 		})
 
 		it("reverts changes when user rejects", async () => {

--- a/src/core/tools/__tests__/editTool.spec.ts
+++ b/src/core/tools/__tests__/editTool.spec.ts
@@ -345,7 +345,9 @@ describe("editTool", () => {
 
 			expect(mockTask.diffViewProvider.saveChanges).toHaveBeenCalled()
 			expect(mockTask.didEditFile).toBe(true)
-			expect(mockTask.recordToolUsage).toHaveBeenCalledWith("edit")
+			// Usage is recorded once at the central presentAssistantMessage
+			// attribution point, not locally by the handler.
+			expect(mockTask.recordToolUsage).not.toHaveBeenCalled()
 		})
 
 		it("reverts changes when user rejects", async () => {

--- a/src/core/tools/__tests__/generateImageTool.test.ts
+++ b/src/core/tools/__tests__/generateImageTool.test.ts
@@ -163,6 +163,9 @@ describe("generateImageTool", () => {
 			expect(mockAskApproval).toHaveBeenCalled()
 			expect(mockGenerateImage).toHaveBeenCalled()
 			expect(mockPushToolResult).toHaveBeenCalled()
+			// Usage is recorded once at the central presentAssistantMessage
+			// attribution point, not locally by the handler.
+			expect(mockCline.recordToolUsage).not.toHaveBeenCalled()
 		})
 
 		it("should add cache-busting parameter to image URI", async () => {

--- a/src/core/tools/__tests__/searchReplaceTool.spec.ts
+++ b/src/core/tools/__tests__/searchReplaceTool.spec.ts
@@ -314,7 +314,9 @@ describe("searchReplaceTool", () => {
 
 			expect(mockCline.diffViewProvider.saveChanges).toHaveBeenCalled()
 			expect(mockCline.didEditFile).toBe(true)
-			expect(mockCline.recordToolUsage).toHaveBeenCalledWith("search_replace")
+			// Usage is recorded once at the central presentAssistantMessage
+			// attribution point, not locally by the handler.
+			expect(mockCline.recordToolUsage).not.toHaveBeenCalled()
 		})
 
 		it("reverts changes when user rejects", async () => {

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -601,7 +601,7 @@
 	},
 	"core/assistant-message/presentAssistantMessage.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 7
+			"count": 3
 		}
 	},
 	"core/auto-approval/__tests__/AutoApprovalHandler.spec.ts": {

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -290,6 +290,7 @@ export const TOOL_DISPLAY_NAMES: Record<ToolName, string> = {
 	skill: "load skill",
 	generate_image: "generate images",
 	custom_tool: "use custom tools",
+	invalid_tool_call: "invalid tool call",
 } as const
 
 // Define available tool groups.


### PR DESCRIPTION
### Related GitHub Issue

Refs: #830 (tool-usage telemetry sanitization and single-point attribution half — split from #835; independent of #1069, #1070, #1071)

### Description

`presentAssistantMessage` already recorded most tool-usage attempts at one central point, but two gaps remained:

1. **Double-counted attempts.** Five tool handlers (`EditTool`, `EditFileTool`, `SearchReplaceTool`, `GenerateImageTool`, `ApplyPatchTool`) each called `task.recordToolUsage(...)` locally on success, on top of the central call in `presentAssistantMessage`. Every successful call through these tools counted as two attempts in `task.toolUsage`.
2. **Raw model-controlled tool names reaching telemetry.** Several `recordToolUsage`/`recordToolError` call sites keyed off `block.name` directly: the missing-`tool_use.id` path, the malformed-`nativeArgs` path, and the final "unknown tool" branch. A malicious or malformed tool name from the model could become an arbitrary `toolsUsed` property key.

This PR:

- Removes the five duplicate local `recordToolUsage` calls. Grepped every `recordToolUsage`/`recordToolError` call site first to confirm the central point in `presentAssistantMessage` covers each removed call before deleting it. `recordToolError` calls in these handlers are untouched — they're legitimate failure counts with no equivalent central coverage.
- Adds `toTelemetryToolName()` in `presentAssistantMessage.ts`, mapping any tool name to a safe analytics key before it can reach `recordToolUsage`/`recordToolError` or PostHog:
  - known static tools → their own name
  - registered custom tools → `custom_tool`
  - `mcp_`-prefixed dynamic tool names (valid or malformed) → `use_mcp_tool`
  - anything else (malformed calls, arbitrary/unknown names) → `invalid_tool_call`
- Applies the mapper at every remaining call site that previously used the raw name, including the missing-`id` and unknown-tool-name paths.
- Moves the central `recordToolUsage`/`captureToolUsage` call to fire only after `validateToolUse` succeeds, so a tool that fails validation records a failure (via the mapper), never a spurious success.
- Adds `invalid_tool_call` as a new static member of the `ToolName` union in `packages/types/src/tool.ts` (with a matching `TOOL_DISPLAY_NAMES` entry in `src/shared/tools.ts`) — the smallest self-contained type needed here, kept independent of #1071.

### Out of scope

Kept narrow to tool-usage attribution, per the split from #835:

- Task-completion aggregation / message-count logic (`Task.toolUsage` summarization into `Task Completed`) — in #1071, not assumed present here.
- Consent/privacy UI, banner, opt-in/opt-out defaults — in #1069.
- Telemetry service circuit breaker / shutdown draining — in #1070 (already merged).
- Model-cache changes, Bedrock/subtask e2e stabilization, general tool-framework cleanup.
- No changesets added.

### Test Procedure

- New `toTelemetryToolName.spec.ts`: static tool keeps its name, custom tool → `custom_tool`, valid and malformed `mcp_` names → `use_mcp_tool`, arbitrary unknown name → `invalid_tool_call`, and an explicit assertion that the raw name is never echoed back.
- New `presentAssistantMessage-tool-usage-attribution.spec.ts`: a normal static tool records exactly one attempt; valid/malformed `mcp_` names map correctly; a validation failure on a known tool records a failure under its own name (no success recorded); a validation failure on an arbitrary unknown name records `invalid_tool_call` and never the raw name.
- Updated `presentAssistantMessage-unknown-tool.spec.ts`: both the missing-id and unknown-tool-name paths now assert `recordToolError` is called with `invalid_tool_call`, not the raw model-supplied name.
- Updated `editTool.spec.ts`, `editFileTool.spec.ts`, `searchReplaceTool.spec.ts`: assert the handler itself no longer calls `recordToolUsage` on success, proving removal of the duplicate didn't lose the attempt (it's covered centrally instead).
- `pnpm check-types` clean repo-wide. `pnpm lint` clean on `src` and `@roo-code/types`, `eslint-suppressions.json` only decreases (7→3 for `presentAssistantMessage.ts`, from removing `any`-casts on the deleted raw-name paths) — no suppression count increased and no new suppression entries added.
- Narrowest suites: `core/assistant-message` + `core/tools` in `src` (591 tests) and `@roo-code/types` (268 tests), all passing.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes.
- [ ] **Visual Snapshot** (UI changes only): N/A — no UI changes.
- [x] **Documentation Impact**: No documentation updates required (no user-facing behavior change).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer handling and display for invalid or unrecognized tool calls.
  * Standardized tool activity and error reporting across built-in, custom, and MCP tools.

* **Bug Fixes**
  * Prevented malformed or unknown tool names from appearing directly in telemetry.
  * Improved attribution for validation failures and unsuccessful calls.
  * Ensured tool usage is recorded only after successful validation.

* **Tests**
  * Expanded coverage for tool attribution, MCP validation, unknown-tool handling, and editing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->