### PR TITLE
fix(webview): throttle state pushes to prevent gray screen OOM

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1044,8 +1044,11 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async addToClineMessages(message: ClineMessage) {
 		this.clineMessages.push(message)
 		const provider = this.providerRef.deref()
+		// Unanswered asks must reach the webview before Message listeners can respond against its state.
+		const requiresImmediateState =
+			message.partial === true || (message.type === "ask" && message.isAnswered !== true)
 		await provider?.postStateToWebviewThrottled()
-		if (message.partial === true) {
+		if (requiresImmediateState) {
 			await provider?.flushPostStateToWebviewThrottled()
 		}
 		this.emit(RooCodeEventName.Message, { action: "created", message })

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -551,12 +551,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			this.emit(RooCodeEventName.QueuedMessagesUpdated, this.taskId, this.messageQueueService.messages)
 			void this.providerRef
 				.deref()
-				?.postStateToWebviewWithoutTaskHistory()
+				?.postStateToWebviewThrottled()
 				.catch((error) => {
-					console.error(
-						"[Task#messageQueueStateChangedHandler] postStateToWebviewWithoutTaskHistory failed:",
-						error,
-					)
+					console.error("[Task#messageQueueStateChangedHandler] postStateToWebviewThrottled failed:", error)
 				})
 		}
 
@@ -1047,9 +1044,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async addToClineMessages(message: ClineMessage) {
 		this.clineMessages.push(message)
 		const provider = this.providerRef.deref()
-		// Avoid resending large, mostly-static fields (notably taskHistory) on every chat message update.
-		// taskHistory is maintained in-memory in the webview and updated via taskHistoryItemUpdated.
-		await provider?.postStateToWebviewWithoutTaskHistory()
+		await provider?.postStateToWebviewThrottled()
+		if (message.partial === true) {
+			await provider?.flushPostStateToWebviewThrottled()
+		}
 		this.emit(RooCodeEventName.Message, { action: "created", message })
 		await this.saveClineMessages()
 
@@ -2249,6 +2247,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		// Force final token usage update before abort event
 		this.emitFinalTokenUsageUpdate()
+
+		await this.providerRef.deref()?.flushPostStateToWebviewThrottled()
 
 		this.emit(RooCodeEventName.TaskAborted)
 

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -8,6 +8,7 @@ import { Anthropic } from "@anthropic-ai/sdk"
 
 import {
 	providerIdentifiers,
+	RooCodeEventName,
 	type GlobalState,
 	type ProviderSettings,
 	type ModelInfo,
@@ -1692,6 +1693,65 @@ describe("Cline", () => {
 			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
 			expect(mockProvider.flushPostStateToWebviewThrottled).not.toHaveBeenCalled()
 			expect(mockProvider.postStateToWebviewWithoutTaskHistory).not.toHaveBeenCalled()
+		})
+
+		it("waits for an unanswered ask flush before emitting the message", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+			vi.spyOn(taskAccess, "saveClineMessages").mockResolvedValue(true)
+			let releaseFlush!: () => void
+			const pendingFlush = new Promise<void>((resolve) => {
+				releaseFlush = resolve
+			})
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockReturnValueOnce(pendingFlush)
+			const messageListener = vi.fn()
+			task.on(RooCodeEventName.Message, messageListener)
+			const message = {
+				ts: 1,
+				type: "ask" as const,
+				ask: "resume_task" as const,
+			}
+
+			const addPromise = taskAccess.addToClineMessages(message)
+
+			await Promise.resolve()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(flushSpy).toHaveBeenCalledOnce()
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(messageListener).not.toHaveBeenCalled()
+
+			releaseFlush()
+			await addPromise
+
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(messageListener.mock.invocationCallOrder[0])
+			expect(messageListener).toHaveBeenCalledWith({ action: "created", message })
+		})
+
+		it("keeps an already answered ask on the throttled path", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			vi.spyOn(getTaskTestAccess(task), "saveClineMessages").mockResolvedValue(true)
+
+			await getTaskTestAccess(task).addToClineMessages({
+				ts: 1,
+				type: "ask",
+				ask: "tool",
+				isAnswered: true,
+			})
+
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.flushPostStateToWebviewThrottled).not.toHaveBeenCalled()
 		})
 
 		it("waits for a new partial message flush before a following message update", async () => {

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -30,6 +30,7 @@ type TaskTestAccess = {
 	startTask: (task?: string, images?: string[]) => Promise<void>
 	resumeTaskFromHistory: () => Promise<void>
 	presentAssistantMessageSafe: () => void
+	addToClineMessages: (message: import("@roo-code/types").ClineMessage) => Promise<void>
 	updateClineMessage: (message: import("@roo-code/types").ClineMessage) => Promise<void>
 	saveClineMessages: () => Promise<boolean>
 	safeEnsureModelFetched: () => Promise<void>
@@ -338,6 +339,8 @@ describe("Cline", () => {
 		mockProvider.postMessageToWebview = vi.fn().mockResolvedValue(undefined)
 		mockProvider.postStateToWebview = vi.fn().mockResolvedValue(undefined)
 		mockProvider.postStateToWebviewWithoutTaskHistory = vi.fn().mockResolvedValue(undefined)
+		mockProvider.postStateToWebviewThrottled = vi.fn().mockResolvedValue(undefined)
+		mockProvider.flushPostStateToWebviewThrottled = vi.fn().mockResolvedValue(undefined)
 		mockProvider.getTaskWithId = vi.fn().mockImplementation(async (id) => ({
 			historyItem: {
 				id,
@@ -1029,6 +1032,8 @@ describe("Cline", () => {
 					say: vi.fn(),
 					postStateToWebview: vi.fn().mockResolvedValue(undefined),
 					postStateToWebviewWithoutTaskHistory: vi.fn().mockResolvedValue(undefined),
+					postStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
+					flushPostStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
 					postMessageToWebview: vi.fn().mockResolvedValue(undefined),
 					updateTaskHistory: vi.fn().mockResolvedValue(undefined),
 				}
@@ -1663,6 +1668,78 @@ describe("Cline", () => {
 		})
 	})
 
+	describe("webview state throttling", () => {
+		it("schedules a complete new message without forcing an immediate state push", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			vi.spyOn(getTaskTestAccess(task), "saveClineMessages").mockResolvedValue(true)
+			const message = {
+				ts: Date.now(),
+				type: "say" as const,
+				say: "text" as const,
+				text: "message",
+			}
+
+			await getTaskTestAccess(task).addToClineMessages(message)
+
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.flushPostStateToWebviewThrottled).not.toHaveBeenCalled()
+			expect(mockProvider.postStateToWebviewWithoutTaskHistory).not.toHaveBeenCalled()
+		})
+
+		it("waits for a new partial message flush before a following message update", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+			vi.spyOn(taskAccess, "saveClineMessages").mockResolvedValue(true)
+			let releaseFlush!: () => void
+			const pendingFlush = new Promise<void>((resolve) => {
+				releaseFlush = resolve
+			})
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockReturnValueOnce(pendingFlush)
+			const updatePostSpy = vi.mocked(mockProvider.postMessageToWebview)
+			const partialMessage = {
+				ts: 1,
+				type: "say" as const,
+				say: "text" as const,
+				text: "partial message",
+				partial: true,
+			}
+			let partialAddSettled = false
+			const addThenUpdate = taskAccess.addToClineMessages(partialMessage).then(async () => {
+				partialAddSettled = true
+				await taskAccess.updateClineMessage({ ...partialMessage, text: "updated partial" })
+			})
+
+			await Promise.resolve()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(partialAddSettled).toBe(false)
+			expect(updatePostSpy).not.toHaveBeenCalled()
+
+			releaseFlush()
+			await addThenUpdate
+
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(updatePostSpy.mock.invocationCallOrder[0])
+			expect(updatePostSpy).toHaveBeenCalledWith({
+				type: "messageUpdated",
+				clineMessage: {
+					...partialMessage,
+					text: "updated partial",
+				},
+			})
+		})
+	})
+
 	describe("abortTask", () => {
 		it("should set abort flag and emit TaskAborted event", async () => {
 			const task = new Task({
@@ -1705,6 +1782,37 @@ describe("Cline", () => {
 			// Verify the same behavior as Cancel button
 			expect(task.abort).toBe(true)
 			expect(disposeSpy).toHaveBeenCalled()
+		})
+
+		it("flushes pending state before TaskAborted and disposal while queue state is intact", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			let queuedMessagesAtFlush = -1
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockImplementation(async () => {
+				queuedMessagesAtFlush = task.messageQueueService.messages.length
+			})
+			const emitSpy = vi.spyOn(task, "emit")
+			const disposeSpy = vi.spyOn(task, "dispose").mockImplementation(() => {})
+
+			task.messageQueueService.addMessage("queued text")
+			await task.abortTask()
+
+			const taskAbortedCallIndex = (emitSpy.mock.calls as unknown[][]).findIndex(
+				([event]) => event === "taskAborted",
+			)
+			expect(taskAbortedCallIndex).toBeGreaterThanOrEqual(0)
+			expect(queuedMessagesAtFlush).toBe(1)
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				emitSpy.mock.invocationCallOrder[taskAbortedCallIndex],
+			)
+			expect(emitSpy.mock.invocationCallOrder[taskAbortedCallIndex]).toBeLessThan(
+				disposeSpy.mock.invocationCallOrder[0],
+			)
 		})
 
 		it("should work with TaskLike interface", async () => {
@@ -2859,9 +2967,9 @@ describe("Cline", () => {
 			resumeSpy.mockRestore()
 		})
 
-		it("logs (instead of crashing) when postStateToWebviewWithoutTaskHistory rejects from the queue handler", async () => {
+		it("logs (instead of crashing) when postStateToWebviewThrottled rejects from the queue handler", async () => {
 			const boom = new Error("postState boom")
-			mockProvider.postStateToWebviewWithoutTaskHistory = vi.fn().mockRejectedValue(boom)
+			mockProvider.postStateToWebviewThrottled = vi.fn().mockRejectedValue(boom)
 
 			const task = new Task({
 				provider: mockProvider,
@@ -2870,13 +2978,14 @@ describe("Cline", () => {
 				startTask: false,
 			})
 
-			// Triggers messageQueueStateChangedHandler -> void postStateToWebviewWithoutTaskHistory()
+			// Triggers messageQueueStateChangedHandler -> void postStateToWebviewThrottled()
 			task.messageQueueService.addMessage("queued text")
 			await flushMicrotasks()
 
-			expect(mockProvider.postStateToWebviewWithoutTaskHistory).toHaveBeenCalled()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.postStateToWebviewWithoutTaskHistory).not.toHaveBeenCalled()
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[Task#messageQueueStateChangedHandler] postStateToWebviewWithoutTaskHistory failed:",
+				"[Task#messageQueueStateChangedHandler] postStateToWebviewThrottled failed:",
 				boom,
 			)
 		})

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -27,6 +27,8 @@ import type { ApiMessage } from "../../task-persistence"
 
 type TaskTestAccess = {
 	getSystemPrompt: () => Promise<string>
+	getEnabledMcpToolsCount: () => Promise<{ enabledToolCount: number; enabledServerCount: number }>
+	initiateTaskLoop: (userContent: Anthropic.Messages.ContentBlockParam[]) => Promise<void>
 	startTask: (task?: string, images?: string[]) => Promise<void>
 	resumeTaskFromHistory: () => Promise<void>
 	presentAssistantMessageSafe: () => void
@@ -2846,6 +2848,50 @@ describe("Cline", () => {
 			expect(safeSpy).toHaveBeenCalled()
 			expect(ensureModelFetched).toHaveBeenCalled()
 			expect(task.cachedStreamingModel?.id).toBe(mockApiConfig.apiModelId)
+		})
+	})
+
+	describe("startTask", () => {
+		it("posts a clean state immediately before adding the first task message", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "new task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+
+			task.clineMessages = [{ ts: 1, type: "say", say: "text", text: "stale message" }]
+
+			let resolvePostState: (() => void) | undefined
+			const pendingPostState = new Promise<void>((resolve) => {
+				resolvePostState = resolve
+			})
+			const postStateSpy = vi
+				.mocked(mockProvider.postStateToWebviewWithoutTaskHistory)
+				.mockImplementationOnce(async () => {
+					expect(task.clineMessages).toEqual([])
+					await pendingPostState
+				})
+			const saySpy = vi.spyOn(task, "say").mockResolvedValue(undefined)
+			vi.spyOn(taskAccess, "getEnabledMcpToolsCount").mockResolvedValue({
+				enabledToolCount: 0,
+				enabledServerCount: 0,
+			})
+			const initiateTaskLoopSpy = vi.spyOn(taskAccess, "initiateTaskLoop").mockResolvedValue(undefined)
+
+			const startPromise = taskAccess.startTask("new task")
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+			expect(mockProvider.postStateToWebviewThrottled).not.toHaveBeenCalled()
+			expect(saySpy).not.toHaveBeenCalled()
+
+			resolvePostState?.()
+			await startPromise
+
+			expect(saySpy).toHaveBeenCalledOnce()
+			expect(saySpy).toHaveBeenCalledWith("text", "new task", undefined)
+			expect(initiateTaskLoopSpy).toHaveBeenCalledOnce()
 		})
 	})
 

--- a/src/core/task/__tests__/Task.throttle.test.ts
+++ b/src/core/task/__tests__/Task.throttle.test.ts
@@ -79,6 +79,8 @@ describe("Task token usage throttling", () => {
 			log: vi.fn(),
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			postStateToWebviewWithoutTaskHistory: vi.fn().mockResolvedValue(undefined),
+			postStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
+			flushPostStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
 			updateTaskHistory: vi.fn().mockResolvedValue(undefined),
 		}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -6,6 +6,7 @@ import EventEmitter from "events"
 import { Anthropic } from "@anthropic-ai/sdk"
 import delay from "delay"
 import axios from "axios"
+import debounce from "lodash.debounce"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
 
@@ -188,6 +189,21 @@ export class ClineProvider
 	private taskEventListeners: WeakMap<Task, Array<() => void>> = new WeakMap()
 	private currentWorkspacePath: string | undefined
 	private _disposed = false
+	private readonly _postStateToWebviewThrottled = debounce(
+		async () => {
+			try {
+				await this.postStateToWebviewWithoutTaskHistory()
+			} catch (error) {
+				this.log(
+					`[ClineProvider#postStateToWebviewThrottled] Failed to post state: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				)
+			}
+		},
+		500,
+		{ leading: true, trailing: true, maxWait: 1000 },
+	)
 	private readonly rateLimitClock: RateLimitClock = createRateLimitClock()
 
 	private recentTasksCache?: string[]
@@ -689,6 +705,7 @@ export class ClineProvider
 		}
 
 		this._disposed = true
+		this._postStateToWebviewThrottled.cancel()
 		this.log("Disposing ClineProvider...")
 
 		// Reject any tasks still waiting for a scheduler permit so they don't
@@ -2176,6 +2193,22 @@ export class ClineProvider
 		state.clineMessagesSeq = this.clineMessagesSeq
 		const { taskHistory: _omit, ...rest } = state
 		await this.postMessageToWebview({ type: "state", state: rest })
+	}
+
+	async postStateToWebviewThrottled(): Promise<void> {
+		if (this._disposed) {
+			return
+		}
+
+		await this._postStateToWebviewThrottled()
+	}
+
+	async flushPostStateToWebviewThrottled(): Promise<void> {
+		if (this._disposed) {
+			return
+		}
+
+		await this._postStateToWebviewThrottled.flush()
 	}
 
 	/**

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -794,6 +794,125 @@ describe("ClineProvider", () => {
 		expect(postMessageSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "action" }))
 	})
 
+	test("postStateToWebviewWithoutTaskHistory waits for the webview post boundary", async () => {
+		let releasePost!: () => void
+		const pendingPost = new Promise<void>((resolve) => {
+			releasePost = resolve
+		})
+		let statePostSettled = false
+
+		vi.spyOn(provider, "getStateToPostToWebview").mockResolvedValue({
+			taskHistory: [],
+		} as unknown as ExtensionState)
+		const postMessageSpy = vi.spyOn(provider, "postMessageToWebview").mockReturnValue(pendingPost)
+
+		const statePost = provider.postStateToWebviewWithoutTaskHistory()
+		void statePost.then(() => {
+			statePostSettled = true
+		})
+		await Promise.resolve()
+
+		expect(postMessageSpy).toHaveBeenCalledOnce()
+		expect(statePostSettled).toBe(false)
+
+		releasePost()
+		await statePost
+		expect(statePostSettled).toBe(true)
+	})
+
+	describe("postStateToWebviewThrottled", () => {
+		beforeEach(() => {
+			vi.useFakeTimers()
+		})
+
+		afterEach(async () => {
+			await provider.dispose()
+			vi.useRealTimers()
+		})
+
+		test("posts on the leading edge and coalesces a burst into one trailing post", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(499)
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("does not starve state posts during continuous updates", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(400)
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(400)
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(199)
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("flushes a pending trailing post exactly once", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await provider.flushPostStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+
+			await vi.advanceTimersByTimeAsync(1000)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("does not duplicate an idle leading post when flushed", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.flushPostStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(1000)
+
+			expect(postStateSpy).toHaveBeenCalledOnce()
+		})
+
+		test("handles state post failures inside the debounced callback", async () => {
+			const error = new Error("state post failed")
+			const logSpy = vi.spyOn(provider, "log").mockImplementation(() => {})
+			vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockRejectedValue(error)
+
+			await expect(provider.postStateToWebviewThrottled()).resolves.toBeUndefined()
+			expect(logSpy).toHaveBeenCalledWith(
+				"[ClineProvider#postStateToWebviewThrottled] Failed to post state: state post failed",
+			)
+		})
+
+		test("cancels pending work on dispose and ignores later schedule or flush calls", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await provider.dispose()
+			await vi.advanceTimersByTimeAsync(1000)
+			await provider.postStateToWebviewThrottled()
+			await provider.flushPostStateToWebviewThrottled()
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+		})
+	})
+
 	test("postMessageToWebview skips postMessage after dispose", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -897,6 +897,16 @@ describe("ClineProvider", () => {
 			)
 		})
 
+		test("stringifies non-Error state post failures inside the debounced callback", async () => {
+			const logSpy = vi.spyOn(provider, "log").mockImplementation(() => {})
+			vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockRejectedValue("state post failed")
+
+			await expect(provider.postStateToWebviewThrottled()).resolves.toBeUndefined()
+			expect(logSpy).toHaveBeenCalledWith(
+				"[ClineProvider#postStateToWebviewThrottled] Failed to post state: state post failed",
+			)
+		})
+
 		test("cancels pending work on dispose and ignores later schedule or flush calls", async () => {
 			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,4 +1,13 @@
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react"
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react"
 import { useDeepCompareEffect, useEvent } from "react-use"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import removeMd from "remove-markdown"
@@ -76,6 +85,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	const {
 		clineMessages: messages,
+		currentTaskId,
 		currentTaskItem,
 		currentTaskTodos,
 		taskHistory,
@@ -102,6 +112,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}, [providerName])
 
 	const messagesRef = useRef(messages)
+	const currentTaskIdRef = useRef(currentTaskId)
+
+	useLayoutEffect(() => {
+		currentTaskIdRef.current = currentTaskId
+	}, [currentTaskId])
 
 	useEffect(() => {
 		messagesRef.current = messages
@@ -513,13 +528,14 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		everVisibleMessagesTsRef.current.clear()
 		setCurrentFollowUpTs(null)
 		setIsCondensing(false)
+		setAggregatedCostsMap(new Map())
 
 		if (autoApproveTimeoutRef.current) {
 			clearTimeout(autoApproveTimeoutRef.current)
 			autoApproveTimeoutRef.current = null
 		}
 		userRespondedRef.current = false
-	}, [task?.ts])
+	}, [currentTaskId])
 
 	const taskTs = task?.ts
 
@@ -937,7 +953,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					// Handle both manual and automatic condensation start
 					// We don't check the task ID because:
 					// 1. There can only be one active task at a time
-					// 2. Task switching resets isCondensing to false (see useEffect with task?.ts dependency)
+					// 2. Task switching resets isCondensing to false (see useEffect with currentTaskId dependency)
 					// 3. For new tasks, currentTaskItem may not be populated yet due to async state updates
 					if (message.text) {
 						setIsCondensing(true)
@@ -961,12 +977,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					playSound("notification")
 					break
 				case "taskWithAggregatedCosts":
-					if (message.text && message.aggregatedCosts) {
-						setAggregatedCostsMap((prev) => {
-							const newMap = new Map(prev)
-							newMap.set(message.text!, message.aggregatedCosts!)
-							return newMap
-						})
+					if (message.text && message.text === currentTaskIdRef.current && message.aggregatedCosts) {
+						setAggregatedCostsMap(new Map([[message.text, message.aggregatedCosts]]))
 					}
 					break
 			}
@@ -1612,6 +1624,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}
 
 	const areButtonsVisible = showScrollToBottom || primaryButtonText || secondaryButtonText
+	const currentTaskAggregatedCosts = currentTaskId ? aggregatedCostsMap.get(currentTaskId) : undefined
 
 	return (
 		<div
@@ -1639,22 +1652,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						cacheWrites={apiMetrics.totalCacheWrites}
 						cacheReads={apiMetrics.totalCacheReads}
 						totalCost={apiMetrics.totalCost}
-						aggregatedCost={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? aggregatedCostsMap.get(currentTaskItem.id)!.totalCost
-								: undefined
-						}
-						hasSubtasks={
-							!!(
-								currentTaskItem?.id &&
-								aggregatedCostsMap.has(currentTaskItem.id) &&
-								aggregatedCostsMap.get(currentTaskItem.id)!.childrenCost > 0
-							)
-						}
+						aggregatedCost={currentTaskAggregatedCosts?.totalCost}
+						hasSubtasks={(currentTaskAggregatedCosts?.childrenCost ?? 0) > 0}
 						parentTaskId={currentTaskItem?.parentTaskId}
 						costBreakdown={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? getCostBreakdownIfNeeded(aggregatedCostsMap.get(currentTaskItem.id)!, {
+							currentTaskAggregatedCosts
+								? getCostBreakdownIfNeeded(currentTaskAggregatedCosts, {
 										own: t("common:costs.own"),
 										subtasks: t("common:costs.subtasks"),
 									})

--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -86,6 +86,25 @@ vi.mock("../ChatRow", () => ({
 	},
 }))
 
+const mockTaskHeaderState = vi.hoisted(() => ({
+	renders: [] as Array<{ taskId?: string; aggregatedCost?: number }>,
+}))
+
+vi.mock("../TaskHeader", () => ({
+	default: function MockTaskHeader({ task, aggregatedCost }: { task: ClineMessage; aggregatedCost?: number }) {
+		mockTaskHeaderState.renders.push({ taskId: task.text, aggregatedCost })
+
+		return (
+			<div
+				data-aggregated-cost={aggregatedCost ?? ""}
+				data-task-id={task.text}
+				data-task-ts={task.ts}
+				data-testid="task-header"
+			/>
+		)
+	},
+}))
+
 vi.mock("../AutoApproveMenu", () => ({
 	default: () => null,
 }))
@@ -331,6 +350,54 @@ const mockPostMessage = (state: Partial<ExtensionState>) => {
 	)
 }
 
+const dispatchExtensionMessage = async (data: Record<string, unknown>) => {
+	await act(async () => {
+		window.dispatchEvent(new MessageEvent("message", { data }))
+	})
+}
+
+const dispatchTaskState = async (id: string, taskTs: number, childIds: string[] = []) => {
+	await dispatchExtensionMessage({
+		type: "state",
+		state: {
+			version: "1.0.0",
+			clineMessages: [
+				{
+					type: "say",
+					say: "task",
+					ts: taskTs,
+					text: id,
+				},
+			],
+			currentTaskId: id,
+			currentTaskItem: {
+				id,
+				ts: taskTs,
+				task: id,
+				childIds,
+			},
+			taskHistory: [],
+			shouldShowAnnouncement: false,
+			allowedCommands: [],
+			alwaysAllowExecute: false,
+			cloudIsAuthenticated: false,
+			telemetrySetting: "enabled",
+		},
+	})
+}
+
+const dispatchAggregatedCosts = async (taskId: string, totalCost: number) => {
+	await dispatchExtensionMessage({
+		type: "taskWithAggregatedCosts",
+		text: taskId,
+		aggregatedCosts: {
+			totalCost,
+			ownCost: 1,
+			childrenCost: totalCost - 1,
+		},
+	})
+}
+
 const defaultProps: ChatViewProps = {
 	isHidden: false,
 	showAnnouncement: false,
@@ -348,6 +415,65 @@ const renderChatView = (props: Partial<ChatViewProps> = {}) => {
 		</ExtensionStateContextProvider>,
 	)
 }
+
+describe("ChatView - Aggregated Costs Lifecycle", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockTaskHeaderState.renders.length = 0
+	})
+
+	it("clears cached aggregated costs when switching tasks", async () => {
+		const { getByTestId } = renderChatView()
+
+		await dispatchTaskState("task-a", 1_000, ["child-a"])
+		await dispatchAggregatedCosts("task-a", 9)
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "9")
+		})
+
+		// Use the same message timestamp to prove task identity, rather than task.ts,
+		// drives the reset.
+		await dispatchTaskState("task-b", 1_000)
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-b")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		await dispatchTaskState("task-a", 1_000, ["child-a"])
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-a")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+	})
+
+	it("rejects a delayed aggregated-cost response from the previous task", async () => {
+		const { getByTestId } = renderChatView()
+
+		await dispatchTaskState("task-a", 1_001, ["child-a"])
+		await dispatchTaskState("task-b", 2_001)
+		await dispatchAggregatedCosts("task-a", 13)
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-b")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		mockTaskHeaderState.renders.length = 0
+		await dispatchTaskState("task-a", 1_001, ["child-a"])
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-a")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		expect(
+			mockTaskHeaderState.renders.some(
+				({ taskId, aggregatedCost }) => taskId === "task-a" && aggregatedCost === 13,
+			),
+		).toBe(false)
+	})
+})
 
 describe("ChatView - Sound Playing Tests", () => {
 	beforeEach(() => vi.clearAllMocks())


### PR DESCRIPTION
### Related GitHub Issue

Closes: #629

### Description

This PR reduces full-state webview churn during long-running tasks with large message histories. The hot paths previously serialized and posted the complete message array for every message addition and queue-state change, producing repeated multi-megabyte snapshots at the message count reported in #629.

- Adds a provider-scoped 500 ms leading/trailing debounce with a 1 second maximum wait for full state updates that omit task history.
- Routes new-message additions and message-queue state changes through the throttled path while keeping task start, API boundaries, and stream completion immediate.
- Flushes pending state before the first lightweight update for a newly created partial message and before task abort, and cancels pending work when the provider is disposed.
- Logs rejected throttled state schedules and flushes without interrupting message persistence or task-abort cleanup.
- Clears aggregated task costs when the active task changes and ignores delayed cost responses for inactive tasks.

Partial streaming continues to use the existing lightweight `messageUpdated` path. The change coalesces high-frequency full snapshots without changing the webview message protocol or task lifecycle. Reviewers should pay particular attention to full-state/lightweight-message ordering and the rejection paths around persistence and abort cleanup.

### Test Procedure

Run the focused regression tests:

```sh
pnpm --dir src exec vitest run \
  core/webview/__tests__/ClineProvider.spec.ts \
  core/task/__tests__/Task.spec.ts \
  core/task/__tests__/Task.throttle.test.ts

pnpm --dir webview-ui exec vitest run \
  src/components/chat/__tests__/ChatView.spec.tsx
```

Run the repository validation commands:

```sh
pnpm test
pnpm check-types
pnpm lint
```

Local results:

- Extension regression tests: 3 files and 220 tests passed.
- ChatView regression tests: 1 file and 26 tests passed.
- Full webview UI suite: 142 files and 1,559 tests passed.
- Full repository test run: 10 test tasks passed.
- Type checks: 11 package tasks passed.
- Lint: 11 package tasks passed.

The regression tests cover:

- Leading/trailing coalescing and the 1 second maximum wait.
- Explicit flush behavior, provider disposal, and scheduling/flush rejection handling.
- Throttled message and message-queue updates.
- Ordering between a new partial message and subsequent `messageUpdated` delivery.
- Immediate clean-state delivery at task start.
- Final-state delivery and cleanup continuity when task abort encounters a state-push failure.
- Message persistence continuity when throttled state scheduling fails.
- Aggregated-cost cleanup on task switch and rejection of delayed responses from an inactive task.

Manual stress verification:

1. Load 3,525 messages of approximately 2 KB each into an actual VS Code webview.
2. Exercise rapid full-state update requests against a state payload of approximately 7.22 MB.
3. Confirm that burst updates are coalesced and the renderer remains responsive to an extension/webview round trip.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Visual Snapshot** (UI changes only): Not applicable; this is a behavior-only change with no static visual changes.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

Not applicable. This change does not alter static visual output.

### Videos (interaction / animation only)

Not applicable. This change does not add or alter a visible interaction or animation.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

### Additional Notes

This PR intentionally addresses the frequency of large full-state pushes. Redesigning message delivery to eliminate the O(N) payload itself is outside the scope of #629.

The manual stress run verified webview renderer survival and responsiveness at the reported message count. It did not record an absolute V8 heap measurement.

### Get in Touch

<!-- Add your Discord username here. -->
