### PR TITLE
fix: stop heredoc delimiter from absorbing trailing control operators

### DIFF
--- a/src/shared/__tests__/parse-command.spec.ts
+++ b/src/shared/__tests__/parse-command.spec.ts
@@ -290,6 +290,25 @@ describe("parseCommand", () => {
 			expect(result[1]).toBe("echo done")
 		})
 
+		it("does not absorb a control operator into the delimiter on the opener line", () => {
+			// A heredoc delimiter is a single shell word; a control operator
+			// (`;`, `|`, `&&`) on the same line terminates the word and must not
+			// be absorbed into the delimiter. Otherwise the terminator line is
+			// never found and the whole (valid) command is rejected as an
+			// unterminated heredoc. The whole heredoc is kept as one opaque token
+			// (matching the other heredoc cases), but must not produce a parse error.
+			const inputs = [
+				"sh -c bash << EOF; echo done\necho hello\nEOF",
+				"sh -c bash << EOF | grep hi\necho hello\nEOF",
+				"sh -c bash << EOF && cat f\necho hello\nEOF",
+			]
+			for (const input of inputs) {
+				const { commands: result, parseError } = parseCommand(input)
+				expect(parseError).toBeNull()
+				expect(result).toEqual([input])
+			}
+		})
+
 		it("treats a heredoc with a missing terminator as one opaque token", () => {
 			// An unterminated heredoc is a syntax error; the whole input must be
 			// returned as a single token so no body line can be auto-approved alone.

--- a/src/shared/__tests__/parse-command.spec.ts
+++ b/src/shared/__tests__/parse-command.spec.ts
@@ -309,6 +309,20 @@ describe("parseCommand", () => {
 			}
 		})
 
+		it("treats a CRLF heredoc as one command without an unterminated error", () => {
+			// With CRLF line endings the delimiter word ends at `\r` (just like
+			// the body scanner strips `\r` before comparing the terminator line).
+			// Without treating `\r` as a terminator, the delimiter would become
+			// `EOF\r`, never match the `EOF` terminator, and be rejected as an
+			// unterminated heredoc. The whole heredoc is kept as one opaque token
+			// (the trailing `\r\n` after the terminator is consumed, matching the
+			// LF case where the trailing newline is left as a separator).
+			const input = "sh -c bash << EOF\r\necho hello\r\nEOF\r\n"
+			const { commands: result, parseError } = parseCommand(input)
+			expect(parseError).toBeNull()
+			expect(result).toEqual(["sh -c bash << EOF\r\necho hello\r\nEOF"])
+		})
+
 		it("treats a heredoc with a missing terminator as one opaque token", () => {
 			// An unterminated heredoc is a syntax error; the whole input must be
 			// returned as a single token so no body line can be auto-approved alone.

--- a/src/shared/parse-command.ts
+++ b/src/shared/parse-command.ts
@@ -142,6 +142,26 @@ interface ScanResult {
  * Returns the bare delimiter word (for terminator line matching) and the index
  * of the first character after the delimiter token.
  */
+// POSIX control operators that terminate a word. A heredoc delimiter is a
+// single word, so it must stop at these just like the shell's tokenizer does.
+// This prevents a trailing control operator (e.g. `;`, `|`, `&&`) from being
+// absorbed into the delimiter (see the "match POSIX shell tokenization" rule
+// in scanTopLevelQuotes).
+function isHeredocDelimiterTerminator(char: string): boolean {
+	return (
+		char === "\n" ||
+		char === " " ||
+		char === "\t" ||
+		char === ";" ||
+		char === "|" ||
+		char === "&" ||
+		char === ">" ||
+		char === "<" ||
+		char === "(" ||
+		char === ")"
+	)
+}
+
 function parseHeredocDelimiter(command: string, start: number): { delimiter: string; endIndex: number } {
 	let i = start
 	let delimiter = ""
@@ -160,11 +180,11 @@ function parseHeredocDelimiter(command: string, start: number): { delimiter: str
 		if (command[i] === '"') i++ // consume closing "
 	} else if (command[i] === "\\") {
 		i++ // skip backslash
-		while (i < command.length && command[i] !== "\n" && command[i] !== " " && command[i] !== "\t") {
+		while (i < command.length && !isHeredocDelimiterTerminator(command[i])) {
 			delimiter += command[i++]
 		}
 	} else {
-		while (i < command.length && command[i] !== "\n" && command[i] !== " " && command[i] !== "\t") {
+		while (i < command.length && !isHeredocDelimiterTerminator(command[i])) {
 			delimiter += command[i++]
 		}
 	}

--- a/src/shared/parse-command.ts
+++ b/src/shared/parse-command.ts
@@ -150,6 +150,7 @@ interface ScanResult {
 function isHeredocDelimiterTerminator(char: string): boolean {
 	return (
 		char === "\n" ||
+		char === "\r" ||
 		char === " " ||
 		char === "\t" ||
 		char === ";" ||


### PR DESCRIPTION
A heredoc delimiter is a single shell word, so a control operator (;, |, &&) on the opener line terminates the word and must not be absorbed into the delimiter. Previously the parser kept scanning past these operators, so the terminator line was never found and a valid command was incorrectly rejected as an unterminated heredoc.

Add isHeredocDelimiterTerminator() to stop the delimiter at POSIX control operators, matching shell tokenization, and apply it to both the backslash-escaped and unquoted delimiter branches. Add regression tests covering ;, |, and && on the opener line.

<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #1116

### Description

**The bug**: When a heredoc opener line is followed by a control operator on the same line (e.g. `<< EOF; echo done`), the parser absorbed the control operator into the heredoc delimiter. Because a heredoc delimiter is a single shell word, POSIX shell tokenization terminates the word at a control operator — but the parser kept scanning past `;`, `|`, `&&`, etc. As a result, the terminator line was never found and a valid command was incorrectly rejected as an unterminated heredoc.

**The fix**: Added a small helper `isHeredocDelimiterTerminator()` in [`parse-command.ts`](../../src/shared/parse-command.ts) that stops the delimiter at POSIX control operators (`; | & > < ( )`) in addition to whitespace/newline, matching shell tokenization. It is applied to both the backslash-escaped and unquoted delimiter branches.

**Key design choices / trade-offs**:
- The fix is minimal and preserves the existing behavior of treating the whole heredoc as a single opaque token (so body lines are never split into independently auto-approved sub-commands).
- Quoted delimiters (`<< 'EOF'`, `<< "EOF"`) are intentionally unaffected — characters inside quotes are literal and not control operators.

**What reviewers should pay attention to**:
- The `>` and `<` additions to the terminator set — these are valid POSIX control operators and align with shell tokenization, but confirm no regression for edge-case delimiters.
- The `&` addition — `&` is a control operator, so a delimiter like `A&B` is now split, which matches the shell.

### Test Procedure

**How I tested**:
- Added regression tests in [`parse-command.spec.ts`](../../src/shared/__tests__/parse-command.spec.ts) covering all three control operators on the opener line: `;`, `|`, and `&&`.
- Ran the full test file: `cd src && npx vitest run shared/__tests__/parse-command.spec.ts` — all 67 tests pass.

**How reviewers can verify**:
1. Run the heredoc test suite: `cd src && npx vitest run shared/__tests__/parse-command.spec.ts`
2. Manually confirm the following inputs are now parsed as single valid commands (no parse error):
   ```
   sh -c bash << EOF; echo done
   echo hello
   EOF
   ```
   ```
   sh -c bash << EOF | grep hi
   echo hello
   EOF
   ```
   ```
   sh -c bash << EOF && cat f
   echo hello
   EOF
   ```

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Visual Snapshot** (UI changes only): N/A — this is a backend parsing change, no UI.
- [x] **Documentation Impact**: No documentation updates are required.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

N/A

### Videos (interaction / animation only)

N/A

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

N/A

### Get in Touch

hehegwk_23849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heredoc parsing when command operators such as `;`, `|`, and `&&` appear on the opener line.
  * Prevented trailing operators, redirections, and parentheses from being incorrectly included in heredoc delimiters.
  * Improved handling of Windows-style line endings in heredocs.
  * Complete heredoc commands now parse correctly without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->