### PR TITLE
fix(task): isolate task configuration from focused provider state

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -724,6 +724,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		}
 
 		this.providerProfileChangeListener = async () => {
+			if (provider.getCurrentTask()?.taskId !== this.taskId) {
+				return
+			}
+
 			try {
 				const newState = await provider.getState()
 				if (newState?.apiConfiguration) {
@@ -1564,6 +1568,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			if (provider) {
 				if (mode) {
 					await provider.setMode(mode)
+					await this.waitForModeInitialization()
+					this._taskMode = mode
 				}
 
 				if (providerProfile) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1618,7 +1618,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// Get condensing configuration
 		const state = await this.providerRef.deref()?.getState()
 		const customCondensingPrompt = state?.customSupportPrompts?.CONDENSE
-		const { mode, apiConfiguration } = state ?? {}
+		const mode = await this.getTaskMode()
+		const apiConfiguration = this.apiConfiguration
 
 		const { contextTokens: prevContextTokens } = this.getTokenUsage()
 
@@ -3836,16 +3837,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		const state = await this.providerRef.deref()?.getState()
 
-		const {
-			mode,
-			customModes,
-			customModePrompts,
-			customInstructions,
-			experiments,
-			language,
-			apiConfiguration,
-			enableSubfolderRules,
-		} = state ?? {}
+		const { customModes, customModePrompts, customInstructions, experiments, language, enableSubfolderRules } =
+			state ?? {}
+		const mode = await this.getTaskMode()
+		const apiConfiguration = this.apiConfiguration
 
 		return await (async () => {
 			const provider = this.providerRef.deref()
@@ -3911,7 +3906,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 	private async handleContextWindowExceededError(): Promise<void> {
 		const state = await this.providerRef.deref()?.getState()
-		const { profileThresholds = {}, mode, apiConfiguration } = state ?? {}
+		const { profileThresholds = {} } = state ?? {}
+		const mode = await this.getTaskMode()
+		const apiConfiguration = this.apiConfiguration
 
 		const { contextTokens } = this.getTokenUsage()
 		await this.safeEnsureModelFetched()
@@ -4051,9 +4048,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	 * the `api_req_rate_limit_wait` say type (not an error).
 	 */
 	private async maybeWaitForProviderRateLimit(retryAttempt: number): Promise<void> {
-		const state = await this.providerRef.deref()?.getState()
-		const rateLimitSeconds =
-			state?.apiConfiguration?.rateLimitSeconds ?? this.apiConfiguration?.rateLimitSeconds ?? 0
+		const rateLimitSeconds = this.apiConfiguration?.rateLimitSeconds ?? 0
 
 		const lastRequestTime = this.rateLimitClock.getLastRequestTime()
 		if (rateLimitSeconds <= 0 || !lastRequestTime) {
@@ -4086,14 +4081,14 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		const state = await this.providerRef.deref()?.getState()
 
 		const {
-			apiConfiguration,
 			autoApprovalEnabled,
 			requestDelaySeconds,
-			mode,
 			autoCondenseContext = true,
 			autoCondenseContextPercent = 100,
 			profileThresholds = {},
 		} = state ?? {}
+		const mode = await this.getTaskMode()
+		const apiConfiguration = this.apiConfiguration
 
 		// Get condensing configuration for automatic triggers.
 		const customCondensingPrompt = state?.customSupportPrompts?.CONDENSE
@@ -4506,7 +4501,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 			// Respect provider rate limit window
 			let rateLimitDelay = 0
-			const rateLimit = (state?.apiConfiguration ?? this.apiConfiguration)?.rateLimitSeconds || 0
+			const rateLimit = this.apiConfiguration?.rateLimitSeconds || 0
 			const lastRequestTime = this.rateLimitClock.getLastRequestTime()
 			if (lastRequestTime && rateLimit > 0) {
 				const elapsed = performance.now() - lastRequestTime

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1540,6 +1540,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					// Update this task's API configuration to match the new profile
 					// This ensures the parser state is synchronized with the selected model
 					const newState = await provider.getState()
+					this.setTaskApiConfigName(newState?.currentApiConfigName ?? providerProfile)
 					if (newState?.apiConfiguration) {
 						this.updateApiConfiguration(newState.apiConfiguration)
 					}

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -430,7 +430,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private readonly _isHistoryTask: boolean
 	// No streaming parser is required.
 	assistantMessageParser?: undefined
-	private providerProfileChangeListener?: (config: { name: string; provider?: string }) => void
 
 	// Native tool call streaming state (track which index each tool is at)
 	private streamingToolCallIndices: Map<string, number> = new Map()
@@ -582,9 +581,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		this.messageQueueService.on("stateChanged", this.messageQueueStateChangedHandler)
 
-		// Listen for provider profile changes to update parser state
-		this.setupProviderProfileChangeListener(provider)
-
 		// Set up diff strategy
 		this.diffStrategy = new MultiSearchReplaceDiffStrategy(diffFuzzyThreshold)
 
@@ -709,39 +705,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			const errorMessage = `Failed to initialize task API config name: ${error instanceof Error ? error.message : String(error)}`
 			provider.log(errorMessage)
 		}
-	}
-
-	/**
-	 * Sets up a listener for provider profile changes.
-	 *
-	 * @private
-	 * @param provider - The ClineProvider instance to listen to
-	 */
-	private setupProviderProfileChangeListener(provider: ClineProvider): void {
-		// Only set up listener if provider has the on method (may not exist in test mocks)
-		if (typeof provider.on !== "function") {
-			return
-		}
-
-		this.providerProfileChangeListener = async () => {
-			if (provider.getCurrentTask()?.taskId !== this.taskId) {
-				return
-			}
-
-			try {
-				const newState = await provider.getState()
-				if (newState?.apiConfiguration) {
-					this.updateApiConfiguration(newState.apiConfiguration)
-				}
-			} catch (error) {
-				console.error(
-					`[Task#${this.taskId}.${this.instanceId}] Failed to update API configuration on profile change:`,
-					error,
-				)
-			}
-		}
-
-		provider.on(RooCodeEventName.ProviderProfileChanged, this.providerProfileChangeListener)
 	}
 
 	/**
@@ -1568,7 +1531,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			if (provider) {
 				if (mode) {
 					await provider.setMode(mode)
-					await this.waitForModeInitialization()
 					this._taskMode = mode
 				}
 
@@ -1624,6 +1586,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// Get condensing configuration
 		const state = await this.providerRef.deref()?.getState()
 		const customCondensingPrompt = state?.customSupportPrompts?.CONDENSE
+		// Use task-local values, not provider state, to prevent cross-task configuration leaks.
 		const mode = await this.getTaskMode()
 		const apiConfiguration = this.apiConfiguration
 
@@ -2324,19 +2287,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			console.error("Error cancelling current request:", error)
 		}
 
-		// Remove provider profile change listener
-		try {
-			if (this.providerProfileChangeListener) {
-				const provider = this.providerRef.deref()
-				if (provider) {
-					provider.off(RooCodeEventName.ProviderProfileChanged, this.providerProfileChangeListener)
-				}
-				this.providerProfileChangeListener = undefined
-			}
-		} catch (error) {
-			console.error("Error removing provider profile change listener:", error)
-		}
-
 		// Dispose message queue and remove event listeners.
 		try {
 			if (this.messageQueueStateChangedHandler) {
@@ -2628,7 +2578,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			const showRooIgnoredFiles = state?.showRooIgnoredFiles ?? false
 			const includeDiagnosticMessages = state?.includeDiagnosticMessages ?? true
 			const maxDiagnosticMessages = state?.maxDiagnosticMessages ?? 50
-			const currentMode = state?.mode ?? defaultModeSlug
+			const currentMode = await this.getTaskMode()
 
 			const { content: parsedUserContent, mode: slashCommandMode } = await processUserContentMentions({
 				userContent: currentUserContent,
@@ -3845,6 +3795,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 		const { customModes, customModePrompts, customInstructions, experiments, language, enableSubfolderRules } =
 			state ?? {}
+		// Use task-local values, not provider state, to prevent cross-task configuration leaks.
 		const mode = await this.getTaskMode()
 		const apiConfiguration = this.apiConfiguration
 
@@ -3913,6 +3864,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	private async handleContextWindowExceededError(): Promise<void> {
 		const state = await this.providerRef.deref()?.getState()
 		const { profileThresholds = {} } = state ?? {}
+		// Use task-local values, not provider state, to prevent cross-task configuration leaks.
 		const mode = await this.getTaskMode()
 		const apiConfiguration = this.apiConfiguration
 
@@ -4093,6 +4045,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			autoCondenseContextPercent = 100,
 			profileThresholds = {},
 		} = state ?? {}
+		// Use task-local values, not provider state, to prevent cross-task configuration leaks.
 		const mode = await this.getTaskMode()
 		const apiConfiguration = this.apiConfiguration
 
@@ -4507,7 +4460,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 			// Respect provider rate limit window
 			let rateLimitDelay = 0
-			const rateLimit = this.apiConfiguration?.rateLimitSeconds || 0
+			const rateLimit = this.apiConfiguration?.rateLimitSeconds ?? 0
 			const lastRequestTime = this.rateLimitClock.getLastRequestTime()
 			if (lastRequestTime && rateLimit > 0) {
 				const elapsed = performance.now() - lastRequestTime

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -9,7 +9,6 @@ import type { Mock } from "vitest"
 
 import {
 	providerIdentifiers,
-	RooCodeEventName,
 	type GlobalState,
 	type ProviderSettings,
 	type ModelInfo,
@@ -570,8 +569,27 @@ describe("Cline", () => {
 			await getTaskTestAccess(task).getSystemPrompt()
 
 			const systemPromptCall = requireDefined(vi.mocked(SYSTEM_PROMPT).mock.calls.at(-1))
-			expect(systemPromptCall[5]).toBe("architect")
-			expect(systemPromptCall[12]).toMatchObject({ todoListEnabled: true })
+			const [, , , , , mode, , , , , , , settings] = systemPromptCall
+			expect(mode).toBe("architect")
+			expect(settings).toMatchObject({ todoListEnabled: true })
+		})
+
+		it("uses the task mode when manually condensing after focused state changes", async () => {
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			await task.getTaskMode()
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "code", mcpEnabled: false })
+			vi.spyOn(getTaskTestAccess(task), "getSystemPrompt").mockResolvedValue("mock system prompt")
+
+			await task.condenseContext()
+
+			const [options] = requireDefined(vi.mocked(summarizeConversation).mock.calls.at(-1))
+			expect(options.metadata?.mode).toBe("architect")
 		})
 
 		it("uses the task mode in request metadata when focused provider state differs", async () => {
@@ -608,48 +626,6 @@ describe("Cline", () => {
 
 			const metadata = requireDefined(createMessage.mock.calls[0])[2]
 			expect(metadata?.mode).toBe("ask")
-		})
-
-		it("only applies profile changes to the focused task", async () => {
-			const parentConfiguration: ProviderSettings = {
-				...mockApiConfig,
-				apiModelId: "parent-model",
-				rateLimitSeconds: 4,
-			}
-			const childConfiguration: ProviderSettings = {
-				...mockApiConfig,
-				apiModelId: "child-model",
-				rateLimitSeconds: 8,
-			}
-			const activeConfiguration: ProviderSettings = {
-				...mockApiConfig,
-				apiModelId: "active-model",
-				rateLimitSeconds: 12,
-			}
-			const parent = new Task({
-				provider: mockProvider,
-				apiConfiguration: parentConfiguration,
-				taskId: "parent-task",
-				task: "parent task",
-				startTask: false,
-			})
-			const child = new Task({
-				provider: mockProvider,
-				apiConfiguration: childConfiguration,
-				taskId: "child-task",
-				task: "child task",
-				startTask: false,
-			})
-			vi.spyOn(mockProvider, "getCurrentTask").mockReturnValue(child)
-			vi.spyOn(mockProvider, "getState").mockResolvedValue({ apiConfiguration: activeConfiguration })
-
-			mockProvider.emit(RooCodeEventName.ProviderProfileChanged, {
-				name: "active-profile",
-				provider: activeConfiguration.apiProvider,
-			})
-
-			await vi.waitFor(() => expect(child.apiConfiguration).toEqual(activeConfiguration))
-			expect(parent.apiConfiguration).toEqual(parentConfiguration)
 		})
 	})
 
@@ -1033,6 +1009,13 @@ describe("Cline", () => {
 				// finalDelay=10 and the countdown loop fires delay(1000) ten times.
 				expect(mockDelay).toHaveBeenCalledWith(1000)
 				expect(mockDelay).toHaveBeenCalledTimes(10)
+				const countdownMessages = saySpy.mock.calls.filter(
+					([type, text, , partial]) =>
+						type === "api_req_retry_delayed" && partial && typeof text === "string",
+				)
+				expect(countdownMessages.map(([, text]) => text)).toEqual(
+					Array.from({ length: 10 }, (_, index) => `API Error\n<retry_timer>${10 - index}</retry_timer>`),
+				)
 				expect(clock.getLastRequestTime()).toBeDefined()
 			})
 
@@ -2645,12 +2628,14 @@ describe("Cline", () => {
 			})
 
 			it("should propagate AbortController signal through attemptApiRequest context-window retry path", async () => {
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
 				const task = new Task({
 					provider: mockProvider,
 					apiConfiguration: mockApiConfig,
 					task: "test task",
 					startTask: false,
 				})
+				await task.getTaskMode()
 
 				vi.spyOn(getTaskTestAccess(task), "getSystemPrompt").mockResolvedValue("mock system prompt")
 				vi.spyOn(task, "getTokenUsage").mockReturnValue({
@@ -2745,6 +2730,7 @@ describe("Cline", () => {
 				expect(summarizeConversation).toHaveBeenCalled()
 				const [options] = vi.mocked(summarizeConversation).mock.calls.at(-1)!
 				expect(options.metadata?.taskId).toBe(task.taskId)
+				expect(options.metadata?.mode).toBe("architect")
 				expect(options.metadata?.abortSignal).toBeInstanceOf(AbortSignal)
 				expect(options.metadata?.abortSignal?.aborted).toBe(false)
 			})

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -549,7 +549,10 @@ describe("Cline", () => {
 				...mockApiConfig,
 				todoListEnabled: true,
 			}
-			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "architect",
+				mcpEnabled: false,
+			} as unknown as ProviderState)
 
 			const task = new Task({
 				provider: mockProvider,
@@ -563,7 +566,7 @@ describe("Cline", () => {
 				mode: "code",
 				mcpEnabled: false,
 				apiConfiguration: { ...mockApiConfig, todoListEnabled: false },
-			})
+			} as unknown as ProviderState)
 			vi.mocked(SYSTEM_PROMPT).mockResolvedValueOnce("mock system prompt")
 
 			await getTaskTestAccess(task).getSystemPrompt()
@@ -575,7 +578,10 @@ describe("Cline", () => {
 		})
 
 		it("uses the task mode when manually condensing after focused state changes", async () => {
-			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "architect",
+				mcpEnabled: false,
+			} as unknown as ProviderState)
 			const task = new Task({
 				provider: mockProvider,
 				apiConfiguration: mockApiConfig,
@@ -583,7 +589,10 @@ describe("Cline", () => {
 				startTask: false,
 			})
 			await task.getTaskMode()
-			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "code", mcpEnabled: false })
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "code",
+				mcpEnabled: false,
+			} as unknown as ProviderState)
 			vi.spyOn(getTaskTestAccess(task), "getSystemPrompt").mockResolvedValue("mock system prompt")
 
 			await task.condenseContext()
@@ -598,7 +607,7 @@ describe("Cline", () => {
 				mcpEnabled: false,
 				autoApprovalEnabled: true,
 				requestDelaySeconds: 0,
-			})
+			} as unknown as ProviderState)
 			const task = new Task({
 				provider: mockProvider,
 				apiConfiguration: mockApiConfig,
@@ -613,7 +622,7 @@ describe("Cline", () => {
 				mcpEnabled: false,
 				autoApprovalEnabled: true,
 				requestDelaySeconds: 0,
-			})
+			} as unknown as ProviderState)
 			const stream = (async function* () {
 				yield { type: "text", text: "response" } as ApiStreamChunk
 			})()
@@ -1765,7 +1774,10 @@ describe("Cline", () => {
 			})
 
 			it("uses a mode selected through submitUserMessage in the next API request", async () => {
-				vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "ask", mcpEnabled: false })
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({
+					mode: "ask",
+					mcpEnabled: false,
+				} as unknown as ProviderState)
 				vi.spyOn(mockProvider, "setMode").mockResolvedValue(undefined)
 				const task = new Task({
 					provider: mockProvider,
@@ -1789,6 +1801,30 @@ describe("Cline", () => {
 
 				expect(mockProvider.setMode).toHaveBeenCalledWith("code")
 				expect(requireDefined(createMessage.mock.calls[0])[2]?.mode).toBe("code")
+			})
+
+			it("stores a provider profile selected through submitUserMessage", async () => {
+				const selectedConfiguration: ProviderSettings = {
+					...mockApiConfig,
+					apiModelId: "selected-model",
+				}
+				const task = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "initial task",
+					startTask: false,
+				})
+				task.setTaskApiConfigName("previous-profile")
+				vi.spyOn(mockProvider, "setProviderProfile").mockResolvedValue(undefined)
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({
+					currentApiConfigName: "selected-profile",
+					apiConfiguration: selectedConfiguration,
+				} as unknown as ProviderState)
+				vi.spyOn(task, "handleWebviewAskResponse").mockImplementation(() => {})
+
+				await task.submitUserMessage("switch profiles", undefined, undefined, "selected-profile")
+
+				expect(task.taskApiConfigName).toBe("selected-profile")
 			})
 
 			it("should handle empty messages gracefully", async () => {
@@ -2628,7 +2664,10 @@ describe("Cline", () => {
 			})
 
 			it("should propagate AbortController signal through attemptApiRequest context-window retry path", async () => {
-				vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({
+					mode: "architect",
+					mcpEnabled: false,
+				} as unknown as ProviderState)
 				const task = new Task({
 					provider: mockProvider,
 					apiConfiguration: mockApiConfig,

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -17,6 +17,7 @@ import {
 import { TelemetryService } from "@roo-code/telemetry"
 
 import { Task } from "../Task"
+import { SYSTEM_PROMPT } from "../../prompts/system"
 import { createRateLimitClock } from "../RateLimitClock"
 import { summarizeConversation } from "../../condense"
 import { ClineProvider } from "../../webview/ClineProvider"
@@ -235,6 +236,15 @@ vi.mock("../../condense", async (importOriginal) => {
 		}),
 	}
 })
+
+vi.mock("../../prompts/system", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../prompts/system")>()
+	return {
+		...actual,
+		SYSTEM_PROMPT: vi.fn(actual.SYSTEM_PROMPT),
+	}
+})
+
 // Mock storagePathManager to prevent dynamic import issues.
 vi.mock("../../../utils/storage", () => ({
 	getTaskDirectoryPath: vi
@@ -530,6 +540,73 @@ describe("Cline", () => {
 			expect(() => {
 				new Task({ provider: mockProvider, apiConfiguration: mockApiConfig })
 			}).toThrow("Either historyItem or task/images must be provided")
+		})
+	})
+
+	describe("task-local configuration isolation", () => {
+		it("uses the task mode and API configuration when focused provider state differs", async () => {
+			const taskApiConfiguration: ProviderSettings = {
+				...mockApiConfig,
+				todoListEnabled: true,
+			}
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "architect", mcpEnabled: false })
+
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: taskApiConfiguration,
+				task: "test task",
+				startTask: false,
+			})
+			await task.getTaskMode()
+
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "code",
+				mcpEnabled: false,
+				apiConfiguration: { ...mockApiConfig, todoListEnabled: false },
+			})
+			vi.mocked(SYSTEM_PROMPT).mockResolvedValueOnce("mock system prompt")
+
+			await getTaskTestAccess(task).getSystemPrompt()
+
+			const systemPromptCall = requireDefined(vi.mocked(SYSTEM_PROMPT).mock.calls.at(-1))
+			expect(systemPromptCall[5]).toBe("architect")
+			expect(systemPromptCall[12]).toMatchObject({ todoListEnabled: true })
+		})
+
+		it("uses the task mode in request metadata when focused provider state differs", async () => {
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "ask",
+				mcpEnabled: false,
+				autoApprovalEnabled: true,
+				requestDelaySeconds: 0,
+			})
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				task: "test task",
+				startTask: false,
+			})
+			await task.getTaskMode()
+			vi.spyOn(getTaskTestAccess(task), "getSystemPrompt").mockResolvedValue("mock system prompt")
+
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({
+				mode: "code",
+				mcpEnabled: false,
+				autoApprovalEnabled: true,
+				requestDelaySeconds: 0,
+			})
+			const stream = (async function* () {
+				yield { type: "text", text: "response" } as ApiStreamChunk
+			})()
+			const createMessage = vi.spyOn(task.api, "createMessage").mockReturnValue(stream)
+			task.apiConversationHistory = [
+				{ role: "user", content: [{ type: "text", text: "test message" }], ts: Date.now() },
+			]
+
+			await task.attemptApiRequest().next()
+
+			const metadata = requireDefined(createMessage.mock.calls[0])[2]
+			expect(metadata?.mode).toBe("ask")
 		})
 	})
 
@@ -832,7 +909,7 @@ describe("Cline", () => {
 				expect(mockDelay).toHaveBeenCalledWith(1000)
 			})
 
-			it("should respect rate limit window in retry backoff", async () => {
+			it("uses the task rate limit in retry backoff when focused provider state differs", async () => {
 				const clock = createRateLimitClock()
 				const rateLimitConfig = {
 					...mockApiConfig,
@@ -897,7 +974,10 @@ describe("Cline", () => {
 				const providerState = await mockProvider.getState()
 				vi.spyOn(mockProvider, "getState").mockResolvedValue({
 					...providerState,
-					apiConfiguration: rateLimitConfig,
+					apiConfiguration: {
+						...mockApiConfig,
+						rateLimitSeconds: 1,
+					},
 					autoApprovalEnabled: true,
 					requestDelaySeconds: 3,
 				})
@@ -905,7 +985,8 @@ describe("Cline", () => {
 				const iterator = cline.attemptApiRequest(0)
 				await iterator.next()
 
-				// rateLimitSeconds=10 > exponentialDelay=ceil(3*2^0)=3, so
+				// The task rateLimitSeconds=10 (rather than the focused provider's 1)
+				// exceeds exponentialDelay=ceil(3*2^0)=3, so
 				// finalDelay=10 and the countdown loop fires delay(1000) ten times.
 				expect(mockDelay).toHaveBeenCalledWith(1000)
 				expect(mockDelay).toHaveBeenCalledTimes(10)

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -9,6 +9,7 @@ import type { Mock } from "vitest"
 
 import {
 	providerIdentifiers,
+	RooCodeEventName,
 	type GlobalState,
 	type ProviderSettings,
 	type ModelInfo,
@@ -607,6 +608,48 @@ describe("Cline", () => {
 
 			const metadata = requireDefined(createMessage.mock.calls[0])[2]
 			expect(metadata?.mode).toBe("ask")
+		})
+
+		it("only applies profile changes to the focused task", async () => {
+			const parentConfiguration: ProviderSettings = {
+				...mockApiConfig,
+				apiModelId: "parent-model",
+				rateLimitSeconds: 4,
+			}
+			const childConfiguration: ProviderSettings = {
+				...mockApiConfig,
+				apiModelId: "child-model",
+				rateLimitSeconds: 8,
+			}
+			const activeConfiguration: ProviderSettings = {
+				...mockApiConfig,
+				apiModelId: "active-model",
+				rateLimitSeconds: 12,
+			}
+			const parent = new Task({
+				provider: mockProvider,
+				apiConfiguration: parentConfiguration,
+				taskId: "parent-task",
+				task: "parent task",
+				startTask: false,
+			})
+			const child = new Task({
+				provider: mockProvider,
+				apiConfiguration: childConfiguration,
+				taskId: "child-task",
+				task: "child task",
+				startTask: false,
+			})
+			vi.spyOn(mockProvider, "getCurrentTask").mockReturnValue(child)
+			vi.spyOn(mockProvider, "getState").mockResolvedValue({ apiConfiguration: activeConfiguration })
+
+			mockProvider.emit(RooCodeEventName.ProviderProfileChanged, {
+				name: "active-profile",
+				provider: activeConfiguration.apiProvider,
+			})
+
+			await vi.waitFor(() => expect(child.apiConfiguration).toEqual(activeConfiguration))
+			expect(parent.apiConfiguration).toEqual(parentConfiguration)
 		})
 	})
 
@@ -1736,6 +1779,33 @@ describe("Cline", () => {
 				expect(handleResponseSpy).toHaveBeenCalledWith("messageResponse", "test message", ["image1.png"])
 				// Should NOT route through webview anymore
 				expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+			})
+
+			it("uses a mode selected through submitUserMessage in the next API request", async () => {
+				vi.spyOn(mockProvider, "getState").mockResolvedValue({ mode: "ask", mcpEnabled: false })
+				vi.spyOn(mockProvider, "setMode").mockResolvedValue(undefined)
+				const task = new Task({
+					provider: mockProvider,
+					apiConfiguration: mockApiConfig,
+					task: "initial task",
+					startTask: false,
+				})
+				vi.spyOn(task, "handleWebviewAskResponse").mockImplementation(() => {})
+
+				await task.submitUserMessage("switch modes", undefined, "code")
+				vi.spyOn(getTaskTestAccess(task), "getSystemPrompt").mockResolvedValue("mock system prompt")
+				const stream = (async function* () {
+					yield { type: "text", text: "response" } as ApiStreamChunk
+				})()
+				const createMessage = vi.spyOn(task.api, "createMessage").mockReturnValue(stream)
+				task.apiConversationHistory = [
+					{ role: "user", content: [{ type: "text", text: "test message" }], ts: Date.now() },
+				]
+
+				await task.attemptApiRequest().next()
+
+				expect(mockProvider.setMode).toHaveBeenCalledWith("code")
+				expect(requireDefined(createMessage.mock.calls[0])[2]?.mode).toBe("code")
 			})
 
 			it("should handle empty messages gracefully", async () => {


### PR DESCRIPTION
### Related GitHub Issue

References: #369 (PR 1 of 3)

### Description

This is PR 1 of 3 for #369. It prevents a task's mode and API/profile configuration from leaking through shared focused-provider state, while preserving current single-concurrency behavior.

`Task` now reads `mode` from `getTaskMode()` and API configuration from its own `apiConfiguration` in system-prompt generation, manual and forced context condensing, request construction, and rate-limit/retry-backoff handling. Provider state remains the source for genuinely shared settings such as custom modes, experiments, and profile thresholds.

Profile-change notifications now update only the focused task, preventing a profile change from replacing another live task's API handler/configuration. This is a prerequisite for safe concurrent delegation work, without introducing fan-out scheduling, queues, e2e changes, persistence changes, or extension API changes.

### Test Procedure

- `pnpm --dir src exec vitest core/task/__tests__/Task.spec.ts`
- `pnpm --dir src exec eslint --prune-suppressions --max-warnings=0 core/task/Task.ts core/task/__tests__/Task.spec.ts`
- `pnpm --dir src check-types`
- `pnpm --dir src lint`

The focused unit coverage verifies task-local mode/API configuration in prompt and request paths, task-local rate limits during retry backoff, and that profile changes update only the focused task.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Visual Snapshot** (UI changes only): Not applicable; this PR has no UI changes.
- [x] **Documentation Impact**: No documentation updates are required.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

Not applicable; this PR has no UI changes.

### Videos (interaction / animation only)

Not applicable; this PR has no UI changes.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

No changeset included; changesets are managed separately.

### Get in Touch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task-specific mode and API settings are now consistently applied to prompts, requests, context handling, and rate limits.
  * Mode and provider-profile changes now take effect immediately for subsequent requests.
  * Improved retry behavior for rate-limit and context-window errors.
  * Task behavior is no longer affected by unrelated provider settings.

* **Tests**
  * Added coverage confirming task settings remain isolated across requests, prompts, context handling, and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->