### PR TITLE
fix(webview): throttle state pushes to prevent gray screen OOM

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1037,9 +1037,17 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// Unanswered asks must reach the webview before Message listeners can respond against its state.
 		const requiresImmediateState =
 			message.partial === true || (message.type === "ask" && message.isAnswered !== true)
-		await provider?.postStateToWebviewThrottled()
+		try {
+			await provider?.postStateToWebviewThrottled()
+		} catch (error) {
+			console.error("[Task#addToClineMessages] postStateToWebviewThrottled failed:", error)
+		}
 		if (requiresImmediateState) {
-			await provider?.flushPostStateToWebviewThrottled()
+			try {
+				await provider?.flushPostStateToWebviewThrottled()
+			} catch (error) {
+				console.error("[Task#addToClineMessages] flushPostStateToWebviewThrottled failed:", error)
+			}
 		}
 		this.emit(RooCodeEventName.Message, { action: "created", message })
 		await this.saveClineMessages()
@@ -2251,7 +2259,14 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// Force final token usage update before abort event
 		this.emitFinalTokenUsageUpdate()
 
-		await this.providerRef.deref()?.flushPostStateToWebviewThrottled()
+		try {
+			await this.providerRef.deref()?.flushPostStateToWebviewThrottled()
+		} catch (error) {
+			console.error(
+				`[Task#abortTask] flushPostStateToWebviewThrottled failed for ${this.taskId}.${this.instanceId}:`,
+				error,
+			)
+		}
 
 		this.emit(RooCodeEventName.TaskAborted)
 

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -570,12 +570,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			this.emit(RooCodeEventName.QueuedMessagesUpdated, this.taskId, this.messageQueueService.messages)
 			void this.providerRef
 				.deref()
-				?.postStateToWebviewWithoutTaskHistory()
+				?.postStateToWebviewThrottled()
 				.catch((error) => {
-					console.error(
-						"[Task#messageQueueStateChangedHandler] postStateToWebviewWithoutTaskHistory failed:",
-						error,
-					)
+					console.error("[Task#messageQueueStateChangedHandler] postStateToWebviewThrottled failed:", error)
 				})
 		}
 
@@ -1037,9 +1034,13 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async addToClineMessages(message: ClineMessage) {
 		this.clineMessages.push(message)
 		const provider = this.providerRef.deref()
-		// Avoid resending large, mostly-static fields (notably taskHistory) on every chat message update.
-		// taskHistory is maintained in-memory in the webview and updated via taskHistoryItemUpdated.
-		await provider?.postStateToWebviewWithoutTaskHistory()
+		// Unanswered asks must reach the webview before Message listeners can respond against its state.
+		const requiresImmediateState =
+			message.partial === true || (message.type === "ask" && message.isAnswered !== true)
+		await provider?.postStateToWebviewThrottled()
+		if (requiresImmediateState) {
+			await provider?.flushPostStateToWebviewThrottled()
+		}
 		this.emit(RooCodeEventName.Message, { action: "created", message })
 		await this.saveClineMessages()
 
@@ -2249,6 +2250,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		// Force final token usage update before abort event
 		this.emitFinalTokenUsageUpdate()
+
+		await this.providerRef.deref()?.flushPostStateToWebviewThrottled()
 
 		this.emit(RooCodeEventName.TaskAborted)
 

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -1986,6 +1986,49 @@ describe("Cline", () => {
 			expect(messageListener).toHaveBeenCalledWith({ action: "created", message })
 		})
 
+		it("continues the message lifecycle when throttled state scheduling and flushing fail", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+			const postError = new Error("state schedule failed")
+			const flushError = new Error("state flush failed")
+			const postSpy = vi.mocked(mockProvider.postStateToWebviewThrottled).mockRejectedValueOnce(postError)
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockRejectedValueOnce(flushError)
+			const saveSpy = vi.spyOn(taskAccess, "saveClineMessages").mockResolvedValue(true)
+			const messageListener = vi.fn()
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+			task.on(RooCodeEventName.Message, messageListener)
+			const message = {
+				ts: 1,
+				type: "ask" as const,
+				ask: "resume_task" as const,
+			}
+
+			await expect(taskAccess.addToClineMessages(message)).resolves.toBeUndefined()
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"[Task#addToClineMessages] postStateToWebviewThrottled failed:",
+				postError,
+			)
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"[Task#addToClineMessages] flushPostStateToWebviewThrottled failed:",
+				flushError,
+			)
+			expect(postSpy).toHaveBeenCalledOnce()
+			expect(flushSpy).toHaveBeenCalledOnce()
+			expect(messageListener).toHaveBeenCalledWith({ action: "created", message })
+			expect(saveSpy).toHaveBeenCalledOnce()
+			expect(postSpy.mock.invocationCallOrder[0]).toBeLessThan(flushSpy.mock.invocationCallOrder[0])
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(messageListener.mock.invocationCallOrder[0])
+			expect(messageListener.mock.invocationCallOrder[0]).toBeLessThan(saveSpy.mock.invocationCallOrder[0])
+
+			consoleErrorSpy.mockRestore()
+		})
+
 		it("keeps an already answered ask on the throttled path", async () => {
 			const task = new Task({
 				provider: mockProvider,
@@ -2128,6 +2171,38 @@ describe("Cline", () => {
 			expect(emitSpy.mock.invocationCallOrder[taskAbortedCallIndex]).toBeLessThan(
 				disposeSpy.mock.invocationCallOrder[0],
 			)
+		})
+
+		it("continues abort cleanup when flushing pending state fails", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const error = new Error("state flush failed")
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockRejectedValueOnce(error)
+			const taskAbortedListener = vi.fn()
+			const disposeSpy = vi.spyOn(task, "dispose").mockImplementation(() => {})
+			const saveSpy = vi.spyOn(getTaskTestAccess(task), "saveClineMessages").mockResolvedValue(true)
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+			task.on(RooCodeEventName.TaskAborted, taskAbortedListener)
+
+			await expect(task.abortTask()).resolves.toBeUndefined()
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				`[Task#abortTask] flushPostStateToWebviewThrottled failed for ${task.taskId}.${task.instanceId}:`,
+				error,
+			)
+			expect(task.abort).toBe(true)
+			expect(flushSpy).toHaveBeenCalledOnce()
+			expect(taskAbortedListener).toHaveBeenCalledOnce()
+			expect(disposeSpy).toHaveBeenCalledOnce()
+			expect(saveSpy).toHaveBeenCalledOnce()
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(taskAbortedListener.mock.invocationCallOrder[0])
+			expect(taskAbortedListener.mock.invocationCallOrder[0]).toBeLessThan(disposeSpy.mock.invocationCallOrder[0])
+
+			consoleErrorSpy.mockRestore()
 		})
 
 		it("should work with TaskLike interface", async () => {

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -9,6 +9,7 @@ import type { Mock } from "vitest"
 
 import {
 	providerIdentifiers,
+	RooCodeEventName,
 	type GlobalState,
 	type ProviderSettings,
 	type ModelInfo,
@@ -29,9 +30,12 @@ import type { ApiMessage } from "../../task-persistence"
 
 type TaskTestAccess = {
 	getSystemPrompt: () => Promise<string>
+	getEnabledMcpToolsCount: () => Promise<{ enabledToolCount: number; enabledServerCount: number }>
+	initiateTaskLoop: (userContent: Anthropic.Messages.ContentBlockParam[]) => Promise<void>
 	startTask: (task?: string, images?: string[]) => Promise<void>
 	resumeTaskFromHistory: () => Promise<void>
 	presentAssistantMessageSafe: () => void
+	addToClineMessages: (message: import("@roo-code/types").ClineMessage) => Promise<void>
 	updateClineMessage: (message: import("@roo-code/types").ClineMessage) => Promise<void>
 	saveClineMessages: () => Promise<boolean>
 	safeEnsureModelFetched: () => Promise<void>
@@ -362,6 +366,8 @@ describe("Cline", () => {
 		mockProvider.postMessageToWebview = vi.fn().mockResolvedValue(undefined)
 		mockProvider.postStateToWebview = vi.fn().mockResolvedValue(undefined)
 		mockProvider.postStateToWebviewWithoutTaskHistory = vi.fn().mockResolvedValue(undefined)
+		mockProvider.postStateToWebviewThrottled = vi.fn().mockResolvedValue(undefined)
+		mockProvider.flushPostStateToWebviewThrottled = vi.fn().mockResolvedValue(undefined)
 		mockProvider.getTaskWithId = vi.fn().mockImplementation(async (id) => ({
 			historyItem: {
 				id,
@@ -1227,6 +1233,8 @@ describe("Cline", () => {
 					say: vi.fn(),
 					postStateToWebview: vi.fn().mockResolvedValue(undefined),
 					postStateToWebviewWithoutTaskHistory: vi.fn().mockResolvedValue(undefined),
+					postStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
+					flushPostStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
 					postMessageToWebview: vi.fn().mockResolvedValue(undefined),
 					updateTaskHistory: vi.fn().mockResolvedValue(undefined),
 					// Task receives a full ClineProvider at runtime; this focused unit test only exercises these methods.
@@ -1916,6 +1924,137 @@ describe("Cline", () => {
 		})
 	})
 
+	describe("webview state throttling", () => {
+		it("schedules a complete new message without forcing an immediate state push", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			vi.spyOn(getTaskTestAccess(task), "saveClineMessages").mockResolvedValue(true)
+			const message = {
+				ts: Date.now(),
+				type: "say" as const,
+				say: "text" as const,
+				text: "message",
+			}
+
+			await getTaskTestAccess(task).addToClineMessages(message)
+
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.flushPostStateToWebviewThrottled).not.toHaveBeenCalled()
+			expect(mockProvider.postStateToWebviewWithoutTaskHistory).not.toHaveBeenCalled()
+		})
+
+		it("waits for an unanswered ask flush before emitting the message", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+			vi.spyOn(taskAccess, "saveClineMessages").mockResolvedValue(true)
+			let releaseFlush!: () => void
+			const pendingFlush = new Promise<void>((resolve) => {
+				releaseFlush = resolve
+			})
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockReturnValueOnce(pendingFlush)
+			const messageListener = vi.fn()
+			task.on(RooCodeEventName.Message, messageListener)
+			const message = {
+				ts: 1,
+				type: "ask" as const,
+				ask: "resume_task" as const,
+			}
+
+			const addPromise = taskAccess.addToClineMessages(message)
+
+			await Promise.resolve()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(flushSpy).toHaveBeenCalledOnce()
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(messageListener).not.toHaveBeenCalled()
+
+			releaseFlush()
+			await addPromise
+
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(messageListener.mock.invocationCallOrder[0])
+			expect(messageListener).toHaveBeenCalledWith({ action: "created", message })
+		})
+
+		it("keeps an already answered ask on the throttled path", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			vi.spyOn(getTaskTestAccess(task), "saveClineMessages").mockResolvedValue(true)
+
+			await getTaskTestAccess(task).addToClineMessages({
+				ts: 1,
+				type: "ask",
+				ask: "tool",
+				isAnswered: true,
+			})
+
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledOnce()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.flushPostStateToWebviewThrottled).not.toHaveBeenCalled()
+		})
+
+		it("waits for a new partial message flush before a following message update", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+			vi.spyOn(taskAccess, "saveClineMessages").mockResolvedValue(true)
+			let releaseFlush!: () => void
+			const pendingFlush = new Promise<void>((resolve) => {
+				releaseFlush = resolve
+			})
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockReturnValueOnce(pendingFlush)
+			const updatePostSpy = vi.mocked(mockProvider.postMessageToWebview)
+			const partialMessage = {
+				ts: 1,
+				type: "say" as const,
+				say: "text" as const,
+				text: "partial message",
+				partial: true,
+			}
+			let partialAddSettled = false
+			const addThenUpdate = taskAccess.addToClineMessages(partialMessage).then(async () => {
+				partialAddSettled = true
+				await taskAccess.updateClineMessage({ ...partialMessage, text: "updated partial" })
+			})
+
+			await Promise.resolve()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(partialAddSettled).toBe(false)
+			expect(updatePostSpy).not.toHaveBeenCalled()
+
+			releaseFlush()
+			await addThenUpdate
+
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(updatePostSpy.mock.invocationCallOrder[0])
+			expect(updatePostSpy).toHaveBeenCalledWith({
+				type: "messageUpdated",
+				clineMessage: {
+					...partialMessage,
+					text: "updated partial",
+				},
+			})
+		})
+	})
+
 	describe("abortTask", () => {
 		it("should set abort flag and emit TaskAborted event", async () => {
 			const task = new Task({
@@ -1958,6 +2097,37 @@ describe("Cline", () => {
 			// Verify the same behavior as Cancel button
 			expect(task.abort).toBe(true)
 			expect(disposeSpy).toHaveBeenCalled()
+		})
+
+		it("flushes pending state before TaskAborted and disposal while queue state is intact", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			let queuedMessagesAtFlush = -1
+			const flushSpy = vi.mocked(mockProvider.flushPostStateToWebviewThrottled).mockImplementation(async () => {
+				queuedMessagesAtFlush = task.messageQueueService.messages.length
+			})
+			const emitSpy = vi.spyOn(task, "emit")
+			const disposeSpy = vi.spyOn(task, "dispose").mockImplementation(() => {})
+
+			task.messageQueueService.addMessage("queued text")
+			await task.abortTask()
+
+			const taskAbortedCallIndex = (emitSpy.mock.calls as unknown[][]).findIndex(
+				([event]) => event === "taskAborted",
+			)
+			expect(taskAbortedCallIndex).toBeGreaterThanOrEqual(0)
+			expect(queuedMessagesAtFlush).toBe(1)
+			expect(flushSpy).toHaveBeenCalledWith()
+			expect(flushSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				emitSpy.mock.invocationCallOrder[taskAbortedCallIndex],
+			)
+			expect(emitSpy.mock.invocationCallOrder[taskAbortedCallIndex]).toBeLessThan(
+				disposeSpy.mock.invocationCallOrder[0],
+			)
 		})
 
 		it("should work with TaskLike interface", async () => {
@@ -3000,6 +3170,50 @@ describe("Cline", () => {
 		})
 	})
 
+	describe("startTask", () => {
+		it("posts a clean state immediately before adding the first task message", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "new task",
+				startTask: false,
+			})
+			const taskAccess = getTaskTestAccess(task)
+
+			task.clineMessages = [{ ts: 1, type: "say", say: "text", text: "stale message" }]
+
+			let resolvePostState: (() => void) | undefined
+			const pendingPostState = new Promise<void>((resolve) => {
+				resolvePostState = resolve
+			})
+			const postStateSpy = vi
+				.mocked(mockProvider.postStateToWebviewWithoutTaskHistory)
+				.mockImplementationOnce(async () => {
+					expect(task.clineMessages).toEqual([])
+					await pendingPostState
+				})
+			const saySpy = vi.spyOn(task, "say").mockResolvedValue(undefined)
+			vi.spyOn(taskAccess, "getEnabledMcpToolsCount").mockResolvedValue({
+				enabledToolCount: 0,
+				enabledServerCount: 0,
+			})
+			const initiateTaskLoopSpy = vi.spyOn(taskAccess, "initiateTaskLoop").mockResolvedValue(undefined)
+
+			const startPromise = taskAccess.startTask("new task")
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+			expect(mockProvider.postStateToWebviewThrottled).not.toHaveBeenCalled()
+			expect(saySpy).not.toHaveBeenCalled()
+
+			resolvePostState?.()
+			await startPromise
+
+			expect(saySpy).toHaveBeenCalledOnce()
+			expect(saySpy).toHaveBeenCalledWith("text", "new task", undefined)
+			expect(initiateTaskLoopSpy).toHaveBeenCalledOnce()
+		})
+	})
+
 	describe("start()", () => {
 		it("should be a no-op if the task was already started in the constructor", () => {
 			const task = new Task({
@@ -3118,9 +3332,9 @@ describe("Cline", () => {
 			resumeSpy.mockRestore()
 		})
 
-		it("logs (instead of crashing) when postStateToWebviewWithoutTaskHistory rejects from the queue handler", async () => {
+		it("logs (instead of crashing) when postStateToWebviewThrottled rejects from the queue handler", async () => {
 			const boom = new Error("postState boom")
-			mockProvider.postStateToWebviewWithoutTaskHistory = vi.fn().mockRejectedValue(boom)
+			mockProvider.postStateToWebviewThrottled = vi.fn().mockRejectedValue(boom)
 
 			const task = new Task({
 				provider: mockProvider,
@@ -3129,13 +3343,14 @@ describe("Cline", () => {
 				startTask: false,
 			})
 
-			// Triggers messageQueueStateChangedHandler -> void postStateToWebviewWithoutTaskHistory()
+			// Triggers messageQueueStateChangedHandler -> void postStateToWebviewThrottled()
 			task.messageQueueService.addMessage("queued text")
 			await flushMicrotasks()
 
-			expect(mockProvider.postStateToWebviewWithoutTaskHistory).toHaveBeenCalled()
+			expect(mockProvider.postStateToWebviewThrottled).toHaveBeenCalledWith()
+			expect(mockProvider.postStateToWebviewWithoutTaskHistory).not.toHaveBeenCalled()
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				"[Task#messageQueueStateChangedHandler] postStateToWebviewWithoutTaskHistory failed:",
+				"[Task#messageQueueStateChangedHandler] postStateToWebviewThrottled failed:",
 				boom,
 			)
 		})

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -2160,7 +2160,7 @@ describe("Cline", () => {
 			await task.abortTask()
 
 			const taskAbortedCallIndex = (emitSpy.mock.calls as unknown[][]).findIndex(
-				([event]) => event === "taskAborted",
+				([event]) => event === RooCodeEventName.TaskAborted,
 			)
 			expect(taskAbortedCallIndex).toBeGreaterThanOrEqual(0)
 			expect(queuedMessagesAtFlush).toBe(1)

--- a/src/core/task/__tests__/Task.throttle.test.ts
+++ b/src/core/task/__tests__/Task.throttle.test.ts
@@ -79,6 +79,8 @@ describe("Task token usage throttling", () => {
 			log: vi.fn(),
 			postStateToWebview: vi.fn().mockResolvedValue(undefined),
 			postStateToWebviewWithoutTaskHistory: vi.fn().mockResolvedValue(undefined),
+			postStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
+			flushPostStateToWebviewThrottled: vi.fn().mockResolvedValue(undefined),
 			updateTaskHistory: vi.fn().mockResolvedValue(undefined),
 		}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -6,6 +6,7 @@ import EventEmitter from "events"
 import { Anthropic } from "@anthropic-ai/sdk"
 import delay from "delay"
 import axios from "axios"
+import debounce from "lodash.debounce"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
 
@@ -189,6 +190,21 @@ export class ClineProvider
 	private taskEventListeners: WeakMap<Task, Array<() => void>> = new WeakMap()
 	private currentWorkspacePath: string | undefined
 	private _disposed = false
+	private readonly _postStateToWebviewThrottled = debounce(
+		async () => {
+			try {
+				await this.postStateToWebviewWithoutTaskHistory()
+			} catch (error) {
+				this.log(
+					`[ClineProvider#postStateToWebviewThrottled] Failed to post state: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				)
+			}
+		},
+		500,
+		{ leading: true, trailing: true, maxWait: 1000 },
+	)
 	private readonly rateLimitClock: RateLimitClock = createRateLimitClock()
 
 	private recentTasksCache?: string[]
@@ -746,6 +762,7 @@ export class ClineProvider
 		}
 
 		this._disposed = true
+		this._postStateToWebviewThrottled.cancel()
 		this.log("Disposing ClineProvider...")
 
 		// Reject any tasks still waiting for a scheduler permit so they don't
@@ -2291,6 +2308,22 @@ export class ClineProvider
 		state.clineMessagesSeq = this.clineMessagesSeq
 		const { taskHistory: _omit, ...rest } = state
 		await this.postMessageToWebview({ type: "state", state: rest })
+	}
+
+	async postStateToWebviewThrottled(): Promise<void> {
+		if (this._disposed) {
+			return
+		}
+
+		await this._postStateToWebviewThrottled()
+	}
+
+	async flushPostStateToWebviewThrottled(): Promise<void> {
+		if (this._disposed) {
+			return
+		}
+
+		await this._postStateToWebviewThrottled.flush()
 	}
 
 	/**

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -162,6 +162,10 @@ function scheduleTask(scheduler: TaskScheduler, task: Task, source: string): voi
 		.catch((error) => console.error(`[${source}] taskScheduler.schedule failed:`, error))
 }
 
+type GetStateOptions = {
+	includeTaskHistory?: boolean
+}
+
 export class ClineProvider
 	extends EventEmitter<TaskProviderEvents>
 	implements vscode.WebviewViewProvider, TelemetryPropertiesProvider, TaskProviderLike
@@ -2303,7 +2307,7 @@ export class ClineProvider
 	 *   `taskHistoryUpdated` / `taskHistoryItemUpdated`.
 	 */
 	async postStateToWebviewWithoutTaskHistory(): Promise<void> {
-		const state = await this.getStateToPostToWebview()
+		const state = await this.getStateToPostToWebview({ includeTaskHistory: false })
 		this.clineMessagesSeq++
 		state.clineMessagesSeq = this.clineMessagesSeq
 		const { taskHistory: _omit, ...rest } = state
@@ -2344,7 +2348,7 @@ export class ClineProvider
 	 *   (cloud auth, org settings, profiles, etc.) without interfering with task message streaming.
 	 */
 	async postStateToWebviewWithoutClineMessages(): Promise<void> {
-		const state = await this.getStateToPostToWebview()
+		const state = await this.getStateToPostToWebview({ includeTaskHistory: false })
 		const { clineMessages: _omitMessages, taskHistory: _omitHistory, ...rest } = state
 		await this.postMessageToWebview({ type: "state", state: rest })
 	}
@@ -2450,7 +2454,7 @@ export class ClineProvider
 		}
 	}
 
-	async getStateToPostToWebview(): Promise<ExtensionState> {
+	async getStateToPostToWebview({ includeTaskHistory = true }: GetStateOptions = {}): Promise<ExtensionState> {
 		// Ensure the store is initialized before reading task history
 		await this.taskHistoryStore.initialized
 
@@ -2479,7 +2483,6 @@ export class ClineProvider
 			ttsSpeed,
 			enableCheckpoints,
 			checkpointTimeout,
-			taskHistory,
 			soundVolume,
 			writeDelayMs,
 			diffFuzzyThreshold,
@@ -2542,7 +2545,7 @@ export class ClineProvider
 			autoCloseZooOpenedFiles,
 			autoCloseZooOpenedFilesAfterUserEdited,
 			autoCloseZooOpenedNewFiles,
-		} = await this.getState()
+		} = await this.getState({ includeTaskHistory: false })
 
 		let cloudOrganizations: CloudOrganizationMembership[] = []
 
@@ -2628,7 +2631,9 @@ export class ClineProvider
 			clineMessages: currentTask?.clineMessages || [],
 			currentTaskTodos: currentTask?.todoList || [],
 			messageQueue: currentTask?.messageQueueService?.messages,
-			taskHistory: this.taskHistoryStore.getAll().filter((item: HistoryItem) => item.ts && item.task),
+			taskHistory: includeTaskHistory
+				? this.taskHistoryStore.getAll().filter((item: HistoryItem) => item.ts && item.task)
+				: [],
 			soundEnabled: soundEnabled ?? false,
 			ttsEnabled: ttsEnabled ?? false,
 			ttsSpeed: ttsSpeed ?? 1.0,
@@ -2763,7 +2768,7 @@ export class ClineProvider
 	 * https://www.eliostruyf.com/devhack-code-extension-storage-options/
 	 */
 
-	async getState(): Promise<
+	async getState({ includeTaskHistory = true }: GetStateOptions = {}): Promise<
 		Omit<
 			ExtensionState,
 			"clineMessages" | "renderContext" | "hasOpenedModeSelector" | "version" | "shouldShowAnnouncement"
@@ -2859,7 +2864,7 @@ export class ClineProvider
 			allowedMaxCost: stateValues.allowedMaxCost,
 			autoCondenseContext: stateValues.autoCondenseContext ?? true,
 			autoCondenseContextPercent: stateValues.autoCondenseContextPercent ?? 100,
-			taskHistory: this.taskHistoryStore.getAll(),
+			taskHistory: includeTaskHistory ? this.taskHistoryStore.getAll() : [],
 			allowedCommands: stateValues.allowedCommands,
 			deniedCommands: stateValues.deniedCommands,
 			soundEnabled: stateValues.soundEnabled ?? false,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2310,6 +2310,12 @@ export class ClineProvider
 		await this.postMessageToWebview({ type: "state", state: rest })
 	}
 
+	/**
+	 * Schedules a debounced state-post attempt. A call made while the debounce timer is active returns
+	 * the result of the most recent invocation, so awaiting this method does not wait for the trailing
+	 * invocation scheduled by that call. Use `flushPostStateToWebviewThrottled()` to force and await any
+	 * pending trailing invocation before continuing.
+	 */
 	async postStateToWebviewThrottled(): Promise<void> {
 		if (this._disposed) {
 			return

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -907,6 +907,24 @@ describe("ClineProvider", () => {
 			)
 		})
 
+		test("handles state post failures while flushing a pending trailing post", async () => {
+			const error = new Error("state post failed")
+			const logSpy = vi.spyOn(provider, "log").mockImplementation(() => {})
+			const postStateSpy = vi
+				.spyOn(provider, "postStateToWebviewWithoutTaskHistory")
+				.mockResolvedValueOnce(undefined)
+				.mockRejectedValueOnce(error)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			await expect(provider.flushPostStateToWebviewThrottled()).resolves.toBeUndefined()
+
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+			expect(logSpy).toHaveBeenCalledWith(
+				"[ClineProvider#postStateToWebviewThrottled] Failed to post state: state post failed",
+			)
+		})
+
 		test("cancels pending work on dispose and ignores later schedule or flush calls", async () => {
 			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -820,6 +820,58 @@ describe("ClineProvider", () => {
 		expect(statePostSettled).toBe(true)
 	})
 
+	test.each([
+		[
+			"postStateToWebviewWithoutTaskHistory",
+			(currentProvider: ClineProvider) => currentProvider.postStateToWebviewWithoutTaskHistory(),
+		],
+		[
+			"postStateToWebviewWithoutClineMessages",
+			(currentProvider: ClineProvider) => currentProvider.postStateToWebviewWithoutClineMessages(),
+		],
+	])("%s skips task history computation", async (_methodName, postState) => {
+		const getAllSpy = vi.spyOn(provider.taskHistoryStore, "getAll")
+		const postMessageSpy = vi.spyOn(provider, "postMessageToWebview").mockResolvedValue(undefined)
+
+		await postState(provider)
+
+		expect(getAllSpy).not.toHaveBeenCalled()
+		expect(postMessageSpy).toHaveBeenCalledOnce()
+		expect(postMessageSpy.mock.calls[0]?.[0].state).not.toHaveProperty("taskHistory")
+	})
+
+	test("getStateToPostToWebview computes task history once after its base state resolves", async () => {
+		const historyItem = {
+			id: "history-task",
+			number: 1,
+			ts: 1,
+			task: "History task",
+			tokensIn: 0,
+			tokensOut: 0,
+			totalCost: 0,
+		}
+		const originalGetState = provider.getState.bind(provider)
+		let baseStateResolved = false
+		const getStateSpy = vi.spyOn(provider, "getState").mockImplementation(async (options) => {
+			const state = await originalGetState(options)
+			baseStateResolved = true
+			return state
+		})
+		const historyReadPhases: boolean[] = []
+		const getAllSpy = vi.spyOn(provider.taskHistoryStore, "getAll").mockImplementation(() => {
+			historyReadPhases.push(baseStateResolved)
+			return [historyItem]
+		})
+
+		const state = await provider.getStateToPostToWebview()
+
+		expect(getStateSpy).toHaveBeenCalledOnce()
+		expect(getStateSpy).toHaveBeenCalledWith({ includeTaskHistory: false })
+		expect(getAllSpy).toHaveBeenCalledOnce()
+		expect(historyReadPhases).toEqual([true])
+		expect(state.taskHistory).toEqual([historyItem])
+	})
+
 	describe("postStateToWebviewThrottled", () => {
 		beforeEach(() => {
 			vi.useFakeTimers()

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -794,6 +794,135 @@ describe("ClineProvider", () => {
 		expect(postMessageSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "action" }))
 	})
 
+	test("postStateToWebviewWithoutTaskHistory waits for the webview post boundary", async () => {
+		let releasePost!: () => void
+		const pendingPost = new Promise<void>((resolve) => {
+			releasePost = resolve
+		})
+		let statePostSettled = false
+
+		vi.spyOn(provider, "getStateToPostToWebview").mockResolvedValue({
+			taskHistory: [],
+		} as unknown as ExtensionState)
+		const postMessageSpy = vi.spyOn(provider, "postMessageToWebview").mockReturnValue(pendingPost)
+
+		const statePost = provider.postStateToWebviewWithoutTaskHistory()
+		void statePost.then(() => {
+			statePostSettled = true
+		})
+		await Promise.resolve()
+
+		expect(postMessageSpy).toHaveBeenCalledOnce()
+		expect(statePostSettled).toBe(false)
+
+		releasePost()
+		await statePost
+		expect(statePostSettled).toBe(true)
+	})
+
+	describe("postStateToWebviewThrottled", () => {
+		beforeEach(() => {
+			vi.useFakeTimers()
+		})
+
+		afterEach(async () => {
+			await provider.dispose()
+			vi.useRealTimers()
+		})
+
+		test("posts on the leading edge and coalesces a burst into one trailing post", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(499)
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("does not starve state posts during continuous updates", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(400)
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(400)
+			await provider.postStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(199)
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await vi.advanceTimersByTimeAsync(1)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("flushes a pending trailing post exactly once", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await provider.flushPostStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+
+			await vi.advanceTimersByTimeAsync(1000)
+			expect(postStateSpy).toHaveBeenCalledTimes(2)
+		})
+
+		test("does not duplicate an idle leading post when flushed", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.flushPostStateToWebviewThrottled()
+			await vi.advanceTimersByTimeAsync(1000)
+
+			expect(postStateSpy).toHaveBeenCalledOnce()
+		})
+
+		test("handles state post failures inside the debounced callback", async () => {
+			const error = new Error("state post failed")
+			const logSpy = vi.spyOn(provider, "log").mockImplementation(() => {})
+			vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockRejectedValue(error)
+
+			await expect(provider.postStateToWebviewThrottled()).resolves.toBeUndefined()
+			expect(logSpy).toHaveBeenCalledWith(
+				"[ClineProvider#postStateToWebviewThrottled] Failed to post state: state post failed",
+			)
+		})
+
+		test("stringifies non-Error state post failures inside the debounced callback", async () => {
+			const logSpy = vi.spyOn(provider, "log").mockImplementation(() => {})
+			vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockRejectedValue("state post failed")
+
+			await expect(provider.postStateToWebviewThrottled()).resolves.toBeUndefined()
+			expect(logSpy).toHaveBeenCalledWith(
+				"[ClineProvider#postStateToWebviewThrottled] Failed to post state: state post failed",
+			)
+		})
+
+		test("cancels pending work on dispose and ignores later schedule or flush calls", async () => {
+			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+
+			await provider.postStateToWebviewThrottled()
+			await provider.postStateToWebviewThrottled()
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+
+			await provider.dispose()
+			await vi.advanceTimersByTimeAsync(1000)
+			await provider.postStateToWebviewThrottled()
+			await provider.flushPostStateToWebviewThrottled()
+
+			expect(postStateSpy).toHaveBeenCalledTimes(1)
+		})
+	})
+
 	test("postMessageToWebview skips postMessage after dispose", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -914,15 +914,33 @@ describe("ClineProvider", () => {
 			expect(postStateSpy).toHaveBeenCalledTimes(2)
 		})
 
-		test("flushes a pending trailing post exactly once", async () => {
-			const postStateSpy = vi.spyOn(provider, "postStateToWebviewWithoutTaskHistory").mockResolvedValue(undefined)
+		test("flushes a pending trailing post exactly once and waits for it", async () => {
+			let releasePost!: () => void
+			const pendingPost = new Promise<void>((resolve) => {
+				releasePost = resolve
+			})
+			const postStateSpy = vi
+				.spyOn(provider, "postStateToWebviewWithoutTaskHistory")
+				.mockResolvedValueOnce(undefined)
+				.mockReturnValueOnce(pendingPost)
 
 			await provider.postStateToWebviewThrottled()
 			await provider.postStateToWebviewThrottled()
 			expect(postStateSpy).toHaveBeenCalledTimes(1)
 
-			await provider.flushPostStateToWebviewThrottled()
+			let flushSettled = false
+			const flushPromise = provider.flushPostStateToWebviewThrottled()
+			void flushPromise.then(() => {
+				flushSettled = true
+			})
+			await Promise.resolve()
+
 			expect(postStateSpy).toHaveBeenCalledTimes(2)
+			expect(flushSettled).toBe(false)
+
+			releasePost()
+			await flushPromise
+			expect(flushSettled).toBe(true)
 
 			await vi.advanceTimersByTimeAsync(1000)
 			expect(postStateSpy).toHaveBeenCalledTimes(2)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1,4 +1,13 @@
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react"
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react"
 import { useDeepCompareEffect, useEvent } from "react-use"
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso"
 import removeMd from "remove-markdown"
@@ -77,6 +86,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	const {
 		clineMessages: messages,
+		currentTaskId,
 		currentTaskItem,
 		currentTaskTodos,
 		taskHistory,
@@ -103,6 +113,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}, [providerName])
 
 	const messagesRef = useRef(messages)
+	const currentTaskIdRef = useRef(currentTaskId)
+
+	useLayoutEffect(() => {
+		currentTaskIdRef.current = currentTaskId
+	}, [currentTaskId])
 
 	useEffect(() => {
 		messagesRef.current = messages
@@ -514,13 +529,14 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		everVisibleMessagesTsRef.current.clear()
 		setCurrentFollowUpTs(null)
 		setIsCondensing(false)
+		setAggregatedCostsMap(new Map())
 
 		if (autoApproveTimeoutRef.current) {
 			clearTimeout(autoApproveTimeoutRef.current)
 			autoApproveTimeoutRef.current = null
 		}
 		userRespondedRef.current = false
-	}, [task?.ts])
+	}, [currentTaskId])
 
 	const taskTs = task?.ts
 
@@ -938,7 +954,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					// Handle both manual and automatic condensation start
 					// We don't check the task ID because:
 					// 1. There can only be one active task at a time
-					// 2. Task switching resets isCondensing to false (see useEffect with task?.ts dependency)
+					// 2. Task switching resets isCondensing to false (see useEffect with currentTaskId dependency)
 					// 3. For new tasks, currentTaskItem may not be populated yet due to async state updates
 					if (message.text) {
 						setIsCondensing(true)
@@ -962,12 +978,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					playSound("notification")
 					break
 				case "taskWithAggregatedCosts":
-					if (message.text && message.aggregatedCosts) {
-						setAggregatedCostsMap((prev) => {
-							const newMap = new Map(prev)
-							newMap.set(message.text!, message.aggregatedCosts!)
-							return newMap
-						})
+					if (message.text && message.text === currentTaskIdRef.current && message.aggregatedCosts) {
+						setAggregatedCostsMap(new Map([[message.text, message.aggregatedCosts]]))
 					}
 					break
 			}
@@ -1630,6 +1642,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	}
 
 	const areButtonsVisible = showScrollToBottom || primaryButtonText || secondaryButtonText
+	const currentTaskAggregatedCosts = currentTaskId ? aggregatedCostsMap.get(currentTaskId) : undefined
 
 	return (
 		<div
@@ -1657,22 +1670,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						cacheWrites={apiMetrics.totalCacheWrites}
 						cacheReads={apiMetrics.totalCacheReads}
 						totalCost={apiMetrics.totalCost}
-						aggregatedCost={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? aggregatedCostsMap.get(currentTaskItem.id)!.totalCost
-								: undefined
-						}
-						hasSubtasks={
-							!!(
-								currentTaskItem?.id &&
-								aggregatedCostsMap.has(currentTaskItem.id) &&
-								aggregatedCostsMap.get(currentTaskItem.id)!.childrenCost > 0
-							)
-						}
+						aggregatedCost={currentTaskAggregatedCosts?.totalCost}
+						hasSubtasks={(currentTaskAggregatedCosts?.childrenCost ?? 0) > 0}
 						parentTaskId={currentTaskItem?.parentTaskId}
 						costBreakdown={
-							currentTaskItem?.id && aggregatedCostsMap.has(currentTaskItem.id)
-								? getCostBreakdownIfNeeded(aggregatedCostsMap.get(currentTaskItem.id)!, {
+							currentTaskAggregatedCosts
+								? getCostBreakdownIfNeeded(currentTaskAggregatedCosts, {
 										own: t("common:costs.own"),
 										subtasks: t("common:costs.subtasks"),
 									})

--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -82,6 +82,25 @@ vi.mock("../ChatRow", () => ({
 	},
 }))
 
+const mockTaskHeaderState = vi.hoisted(() => ({
+	renders: [] as Array<{ taskId?: string; aggregatedCost?: number }>,
+}))
+
+vi.mock("../TaskHeader", () => ({
+	default: function MockTaskHeader({ task, aggregatedCost }: { task: ClineMessage; aggregatedCost?: number }) {
+		mockTaskHeaderState.renders.push({ taskId: task.text, aggregatedCost })
+
+		return (
+			<div
+				data-aggregated-cost={aggregatedCost ?? ""}
+				data-task-id={task.text}
+				data-task-ts={task.ts}
+				data-testid="task-header"
+			/>
+		)
+	},
+}))
+
 vi.mock("../AutoApproveMenu", () => ({
 	default: () => null,
 }))
@@ -339,6 +358,54 @@ const mockPostMessage = (state: Record<string, unknown>) => {
 	)
 }
 
+const dispatchExtensionMessage = async (data: Record<string, unknown>) => {
+	await act(async () => {
+		window.dispatchEvent(new MessageEvent("message", { data }))
+	})
+}
+
+const dispatchTaskState = async (id: string, taskTs: number, childIds: string[] = []) => {
+	await dispatchExtensionMessage({
+		type: "state",
+		state: {
+			version: "1.0.0",
+			clineMessages: [
+				{
+					type: "say",
+					say: "task",
+					ts: taskTs,
+					text: id,
+				},
+			],
+			currentTaskId: id,
+			currentTaskItem: {
+				id,
+				ts: taskTs,
+				task: id,
+				childIds,
+			},
+			taskHistory: [],
+			shouldShowAnnouncement: false,
+			allowedCommands: [],
+			alwaysAllowExecute: false,
+			cloudIsAuthenticated: false,
+			telemetrySetting: "enabled",
+		},
+	})
+}
+
+const dispatchAggregatedCosts = async (taskId: string, totalCost: number) => {
+	await dispatchExtensionMessage({
+		type: "taskWithAggregatedCosts",
+		text: taskId,
+		aggregatedCosts: {
+			totalCost,
+			ownCost: 1,
+			childrenCost: totalCost - 1,
+		},
+	})
+}
+
 const defaultProps: ChatViewProps = {
 	isHidden: false,
 	showAnnouncement: false,
@@ -395,6 +462,65 @@ describe("ChatView - Tool Batching Tests", () => {
 			expect(toolRow?.text).toContain('"path":"a.ts"')
 			expect(toolRow?.text).toContain('"path":"b.ts"')
 		})
+	})
+})
+
+describe("ChatView - Aggregated Costs Lifecycle", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mockTaskHeaderState.renders.length = 0
+	})
+
+	it("clears cached aggregated costs when switching tasks", async () => {
+		const { getByTestId } = renderChatView()
+
+		await dispatchTaskState("task-a", 1_000, ["child-a"])
+		await dispatchAggregatedCosts("task-a", 9)
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "9")
+		})
+
+		// Use the same message timestamp to prove task identity, rather than task.ts,
+		// drives the reset.
+		await dispatchTaskState("task-b", 1_000)
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-b")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		await dispatchTaskState("task-a", 1_000, ["child-a"])
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-a")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+	})
+
+	it("rejects a delayed aggregated-cost response from the previous task", async () => {
+		const { getByTestId } = renderChatView()
+
+		await dispatchTaskState("task-a", 1_001, ["child-a"])
+		await dispatchTaskState("task-b", 2_001)
+		await dispatchAggregatedCosts("task-a", 13)
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-b")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		mockTaskHeaderState.renders.length = 0
+		await dispatchTaskState("task-a", 1_001, ["child-a"])
+
+		await waitFor(() => {
+			expect(getByTestId("task-header")).toHaveAttribute("data-task-id", "task-a")
+			expect(getByTestId("task-header")).toHaveAttribute("data-aggregated-cost", "")
+		})
+
+		expect(
+			mockTaskHeaderState.renders.some(
+				({ taskId, aggregatedCost }) => taskId === "task-a" && aggregatedCost === 13,
+			),
+		).toBe(false)
 	})
 })
 

--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -367,8 +367,7 @@ const dispatchExtensionMessage = async (data: Record<string, unknown>) => {
 const dispatchTaskState = async (id: string, taskTs: number, childIds: string[] = []) => {
 	await dispatchExtensionMessage({
 		type: "state",
-		state: {
-			version: "1.0.0",
+		state: makeExtensionState({
 			clineMessages: [
 				{
 					type: "say",
@@ -380,17 +379,15 @@ const dispatchTaskState = async (id: string, taskTs: number, childIds: string[] 
 			currentTaskId: id,
 			currentTaskItem: {
 				id,
+				number: 1,
 				ts: taskTs,
 				task: id,
+				tokensIn: 0,
+				tokensOut: 0,
+				totalCost: 0,
 				childIds,
 			},
-			taskHistory: [],
-			shouldShowAnnouncement: false,
-			allowedCommands: [],
-			alwaysAllowExecute: false,
-			cloudIsAuthenticated: false,
-			telemetrySetting: "enabled",
-		},
+		}),
 	})
 }
 


### PR DESCRIPTION
### Related GitHub Issue

Closes: #629  <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

This PR reduces full-state webview churn during long-running tasks with large message histories. The hot paths previously serialized and posted the complete message array for every message addition and queue-state change, producing repeated multi-megabyte snapshots at the message count reported in #629.

- Adds a provider-scoped 500 ms leading/trailing debounce with a 1 second maximum wait for full state updates that omit task history.
- Routes new-message additions and message-queue state changes through the throttled path while keeping task start, API boundaries, and stream completion immediate.
- Flushes pending state before the first lightweight update for a newly created partial message and before task abort, and cancels pending work when the provider is disposed.
- Logs rejected throttled state schedules and flushes without interrupting message persistence or task-abort cleanup.
- Clears aggregated task costs when the active task changes and ignores delayed cost responses for inactive tasks.

Partial streaming continues to use the existing lightweight `messageUpdated` path. The change coalesces high-frequency full snapshots without changing the webview message protocol or task lifecycle.

### Test Procedure

Run the focused regression tests:

```sh
pnpm --dir src exec vitest run \
  core/webview/__tests__/ClineProvider.spec.ts \
  core/task/__tests__/Task.spec.ts \
  core/task/__tests__/Task.throttle.test.ts

pnpm --dir webview-ui exec vitest run \
  src/components/chat/__tests__/ChatView.spec.tsx
```

Run the repository validation commands:

```sh
pnpm test
pnpm check-types
pnpm lint
```

The regression tests cover:

- Leading/trailing coalescing and the 1 second maximum wait.
- Explicit flush behavior, provider disposal, and scheduling/flush rejection handling.
- Throttled message and message-queue updates.
- Ordering between a new partial message and subsequent `messageUpdated` delivery.
- Immediate clean-state delivery at task start.
- Final-state delivery and cleanup continuity when task abort encounters a state-push failure.
- Message persistence continuity when throttled state scheduling fails.
- Aggregated-cost cleanup on task switch and rejection of delayed responses from an inactive task.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Visual Snapshot** (UI changes only): If a user would notice this change at a glance (layout, theme tokens, brand elements, empty/error states), I've added or updated a `*.visual.tsx` snapshot in `webview-ui/`. See `webview-ui/AGENTS.md` → "When a UI change needs a snapshot".
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

### Videos (interaction / animation only)

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This PR intentionally addresses the frequency of large full-state pushes. Redesigning message delivery to eliminate the O(N) payload itself is outside the scope of #629.


### Get in Touch



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary interface refreshes while keeping partial responses and task interruptions synchronized.
  * Ensured pending task updates are delivered before a task is aborted.
  * Fixed task cost displays so they reset correctly when switching tasks and ignore delayed updates from previous tasks.
  * Improved reliability and error handling for task state and message updates.
* **Performance**
  * Smoothed task status updates by grouping rapid changes without delaying important updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->