### PR TITLE
fix(provider): isolate profile mutations from focused tasks

### DIFF
--- a/apps/vscode-e2e/src/suite/subtasks.test.ts
+++ b/apps/vscode-e2e/src/suite/subtasks.test.ts
@@ -660,7 +660,8 @@ suite("Roo Code Subtasks", function () {
 			...parentProfile,
 			openRouterModelId: "openai/gpt-4.1-mini",
 		}
-		const priorModeApiConfigs = api.getConfiguration().modeApiConfigs ?? {}
+		const priorConfiguration = api.getConfiguration()
+		const priorActiveProfile = api.getActiveProfile()
 		const parentProfileId = await api.upsertProfile("subtask-parent-profile", parentProfile, true)
 		const childProfileId = await api.upsertProfile("subtask-child-profile", childProfile, false)
 		await api.setConfiguration({
@@ -735,7 +736,10 @@ suite("Roo Code Subtasks", function () {
 			)
 		} finally {
 			api.off(RooCodeEventName.Message, messageHandler)
-			await api.setConfiguration({ modeApiConfigs: priorModeApiConfigs })
+			await api.setConfiguration(priorConfiguration)
+			if (priorActiveProfile) {
+				await api.setActiveProfile(priorActiveProfile)
+			}
 			await api.deleteProfile("subtask-child-profile").catch(() => {})
 			await api.deleteProfile("subtask-parent-profile").catch(() => {})
 			while (api.getCurrentTaskStack().length > 0) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -206,18 +206,43 @@ export class ClineProvider
 
 	private enqueueProviderProfileMutation<T>(fn: () => Promise<T>): Promise<T> {
 		const run = this.providerProfileMutationQueue.then(fn, fn)
-		const callerResult = this.withProviderProfileMutationTimeout(run)
-		this.providerProfileMutationQueue = run.then(
+		let timedOut = false
+		const callerResult = this.withProviderProfileMutationTimeout(run, () => {
+			timedOut = true
+			this.log("Provider profile mutation timed out; releasing the mutation queue")
+		})
+
+		void run.then(
+			() => {
+				if (timedOut) {
+					this.log("Provider profile mutation completed after timing out")
+				}
+			},
+			(error) => {
+				if (timedOut) {
+					this.log(
+						`Provider profile mutation failed after timing out: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
+					)
+				}
+			},
+		)
+
+		// Advance from the timeout-bounded caller result, rather than the raw operation. A
+		// provider call that never settles must not block all subsequent profile changes.
+		this.providerProfileMutationQueue = callerResult.then(
 			() => undefined,
 			() => undefined,
 		)
 		return callerResult
 	}
 
-	private withProviderProfileMutationTimeout<T>(operation: Promise<T>): Promise<T> {
+	private withProviderProfileMutationTimeout<T>(operation: Promise<T>, onTimeout: () => void): Promise<T> {
 		let timeoutId: ReturnType<typeof setTimeout> | undefined
 		const timeout = new Promise<never>((_, reject) => {
 			timeoutId = setTimeout(() => {
+				onTimeout()
 				reject(new Error("Provider profile mutation timed out"))
 			}, ClineProvider.PENDING_OPERATION_TIMEOUT_MS)
 		})
@@ -1536,8 +1561,10 @@ export class ClineProvider
 	 * @param targetTask The task whose in-memory mode should be updated. Defaults to the
 	 * current task. Pass null to apply only global mode/profile effects for a pending child.
 	 */
-	public async handleModeSwitch(newMode: Mode, targetTask: Task | null | undefined = this.getCurrentTask()) {
-		return this.enqueueProviderProfileMutation(() => this.handleModeSwitchUnlocked(newMode, targetTask))
+	public async handleModeSwitch(newMode: Mode, targetTask?: Task | null) {
+		return this.enqueueProviderProfileMutation(() =>
+			this.handleModeSwitchUnlocked(newMode, targetTask === undefined ? this.getCurrentTask() : targetTask),
+		)
 	}
 
 	private async handleModeSwitchUnlocked(newMode: Mode, targetTask: Task | null | undefined): Promise<void> {
@@ -1822,12 +1849,14 @@ export class ClineProvider
 		const persistTaskHistory = options?.persistTaskHistory ?? true
 		const skipCurrentTaskRebuild = options?.skipCurrentTaskRebuild ?? false
 
-		// See `upsertProviderProfile` for a description of what this is doing.
-		await Promise.all([
-			this.contextProxy.setValue("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
-			this.contextProxy.setValue("currentApiConfigName", name),
-			this.contextProxy.setProviderSettings(providerSettings),
-		])
+		if (!skipCurrentTaskRebuild) {
+			// See `upsertProviderProfile` for a description of what this is doing.
+			await Promise.all([
+				this.contextProxy.setValue("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
+				this.contextProxy.setValue("currentApiConfigName", name),
+				this.contextProxy.setProviderSettings(providerSettings),
+			])
+		}
 
 		const { mode } = await this.getState()
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -197,10 +197,36 @@ export class ClineProvider
 	private globalStateWriteThroughTimer: ReturnType<typeof setTimeout> | null = null
 	private static readonly GLOBAL_STATE_WRITE_THROUGH_DEBOUNCE_MS = 5000 // 5 seconds
 	private static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
+	private providerProfileMutationQueue = Promise.resolve()
 
 	private runDelegationTransition<T>(parentTaskId: string, fn: () => Promise<T>): Promise<T> {
 		this.delegationTransitionLocks ??= new Map()
 		return runDelegationTransition(this.delegationTransitionLocks, parentTaskId, fn)
+	}
+
+	private enqueueProviderProfileMutation<T>(fn: () => Promise<T>): Promise<T> {
+		const run = this.providerProfileMutationQueue.then(fn, fn)
+		const callerResult = this.withProviderProfileMutationTimeout(run)
+		this.providerProfileMutationQueue = run.then(
+			() => undefined,
+			() => undefined,
+		)
+		return callerResult
+	}
+
+	private withProviderProfileMutationTimeout<T>(operation: Promise<T>): Promise<T> {
+		let timeoutId: ReturnType<typeof setTimeout> | undefined
+		const timeout = new Promise<never>((_, reject) => {
+			timeoutId = setTimeout(() => {
+				reject(new Error("Provider profile mutation timed out"))
+			}, ClineProvider.PENDING_OPERATION_TIMEOUT_MS)
+		})
+
+		return Promise.race([operation, timeout]).finally(() => {
+			if (timeoutId) {
+				clearTimeout(timeoutId)
+			}
+		})
 	}
 	private readonly pendingEditOperations: PendingEditOperationStore
 
@@ -1507,9 +1533,15 @@ export class ClineProvider
 	/**
 	 * Handle switching to a new mode, including updating the associated API configuration
 	 * @param newMode The mode to switch to
+	 * @param targetTask The task whose in-memory mode should be updated. Defaults to the
+	 * current task. Pass null to apply only global mode/profile effects for a pending child.
 	 */
-	public async handleModeSwitch(newMode: Mode) {
-		const task = this.getCurrentTask()
+	public async handleModeSwitch(newMode: Mode, targetTask: Task | null | undefined = this.getCurrentTask()) {
+		return this.enqueueProviderProfileMutation(() => this.handleModeSwitchUnlocked(newMode, targetTask))
+	}
+
+	private async handleModeSwitchUnlocked(newMode: Mode, targetTask: Task | null | undefined): Promise<void> {
+		const task = targetTask
 
 		if (task) {
 			TelemetryService.instance.captureModeSwitch(task.taskId, newMode)
@@ -1546,7 +1578,9 @@ export class ClineProvider
 		// If workspace lock is on, keep the current API config — don't load mode-specific config
 		const lockApiConfigAcrossModes = this.context.workspaceState.get("lockApiConfigAcrossModes", false)
 		if (lockApiConfigAcrossModes) {
-			await this.postStateToWebview()
+			if (targetTask !== null) {
+				await this.postStateToWebview()
+			}
 			return
 		}
 
@@ -1572,7 +1606,10 @@ export class ClineProvider
 				const hasActualSettings = !!fullProfile.apiProvider
 
 				if (hasActualSettings) {
-					await this.activateProviderProfile({ name: profile.name })
+					await this.activateProviderProfileUnlocked(
+						{ name: profile.name },
+						targetTask === null ? { skipCurrentTaskRebuild: true } : undefined,
+					)
 				} else {
 					// The task will continue with the current/default configuration.
 				}
@@ -1592,7 +1629,9 @@ export class ClineProvider
 			}
 		}
 
-		await this.postStateToWebview()
+		if (targetTask !== null) {
+			await this.postStateToWebview()
+		}
 	}
 
 	// Provider Profile Management
@@ -1608,8 +1647,9 @@ export class ClineProvider
 	 */
 	private updateTaskApiHandlerIfNeeded(
 		providerSettings: ProviderSettings,
-		options: { forceRebuild?: boolean } = {},
+		options: { forceRebuild?: boolean; skipCurrentTaskRebuild?: boolean } = {},
 	): void {
+		if (options.skipCurrentTaskRebuild) return
 		const task = this.getCurrentTask()
 		if (!task) return
 
@@ -1725,7 +1765,11 @@ export class ClineProvider
 		await this.postStateToWebview()
 	}
 
-	private async persistStickyProviderProfileToCurrentTask(apiConfigName: string): Promise<void> {
+	private async persistStickyProviderProfileToCurrentTask(
+		apiConfigName: string,
+		options: { skipCurrentTaskRebuild?: boolean } = {},
+	): Promise<void> {
+		if (options.skipCurrentTaskRebuild) return
 		const task = this.getCurrentTask()
 		if (!task) {
 			return
@@ -1755,12 +1799,28 @@ export class ClineProvider
 
 	async activateProviderProfile(
 		args: { name: string } | { id: string },
-		options?: { persistModeConfig?: boolean; persistTaskHistory?: boolean },
+		options?: {
+			persistModeConfig?: boolean
+			persistTaskHistory?: boolean
+			skipCurrentTaskRebuild?: boolean
+		},
 	) {
+		return this.enqueueProviderProfileMutation(() => this.activateProviderProfileUnlocked(args, options))
+	}
+
+	private async activateProviderProfileUnlocked(
+		args: { name: string } | { id: string },
+		options?: {
+			persistModeConfig?: boolean
+			persistTaskHistory?: boolean
+			skipCurrentTaskRebuild?: boolean
+		},
+	): Promise<void> {
 		const { name, id, ...providerSettings } = await this.providerSettingsManager.activateProfile(args)
 
 		const persistModeConfig = options?.persistModeConfig ?? true
 		const persistTaskHistory = options?.persistTaskHistory ?? true
+		const skipCurrentTaskRebuild = options?.skipCurrentTaskRebuild ?? false
 
 		// See `upsertProviderProfile` for a description of what this is doing.
 		await Promise.all([
@@ -1776,17 +1836,19 @@ export class ClineProvider
 		}
 
 		// Change the provider for the current task.
-		this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true })
+		this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true, skipCurrentTaskRebuild })
 
 		// Update the current task's sticky provider profile, unless this activation is
 		// being used purely as a non-persisting restoration (e.g., reopening a task from history).
 		if (persistTaskHistory) {
-			await this.persistStickyProviderProfileToCurrentTask(name)
+			await this.persistStickyProviderProfileToCurrentTask(name, { skipCurrentTaskRebuild })
 		}
 
-		await this.postStateToWebview()
+		if (!skipCurrentTaskRebuild) {
+			await this.postStateToWebview()
+		}
 
-		if (providerSettings.apiProvider) {
+		if (providerSettings.apiProvider && !skipCurrentTaskRebuild) {
 			this.emit(RooCodeEventName.ProviderProfileChanged, { name, provider: providerSettings.apiProvider })
 		}
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -196,7 +196,7 @@ export class ClineProvider
 	private taskHistoryStoreInitialized = false
 	private globalStateWriteThroughTimer: ReturnType<typeof setTimeout> | null = null
 	private static readonly GLOBAL_STATE_WRITE_THROUGH_DEBOUNCE_MS = 5000 // 5 seconds
-	private static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
+	public static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
 	private providerProfileMutationQueue = Promise.resolve()
 
 	private runDelegationTransition<T>(parentTaskId: string, fn: () => Promise<T>): Promise<T> {
@@ -205,11 +205,12 @@ export class ClineProvider
 	}
 
 	private enqueueProviderProfileMutation<T>(fn: () => Promise<T>): Promise<T> {
+		// Run after either outcome so a rejected mutation never poisons the queue.
 		const run = this.providerProfileMutationQueue.then(fn, fn)
 		let timedOut = false
 		const callerResult = this.withProviderProfileMutationTimeout(run, () => {
 			timedOut = true
-			this.log("Provider profile mutation timed out; releasing the mutation queue")
+			this.log("Provider profile mutation timed out; waiting for the in-flight mutation to settle")
 		})
 
 		void run.then(
@@ -229,9 +230,9 @@ export class ClineProvider
 			},
 		)
 
-		// Advance from the timeout-bounded caller result, rather than the raw operation. A
-		// provider call that never settles must not block all subsequent profile changes.
-		this.providerProfileMutationQueue = callerResult.then(
+		// Keep the raw operation as the queue boundary. Releasing the queue on timeout
+		// would allow its later state writes to overwrite a subsequent mutation.
+		this.providerProfileMutationQueue = run.then(
 			() => undefined,
 			() => undefined,
 		)
@@ -253,6 +254,7 @@ export class ClineProvider
 			}
 		})
 	}
+
 	private readonly pendingEditOperations: PendingEditOperationStore
 
 	private cloudOrganizationsCache: CloudOrganizationMembership[] | null = null
@@ -1561,10 +1563,8 @@ export class ClineProvider
 	 * @param targetTask The task whose in-memory mode should be updated. Defaults to the
 	 * current task. Pass null to apply only global mode/profile effects for a pending child.
 	 */
-	public async handleModeSwitch(newMode: Mode, targetTask?: Task | null) {
-		return this.enqueueProviderProfileMutation(() =>
-			this.handleModeSwitchUnlocked(newMode, targetTask === undefined ? this.getCurrentTask() : targetTask),
-		)
+	public async handleModeSwitch(newMode: Mode, targetTask: Task | null | undefined = this.getCurrentTask()) {
+		return this.enqueueProviderProfileMutation(() => this.handleModeSwitchUnlocked(newMode, targetTask))
 	}
 
 	private async handleModeSwitchUnlocked(newMode: Mode, targetTask: Task | null | undefined): Promise<void> {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -204,25 +204,28 @@ export class ClineProvider
 		return runDelegationTransition(this.delegationTransitionLocks, parentTaskId, fn)
 	}
 
-	private enqueueProviderProfileMutation<T>(fn: () => Promise<T>): Promise<T> {
-		// Run after either outcome so a rejected mutation never poisons the queue.
-		const run = this.providerProfileMutationQueue.then(fn, fn)
-		let timedOut = false
+	private enqueueProviderProfileMutation<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+		const controller = new AbortController()
+		// Run fn after either outcome so a rejected mutation never poisons the queue.
+		const run = this.providerProfileMutationQueue.then(
+			() => fn(controller.signal),
+			() => fn(controller.signal),
+		)
 		const callerResult = this.withProviderProfileMutationTimeout(run, () => {
-			timedOut = true
-			this.log("Provider profile mutation timed out; waiting for the in-flight mutation to settle")
+			controller.abort()
+			this.log("Provider profile mutation timed out; aborting in-flight mutation")
 		})
 
 		void run.then(
 			() => {
-				if (timedOut) {
-					this.log("Provider profile mutation completed after timing out")
+				if (controller.signal.aborted) {
+					this.log("Provider profile mutation completed after cancellation")
 				}
 			},
 			(error) => {
-				if (timedOut) {
+				if (controller.signal.aborted) {
 					this.log(
-						`Provider profile mutation failed after timing out: ${
+						`Provider profile mutation errored after cancellation: ${
 							error instanceof Error ? error.message : String(error)
 						}`,
 					)
@@ -230,9 +233,9 @@ export class ClineProvider
 			},
 		)
 
-		// Keep the raw operation as the queue boundary. Releasing the queue on timeout
-		// would allow its later state writes to overwrite a subsequent mutation.
-		this.providerProfileMutationQueue = run.then(
+		// Advance from the timeout-bounded result. Each fn checks its AbortSignal before
+		// writing state, so advancing the queue on timeout cannot produce stale overwrites.
+		this.providerProfileMutationQueue = callerResult.then(
 			() => undefined,
 			() => undefined,
 		)
@@ -1564,10 +1567,16 @@ export class ClineProvider
 	 * current task. Pass null to apply only global mode/profile effects for a pending child.
 	 */
 	public async handleModeSwitch(newMode: Mode, targetTask: Task | null | undefined = this.getCurrentTask()) {
-		return this.enqueueProviderProfileMutation(() => this.handleModeSwitchUnlocked(newMode, targetTask))
+		return this.enqueueProviderProfileMutation((signal) =>
+			this.handleModeSwitchUnlocked(newMode, targetTask, signal),
+		)
 	}
 
-	private async handleModeSwitchUnlocked(newMode: Mode, targetTask: Task | null | undefined): Promise<void> {
+	private async handleModeSwitchUnlocked(
+		newMode: Mode,
+		targetTask: Task | null | undefined,
+		signal?: AbortSignal,
+	): Promise<void> {
 		const task = targetTask
 
 		if (task) {
@@ -1611,9 +1620,13 @@ export class ClineProvider
 			return
 		}
 
+		if (signal?.aborted) return
+
 		// Load the saved API config for the new mode if it exists.
 		const savedConfigId = await this.providerSettingsManager.getModeConfigId(newMode)
 		const listApiConfig = await this.providerSettingsManager.listConfig()
+
+		if (signal?.aborted) return
 
 		// Update listApiConfigMeta first to ensure UI has latest data.
 		await this.updateGlobalState("listApiConfigMeta", listApiConfig)
@@ -1636,6 +1649,7 @@ export class ClineProvider
 					await this.activateProviderProfileUnlocked(
 						{ name: profile.name },
 						targetTask === null ? { skipCurrentTaskRebuild: true } : undefined,
+						signal,
 					)
 				} else {
 					// The task will continue with the current/default configuration.
@@ -1720,45 +1734,49 @@ export class ClineProvider
 		activate: boolean = true,
 	): Promise<string | undefined> {
 		try {
-			// TODO: Do we need to be calling `activateProfile`? It's not
-			// clear to me what the source of truth should be; in some cases
-			// we rely on the `ContextProxy`'s data store and in other cases
-			// we rely on the `ProviderSettingsManager`'s data store. It might
-			// be simpler to unify these two.
-			const id = await this.providerSettingsManager.saveConfig(name, providerSettings)
+			return await this.enqueueProviderProfileMutation(async (signal) => {
+				// TODO: Do we need to be calling `activateProfile`? It's not
+				// clear to me what the source of truth should be; in some cases
+				// we rely on the `ContextProxy`'s data store and in other cases
+				// we rely on the `ProviderSettingsManager`'s data store. It might
+				// be simpler to unify these two.
+				const id = await this.providerSettingsManager.saveConfig(name, providerSettings)
 
-			if (activate) {
-				const { mode } = await this.getState()
+				if (signal.aborted) return id
 
-				// These promises do the following:
-				// 1. Adds or updates the list of provider profiles.
-				// 2. Sets the current provider profile.
-				// 3. Sets the current mode's provider profile.
-				// 4. Copies the provider settings to the context.
-				//
-				// Note: 1, 2, and 4 can be done in one `ContextProxy` call:
-				// this.contextProxy.setValues({ ...providerSettings, listApiConfigMeta: ..., currentApiConfigName: ... })
-				// We should probably switch to that and verify that it works.
-				// I left the original implementation in just to be safe.
-				await Promise.all([
-					this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
-					this.updateGlobalState("currentApiConfigName", name),
-					this.providerSettingsManager.setModeConfig(mode, id),
-					this.contextProxy.setProviderSettings(providerSettings),
-				])
+				if (activate) {
+					const { mode } = await this.getState()
 
-				// Change the provider for the current task.
-				// TODO: We should rename `buildApiHandler` for clarity (e.g. `getProviderClient`).
-				this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true })
+					// These promises do the following:
+					// 1. Adds or updates the list of provider profiles.
+					// 2. Sets the current provider profile.
+					// 3. Sets the current mode's provider profile.
+					// 4. Copies the provider settings to the context.
+					//
+					// Note: 1, 2, and 4 can be done in one `ContextProxy` call:
+					// this.contextProxy.setValues({ ...providerSettings, listApiConfigMeta: ..., currentApiConfigName: ... })
+					// We should probably switch to that and verify that it works.
+					// I left the original implementation in just to be safe.
+					await Promise.all([
+						this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
+						this.updateGlobalState("currentApiConfigName", name),
+						this.providerSettingsManager.setModeConfig(mode, id),
+						this.contextProxy.setProviderSettings(providerSettings),
+					])
 
-				// Keep the current task's sticky provider profile in sync with the newly-activated profile.
-				await this.persistStickyProviderProfileToCurrentTask(name)
-			} else {
-				await this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig())
-			}
+					// Change the provider for the current task.
+					// TODO: We should rename `buildApiHandler` for clarity (e.g. `getProviderClient`).
+					this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true })
 
-			await this.postStateToWebview()
-			return id
+					// Keep the current task's sticky provider profile in sync with the newly-activated profile.
+					await this.persistStickyProviderProfileToCurrentTask(name)
+				} else {
+					await this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig())
+				}
+
+				await this.postStateToWebview()
+				return id
+			})
 		} catch (error) {
 			this.log(
 				`Error create new api configuration: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
@@ -1832,7 +1850,9 @@ export class ClineProvider
 			skipCurrentTaskRebuild?: boolean
 		},
 	) {
-		return this.enqueueProviderProfileMutation(() => this.activateProviderProfileUnlocked(args, options))
+		return this.enqueueProviderProfileMutation((signal) =>
+			this.activateProviderProfileUnlocked(args, options, signal),
+		)
 	}
 
 	private async activateProviderProfileUnlocked(
@@ -1842,8 +1862,11 @@ export class ClineProvider
 			persistTaskHistory?: boolean
 			skipCurrentTaskRebuild?: boolean
 		},
+		signal?: AbortSignal,
 	): Promise<void> {
 		const { name, id, ...providerSettings } = await this.providerSettingsManager.activateProfile(args)
+
+		if (signal?.aborted) return
 
 		const persistModeConfig = options?.persistModeConfig ?? true
 		const persistTaskHistory = options?.persistTaskHistory ?? true

--- a/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
@@ -457,6 +457,7 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 
 		test("provider profile mutation rejection does not poison later queued mutations", async () => {
 			const firstError = new Error("first profile failed")
+			const setValueSpy = vi.spyOn(provider.contextProxy, "setValue")
 
 			provider["providerSettingsManager"].activateProfile = vi
 				.fn()
@@ -470,14 +471,27 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 
 			await expect(provider.activateProviderProfile({ name: "first-profile" })).rejects.toThrow(firstError)
 			await expect(provider.activateProviderProfile({ name: "second-profile" })).resolves.toBeUndefined()
+			expect(setValueSpy).toHaveBeenCalledWith("currentApiConfigName", "second-profile")
 		})
 
-		test("provider profile mutation timeout releases later queued mutations", async () => {
+		test("timed-out provider profile mutations retain the queue boundary until they settle", async () => {
 			vi.useFakeTimers()
 			const logSpy = vi.spyOn(provider, "log")
+			let resolveFirst!: () => void
+			const firstActivation = new Promise<void>((resolve) => {
+				resolveFirst = resolve
+			})
 			provider["providerSettingsManager"].activateProfile = vi
 				.fn()
-				.mockImplementationOnce(() => new Promise<never>(() => {}))
+				.mockImplementationOnce(async () => {
+					await firstActivation
+					return {
+						name: "first-profile",
+						id: "first-id",
+						apiProvider: "openrouter",
+						openRouterModelId: "openai/gpt-4",
+					}
+				})
 				.mockResolvedValueOnce({
 					name: "second-profile",
 					id: "second-id",
@@ -488,17 +502,24 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			try {
 				const first = provider.activateProviderProfile({ name: "first-profile" })
 				const firstResult = expect(first).rejects.toThrow("Provider profile mutation timed out")
-				await vi.advanceTimersByTimeAsync(30_000)
+				await vi.advanceTimersByTimeAsync(ClineProvider.PENDING_OPERATION_TIMEOUT_MS)
 				await firstResult
 
-				await expect(provider.activateProviderProfile({ name: "second-profile" })).resolves.toBeUndefined()
-				expect(logSpy).toHaveBeenCalledWith("Provider profile mutation timed out; releasing the mutation queue")
+				const second = provider.activateProviderProfile({ name: "second-profile" })
+				expect(provider["providerSettingsManager"].activateProfile).toHaveBeenCalledTimes(1)
+
+				resolveFirst()
+				await expect(second).resolves.toBeUndefined()
+				expect(provider["providerSettingsManager"].activateProfile).toHaveBeenCalledTimes(2)
+				expect(logSpy).toHaveBeenCalledWith(
+					"Provider profile mutation timed out; waiting for the in-flight mutation to settle",
+				)
 			} finally {
 				vi.useRealTimers()
 			}
 		})
 
-		test("mode switch resolves its default task when its queued mutation starts", async () => {
+		test("mode switch preserves its default task when queued behind a profile mutation", async () => {
 			let releaseProfileActivation!: () => void
 			const profileActivation = new Promise<void>((resolve) => {
 				releaseProfileActivation = resolve
@@ -515,6 +536,10 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 
 			const firstTask = new Task(defaultTaskOptions)
 			const secondTask = new Task(defaultTaskOptions)
+			Object.defineProperty(firstTask, "taskId", { value: "first-task-id" })
+			Object.defineProperty(secondTask, "taskId", { value: "second-task-id" })
+			firstTask["_taskMode"] = "code" as Mode
+			secondTask["_taskMode"] = "code" as Mode
 			await provider.addClineToStack(firstTask)
 
 			const profileSwitch = provider.activateProviderProfile({ name: "first-profile" })
@@ -525,8 +550,8 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			await profileSwitch
 			await modeSwitch
 
-			expect(firstTask["_taskMode"]).not.toBe("ask")
-			expect(secondTask["_taskMode"]).toBe("ask")
+			expect(firstTask["_taskMode"]).toBe("ask")
+			expect(secondTask["_taskMode"]).toBe("code")
 		})
 
 		test("fan-out preparation leaves the focused task untouched", async () => {
@@ -570,6 +595,8 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			expect(postStateSpy).not.toHaveBeenCalled()
 			expect(setValueSpy).not.toHaveBeenCalledWith("currentApiConfigName", "ask-profile")
 			expect(setProviderSettingsSpy).not.toHaveBeenCalled()
+			expect(emitSpy).toHaveBeenCalledWith(RooCodeEventName.ModeChanged, "ask")
+			expect(provider["providerSettingsManager"].activateProfile).toHaveBeenCalledWith({ name: "ask-profile" })
 		})
 
 		test("calls updateApiConfiguration when provider/model unchanged but settings differ (explicit profile switch)", async () => {

--- a/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
@@ -3,9 +3,10 @@
 import * as vscode from "vscode"
 
 import { TelemetryService } from "@roo-code/telemetry"
-import { getModelId } from "@roo-code/types"
+import { getModelId, RooCodeEventName } from "@roo-code/types"
 
 import { ContextProxy } from "../../config/ContextProxy"
+import type { Mode } from "../../../shared/modes"
 import { Task, TaskOptions } from "../../task/Task"
 import { ClineProvider } from "../ClineProvider"
 
@@ -110,6 +111,7 @@ vi.mock("../../task/Task", () => ({
 			overwriteApiConversationHistory: vi.fn(),
 			taskId: options?.historyItem?.id || "test-task-id",
 			emit: vi.fn(),
+			setTaskApiConfigName: vi.fn(),
 			updateApiConfiguration: vi.fn().mockImplementation(function (this: any, newConfig: any) {
 				this.apiConfiguration = newConfig
 			}),
@@ -235,6 +237,7 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 					{ name: "test-config", id: "test-id", apiProvider: "openrouter", modelId: "openai/gpt-4" },
 				]),
 			setModeConfig: vi.fn(),
+			getModeConfigId: vi.fn().mockResolvedValue(undefined),
 			activateProfile: vi.fn().mockResolvedValue({
 				name: "test-config",
 				id: "test-id",
@@ -410,6 +413,104 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 	})
 
 	describe("activateProviderProfile", () => {
+		test("serializes provider profile mutations without interleaving", async () => {
+			const events: string[] = []
+			let resolveFirst!: () => void
+
+			provider["providerSettingsManager"].activateProfile = vi
+				.fn()
+				.mockImplementationOnce(async () => {
+					events.push("first:start")
+					await new Promise<void>((resolve) => {
+						resolveFirst = resolve
+					})
+					events.push("first:end")
+					return {
+						name: "first-profile",
+						id: "first-id",
+						apiProvider: "openrouter",
+						openRouterModelId: "openai/gpt-4",
+					}
+				})
+				.mockImplementationOnce(async () => {
+					events.push("second:start")
+					return {
+						name: "second-profile",
+						id: "second-id",
+						apiProvider: "openrouter",
+						openRouterModelId: "openai/gpt-4.1-mini",
+					}
+				})
+
+			const first = provider.activateProviderProfile({ name: "first-profile" })
+			const second = provider.activateProviderProfile({ name: "second-profile" })
+
+			await Promise.resolve()
+			expect(events).toEqual(["first:start"])
+
+			resolveFirst()
+			await first
+			await second
+
+			expect(events).toEqual(["first:start", "first:end", "second:start"])
+		})
+
+		test("provider profile mutation rejection does not poison later queued mutations", async () => {
+			const firstError = new Error("first profile failed")
+
+			provider["providerSettingsManager"].activateProfile = vi
+				.fn()
+				.mockRejectedValueOnce(firstError)
+				.mockResolvedValueOnce({
+					name: "second-profile",
+					id: "second-id",
+					apiProvider: "openrouter",
+					openRouterModelId: "openai/gpt-4.1-mini",
+				})
+
+			await expect(provider.activateProviderProfile({ name: "first-profile" })).rejects.toThrow(firstError)
+			await expect(provider.activateProviderProfile({ name: "second-profile" })).resolves.toBeUndefined()
+		})
+
+		test("fan-out preparation leaves the focused task untouched", async () => {
+			const mockTask = new Task({
+				...defaultTaskOptions,
+				apiConfiguration: {
+					apiProvider: "openrouter",
+					openRouterModelId: "openai/gpt-4",
+				},
+			})
+			await provider.addClineToStack(mockTask)
+			provider["providerSettingsManager"].getModeConfigId = vi.fn().mockResolvedValue("ask-id")
+			provider["providerSettingsManager"].listConfig = vi
+				.fn()
+				.mockResolvedValue([{ name: "ask-profile", id: "ask-id", apiProvider: "openrouter" }])
+			provider["providerSettingsManager"].getProfile = vi.fn().mockResolvedValue({
+				name: "ask-profile",
+				id: "ask-id",
+				apiProvider: "openrouter",
+				openRouterModelId: "openai/gpt-4.1-mini",
+			})
+			provider["providerSettingsManager"].activateProfile = vi.fn().mockResolvedValue({
+				name: "ask-profile",
+				id: "ask-id",
+				apiProvider: "openrouter",
+				openRouterModelId: "openai/gpt-4.1-mini",
+			})
+			const emitSpy = vi.spyOn(provider, "emit")
+			const postStateSpy = vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+
+			await provider.handleModeSwitch("ask" as Mode, null)
+
+			expect(mockTask.updateApiConfiguration).not.toHaveBeenCalled()
+			expect(mockTask.setTaskApiConfigName).not.toHaveBeenCalled()
+			expect(emitSpy).not.toHaveBeenCalledWith(
+				RooCodeEventName.ProviderProfileChanged,
+				expect.objectContaining({ name: "ask-profile" }),
+			)
+			expect(postStateSpy).not.toHaveBeenCalled()
+		})
+
 		test("calls updateApiConfiguration when provider/model unchanged but settings differ (explicit profile switch)", async () => {
 			const mockTask = new Task({
 				...defaultTaskOptions,

--- a/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
@@ -474,9 +474,10 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			expect(setValueSpy).toHaveBeenCalledWith("currentApiConfigName", "second-profile")
 		})
 
-		test("timed-out provider profile mutations retain the queue boundary until they settle", async () => {
+		test("timed-out mutations abort before writing state and advance the queue", async () => {
 			vi.useFakeTimers()
 			const logSpy = vi.spyOn(provider, "log")
+			const setValueSpy = vi.spyOn(provider.contextProxy, "setValue")
 			let resolveFirst!: () => void
 			const firstActivation = new Promise<void>((resolve) => {
 				resolveFirst = resolve
@@ -505,15 +506,20 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 				await vi.advanceTimersByTimeAsync(ClineProvider.PENDING_OPERATION_TIMEOUT_MS)
 				await firstResult
 
+				// Queue advanced immediately on timeout — second enqueues now.
 				const second = provider.activateProviderProfile({ name: "second-profile" })
+				// activateProfile not yet called for second (it runs in the next microtask).
 				expect(provider["providerSettingsManager"].activateProfile).toHaveBeenCalledTimes(1)
 
+				// Resolve the first activation's inner promise so its in-flight mock can return.
+				// The aborted signal prevents it from writing any state.
 				resolveFirst()
 				await expect(second).resolves.toBeUndefined()
 				expect(provider["providerSettingsManager"].activateProfile).toHaveBeenCalledTimes(2)
-				expect(logSpy).toHaveBeenCalledWith(
-					"Provider profile mutation timed out; waiting for the in-flight mutation to settle",
-				)
+				// Aborted first activation wrote nothing; only second profile is set.
+				expect(setValueSpy).not.toHaveBeenCalledWith("currentApiConfigName", "first-profile")
+				expect(setValueSpy).toHaveBeenCalledWith("currentApiConfigName", "second-profile")
+				expect(logSpy).toHaveBeenCalledWith("Provider profile mutation timed out; aborting in-flight mutation")
 			} finally {
 				vi.useRealTimers()
 			}

--- a/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
@@ -525,8 +525,8 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			await profileSwitch
 			await modeSwitch
 
-			expect((firstTask as unknown as { _taskMode?: Mode })._taskMode).not.toBe("ask")
-			expect((secondTask as unknown as { _taskMode?: Mode })._taskMode).toBe("ask")
+			expect(firstTask["_taskMode"]).not.toBe("ask")
+			expect(secondTask["_taskMode"]).toBe("ask")
 		})
 
 		test("fan-out preparation leaves the focused task untouched", async () => {

--- a/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
@@ -472,6 +472,63 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			await expect(provider.activateProviderProfile({ name: "second-profile" })).resolves.toBeUndefined()
 		})
 
+		test("provider profile mutation timeout releases later queued mutations", async () => {
+			vi.useFakeTimers()
+			const logSpy = vi.spyOn(provider, "log")
+			provider["providerSettingsManager"].activateProfile = vi
+				.fn()
+				.mockImplementationOnce(() => new Promise<never>(() => {}))
+				.mockResolvedValueOnce({
+					name: "second-profile",
+					id: "second-id",
+					apiProvider: "openrouter",
+					openRouterModelId: "openai/gpt-4.1-mini",
+				})
+
+			try {
+				const first = provider.activateProviderProfile({ name: "first-profile" })
+				const firstResult = expect(first).rejects.toThrow("Provider profile mutation timed out")
+				await vi.advanceTimersByTimeAsync(30_000)
+				await firstResult
+
+				await expect(provider.activateProviderProfile({ name: "second-profile" })).resolves.toBeUndefined()
+				expect(logSpy).toHaveBeenCalledWith("Provider profile mutation timed out; releasing the mutation queue")
+			} finally {
+				vi.useRealTimers()
+			}
+		})
+
+		test("mode switch resolves its default task when its queued mutation starts", async () => {
+			let releaseProfileActivation!: () => void
+			const profileActivation = new Promise<void>((resolve) => {
+				releaseProfileActivation = resolve
+			})
+			provider["providerSettingsManager"].activateProfile = vi.fn().mockImplementationOnce(async () => {
+				await profileActivation
+				return {
+					name: "first-profile",
+					id: "first-id",
+					apiProvider: "openrouter",
+					openRouterModelId: "openai/gpt-4",
+				}
+			})
+
+			const firstTask = new Task(defaultTaskOptions)
+			const secondTask = new Task(defaultTaskOptions)
+			await provider.addClineToStack(firstTask)
+
+			const profileSwitch = provider.activateProviderProfile({ name: "first-profile" })
+			const modeSwitch = provider.handleModeSwitch("ask" as Mode)
+			await provider.addClineToStack(secondTask)
+
+			releaseProfileActivation()
+			await profileSwitch
+			await modeSwitch
+
+			expect((firstTask as unknown as { _taskMode?: Mode })._taskMode).not.toBe("ask")
+			expect((secondTask as unknown as { _taskMode?: Mode })._taskMode).toBe("ask")
+		})
+
 		test("fan-out preparation leaves the focused task untouched", async () => {
 			const mockTask = new Task({
 				...defaultTaskOptions,
@@ -499,6 +556,8 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 			})
 			const emitSpy = vi.spyOn(provider, "emit")
 			const postStateSpy = vi.spyOn(provider, "postStateToWebview").mockResolvedValue(undefined)
+			const setValueSpy = vi.spyOn(provider.contextProxy, "setValue")
+			const setProviderSettingsSpy = vi.spyOn(provider.contextProxy, "setProviderSettings")
 
 			await provider.handleModeSwitch("ask" as Mode, null)
 
@@ -509,6 +568,8 @@ describe("ClineProvider - API Handler Rebuild Guard", () => {
 				expect.objectContaining({ name: "ask-profile" }),
 			)
 			expect(postStateSpy).not.toHaveBeenCalled()
+			expect(setValueSpy).not.toHaveBeenCalledWith("currentApiConfigName", "ask-profile")
+			expect(setProviderSettingsSpy).not.toHaveBeenCalled()
 		})
 
 		test("calls updateApiConfiguration when provider/model unchanged but settings differ (explicit profile switch)", async () => {

--- a/src/core/webview/__tests__/ClineProvider.lockApiConfig.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.lockApiConfig.spec.ts
@@ -374,14 +374,15 @@ describe("ClineProvider - Lock API Config Across Modes", () => {
 				apiProvider: "anthropic",
 			})
 
-			const activateProviderProfileSpy = vi
-				.spyOn(provider, "activateProviderProfile")
-				.mockResolvedValue(undefined)
+			const activateProfileSpy = vi.spyOn(provider.providerSettingsManager, "activateProfile").mockResolvedValue({
+				name: "architect-profile",
+				apiProvider: "anthropic",
+			})
 
 			await provider.handleModeSwitch("architect")
 
 			expect(getModeConfigIdSpy).toHaveBeenCalledWith("architect")
-			expect(activateProviderProfileSpy).toHaveBeenCalledWith({ name: "architect-profile" })
+			expect(activateProfileSpy).toHaveBeenCalledWith({ name: "architect-profile" })
 		})
 	})
 })

--- a/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
@@ -1155,18 +1155,11 @@ describe("ClineProvider - Sticky Mode", () => {
 				return Promise.resolve([])
 			})
 
-			// Mock getCurrentTask to return different tasks
-			const getCurrentTaskSpy = vi.spyOn(provider, "getCurrentTask")
-
-			// Simulate simultaneous mode switches for different tasks
-			getCurrentTaskSpy.mockReturnValue(task1 as any)
-			const switch1 = provider.handleModeSwitch("architect")
-
-			getCurrentTaskSpy.mockReturnValue(task2 as any)
-			const switch2 = provider.handleModeSwitch("debug")
-
-			getCurrentTaskSpy.mockReturnValue(task3 as any)
-			const switch3 = provider.handleModeSwitch("code")
+			// Simulate simultaneous mode switches for distinct, explicitly targeted tasks.
+			// These lightweight task doubles only implement the members exercised by this test.
+			const switch1 = provider.handleModeSwitch("architect", task1 as unknown as Task)
+			const switch2 = provider.handleModeSwitch("debug", task2 as unknown as Task)
+			const switch3 = provider.handleModeSwitch("code", task3 as unknown as Task)
 
 			await Promise.all([switch1, switch2, switch3])
 

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1076,7 +1076,7 @@
 	},
 	"core/webview/__tests__/ClineProvider.sticky-mode.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 40
+			"count": 37
 		}
 	},
 	"core/webview/__tests__/ClineProvider.sticky-profile.spec.ts": {

--- a/src/extension/__tests__/api-configuration.spec.ts
+++ b/src/extension/__tests__/api-configuration.spec.ts
@@ -30,9 +30,36 @@ describe("API - configuration", () => {
 		})
 
 		expect(saveConfig).toHaveBeenCalledWith("default", expect.objectContaining({ currentApiConfigName: "default" }))
+		expect(setValues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				currentApiConfigName: "default",
+				modeApiConfigs: expect.anything(),
+			}),
+		)
 		expect(setModeConfig).toHaveBeenCalledTimes(2)
 		expect(setModeConfig).toHaveBeenCalledWith("code", "code-config")
 		expect(setModeConfig).toHaveBeenCalledWith("architect", "architect-config")
+		expect(postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("does not persist mode mappings when none are supplied", async () => {
+		const setValues = vi.fn().mockResolvedValue(undefined)
+		const saveConfig = vi.fn().mockResolvedValue("default-id")
+		const setModeConfig = vi.fn().mockResolvedValue(undefined)
+		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const provider = {
+			context: {},
+			on: vi.fn(),
+			contextProxy: { setValues },
+			providerSettingsManager: { saveConfig, setModeConfig },
+			postStateToWebview,
+		} as unknown as ClineProvider
+		const outputChannel = { appendLine: vi.fn() } as unknown as vscode.OutputChannel
+		const api = new API(outputChannel, provider)
+
+		await api.setConfiguration({ currentApiConfigName: "default" })
+
+		expect(setModeConfig).not.toHaveBeenCalled()
 		expect(postStateToWebview).toHaveBeenCalledOnce()
 	})
 })

--- a/src/extension/__tests__/api-configuration.spec.ts
+++ b/src/extension/__tests__/api-configuration.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest"
+import type * as vscode from "vscode"
+
+import { API } from "../api"
+import type { ClineProvider } from "../../core/webview/ClineProvider"
+
+vi.mock("@roo-code/ipc", () => ({
+	IpcServer: class {},
+}))
+
+describe("API - configuration", () => {
+	it("persists every supplied mode API config mapping", async () => {
+		const setValues = vi.fn().mockResolvedValue(undefined)
+		const saveConfig = vi.fn().mockResolvedValue("default-id")
+		const setModeConfig = vi.fn().mockResolvedValue(undefined)
+		const postStateToWebview = vi.fn().mockResolvedValue(undefined)
+		const provider = {
+			context: {},
+			on: vi.fn(),
+			contextProxy: { setValues },
+			providerSettingsManager: { saveConfig, setModeConfig },
+			postStateToWebview,
+		} as unknown as ClineProvider
+		const outputChannel = { appendLine: vi.fn() } as unknown as vscode.OutputChannel
+		const api = new API(outputChannel, provider)
+
+		await api.setConfiguration({
+			currentApiConfigName: "default",
+			modeApiConfigs: { code: "code-config", architect: "architect-config" },
+		})
+
+		expect(saveConfig).toHaveBeenCalledWith("default", expect.objectContaining({ currentApiConfigName: "default" }))
+		expect(setModeConfig).toHaveBeenCalledTimes(2)
+		expect(setModeConfig).toHaveBeenCalledWith("code", "code-config")
+		expect(setModeConfig).toHaveBeenCalledWith("architect", "architect-config")
+		expect(postStateToWebview).toHaveBeenCalledOnce()
+	})
+})

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -23,6 +23,7 @@ import {
 import { IpcServer } from "@roo-code/ipc"
 
 import { Package } from "../shared/package"
+import type { Mode } from "../shared/modes"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { Terminal } from "../integrations/terminal/Terminal"
 import { TerminalRegistry } from "../integrations/terminal/TerminalRegistry"
@@ -505,6 +506,13 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	public async setConfiguration(values: RooCodeSettings) {
 		await this.sidebarProvider.contextProxy.setValues(values)
 		await this.sidebarProvider.providerSettingsManager.saveConfig(values.currentApiConfigName || "default", values)
+		if (values.modeApiConfigs) {
+			await Promise.all(
+				Object.entries(values.modeApiConfigs).map(([mode, configId]) =>
+					this.sidebarProvider.providerSettingsManager.setModeConfig(mode as Mode, configId),
+				),
+			)
+		}
 		await this.sidebarProvider.postStateToWebview()
 	}
 


### PR DESCRIPTION
## Summary

PR 2 of 3 for #369, extracted from #1046.

- Serializes provider profile and mode mutations with the existing 30-second timeout while preserving errors for the initiating caller.
- Allows pending-child mode/profile preparation without rebuilding, reconfiguring, or posting the currently focused task.
- Persists supplied `modeApiConfigs` mappings through `ProviderSettingsManager.setModeConfig()`.

This prepares safe provider mode/profile handling for future concurrent delegation, but does **not** enable concurrency or fan-out. #1085 is the complementary task-local isolation extraction.

## Validation

- `pnpm --dir src exec vitest run core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts`
- `pnpm --dir src exec vitest run extension/__tests__/api-configuration.spec.ts`
- `pnpm --dir src exec tsc --noEmit -p tsconfig.json`
- Targeted ESLint suppression-pruning checks and repository lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API configuration updates can save settings for multiple modes in one operation.
  * Profile and mode changes are coordinated more reliably during simultaneous updates.
* **Bug Fixes**
  * Switching profiles or modes avoids unnecessary active-task rebuilds and webview refreshes.
  * Pending tasks retain the correct configuration and active state.
  * Updates recover cleanly after delayed or failed profile and mode changes.
  * Cross-profile workflows fully restore previous settings after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->