### PR TITLE
fix(mcp): treat 404 as 405 for streamable-http SSE GET

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -152,6 +152,35 @@ const McpSettingsSchema = z.object({
 	mcpServers: z.record(ServerConfigSchema),
 })
 
+/**
+ * `fetch` wrapper for Streamable HTTP MCP transports that reports a `404` answer to a
+ * `GET` request as `405 Method Not Allowed`.
+ *
+ * The MCP SDK opens the optional server-to-client SSE stream with a `GET` request. Per the
+ * MCP spec a server that does not offer such a stream must answer `405`, which the SDK
+ * treats as "no SSE stream available" and silently ignores. Servers answering `404`
+ * instead make the SDK fail the whole connection with
+ * `Failed to open SSE stream: Not Found`, even though POST-based requests work fine, so
+ * the status is normalized here.
+ *
+ * Any other request method or status code is passed through untouched.
+ *
+ * See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1150
+ */
+const streamableHttpFetch: typeof fetch = async (url, init) => {
+	const response = await fetch(url, init)
+
+	if (init?.method?.toUpperCase() === "GET" && response.status === 404) {
+		return new Response(response.body, {
+			status: 405,
+			statusText: "Method Not Allowed",
+			headers: response.headers,
+		})
+	}
+
+	return response
+}
+
 export class McpHub {
 	private providerRef: WeakRef<ClineProvider>
 	private disposables: vscode.Disposable[] = []
@@ -824,6 +853,7 @@ export class McpHub {
 				transport = new StreamableHTTPClientTransport(new URL(configInjected.url), {
 					authProvider,
 					requestInit: { headers: configInjected.headers },
+					fetch: streamableHttpFetch,
 				})
 
 				// Set up Streamable HTTP specific error handling


### PR DESCRIPTION
### Related GitHub Issue

Closes: #1079

### Description
Servers that answer the SDK's optional SSE-stream GET with 404 instead of the spec-mandated 405 made the whole connection fail with "Failed to open SSE stream: Not Found".

Ports https://github.com/cline/cline/pull/8321
Refs https://github.com/modelcontextprotocol/typescript-sdk/issues/1150

LLM: Done with Claude Opus 5 in Zoo Code.

### Test Procedure

I tested it with the NetHunt MCP server; didn't work before, works with this.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Streamable HTTP MCP connections by correctly handling unsupported GET requests.
  * Preserved response details while reporting the appropriate “Method Not Allowed” status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->