### PR TITLE
test(webview): e2e tests + API task controls (branch 3/3)

### DIFF
--- a/apps/vscode-e2e/fixtures/modes.json
+++ b/apps/vscode-e2e/fixtures/modes.json
@@ -13,6 +13,20 @@
 					}
 				]
 			}
+		},
+		{
+			"match": {
+				"userMessage": "Use the `switch_mode` tool to switch to debug mode."
+			},
+			"response": {
+				"toolCalls": [
+					{
+						"name": "switch_mode",
+						"arguments": "{\"mode_slug\":\"debug\",\"reason\":\"User requested to switch to debug mode.\"}",
+						"id": "call_modes_switch_002"
+					}
+				]
+			}
 		}
 	]
 }

--- a/apps/vscode-e2e/src/fixtures/view-state.ts
+++ b/apps/vscode-e2e/src/fixtures/view-state.ts
@@ -1,0 +1,95 @@
+import type { ChatCompletionRequest, ChatMessage, LLMock } from "@copilotkit/aimock"
+
+const TASKS = ["A", "B", "C"] as const
+const ROUNDS = 10
+
+const MODE_SEQUENCES: Record<(typeof TASKS)[number], string[]> = {
+	A: ["ask", "debug", "architect", "orchestrator", "code", "ask", "debug", "architect", "orchestrator", "code"],
+	B: ["debug", "architect", "orchestrator", "code", "ask", "debug", "architect", "orchestrator", "code", "ask"],
+	C: ["architect", "orchestrator", "code", "ask", "debug", "architect", "orchestrator", "code", "ask", "debug"],
+}
+
+const markerFor = (taskName: (typeof TASKS)[number]) => `FOLLOWUP_MODE_ISOLATION_${taskName}`
+const answerFor = (taskName: (typeof TASKS)[number], round: number) => `${taskName} follow-up round ${round}`
+const callIdFor = (taskName: (typeof TASKS)[number], round: number) =>
+	`call_followup_mode_${taskName.toLowerCase()}_${String(round).padStart(2, "0")}`
+
+const lastToolResultContains = (req: ChatCompletionRequest, toolCallId: string, expected: string[]) => {
+	const messages = Array.isArray(req?.messages) ? req.messages : []
+	const toolMessage = messages.filter((message: ChatMessage) => message?.role === "tool").at(-1)
+	const content = toolMessage?.content
+
+	return (
+		toolMessage?.tool_call_id === toolCallId &&
+		typeof content === "string" &&
+		expected.every((text) => content.includes(text))
+	)
+}
+
+const followupToolCall = (taskName: (typeof TASKS)[number], round: number) => ({
+	name: "ask_followup_question",
+	arguments: JSON.stringify({
+		question: `Task ${taskName}: choose mode for round ${round}`,
+		follow_up: [
+			{
+				text: answerFor(taskName, round),
+				mode: MODE_SEQUENCES[taskName][round - 1],
+			},
+		],
+	}),
+	id: callIdFor(taskName, round),
+})
+
+export const getFollowupModeIsolationPlan = () =>
+	TASKS.map((taskName) => ({
+		taskName,
+		marker: markerFor(taskName),
+		rounds: MODE_SEQUENCES[taskName].map((mode, index) => ({
+			round: index + 1,
+			answer: answerFor(taskName, index + 1),
+			mode,
+		})),
+	}))
+
+export function addViewStateFixtures(mock: InstanceType<typeof LLMock>) {
+	for (const taskName of TASKS) {
+		mock.addFixture({
+			match: {
+				userMessage: markerFor(taskName),
+			},
+			response: {
+				toolCalls: [followupToolCall(taskName, 1)],
+			},
+		})
+
+		for (let round = 1; round < ROUNDS; round++) {
+			mock.addFixture({
+				match: {
+					predicate: (req) =>
+						lastToolResultContains(req, callIdFor(taskName, round), [answerFor(taskName, round)]),
+				},
+				response: {
+					toolCalls: [followupToolCall(taskName, round + 1)],
+				},
+			})
+		}
+
+		mock.addFixture({
+			match: {
+				predicate: (req) =>
+					lastToolResultContains(req, callIdFor(taskName, ROUNDS), [answerFor(taskName, ROUNDS)]),
+			},
+			response: {
+				toolCalls: [
+					{
+						name: "attempt_completion",
+						arguments: JSON.stringify({
+							result: `Task ${taskName} completed ${ROUNDS} follow-up mode switches.`,
+						}),
+						id: `call_followup_mode_${taskName.toLowerCase()}_complete`,
+					},
+				],
+			},
+		})
+	}
+}

--- a/apps/vscode-e2e/src/runTest.ts
+++ b/apps/vscode-e2e/src/runTest.ts
@@ -22,6 +22,7 @@ import { addSubtaskFixtures } from "./fixtures/subtasks"
 import { addUseMcpToolResultFixtures } from "./fixtures/use-mcp-tool"
 import { addWriteToFileResultFixtures } from "./fixtures/write-to-file"
 import { toolResultContains } from "./fixtures/tool-result"
+import { addViewStateFixtures } from "./fixtures/view-state"
 
 function getCliFlagValue(flag: string) {
 	return process.argv.find((arg, index) => process.argv[index - 1] === flag)
@@ -130,6 +131,7 @@ async function main() {
 				addUseMcpToolResultFixtures(mock)
 				addWriteToFileResultFixtures(mock)
 				addDeepSeekV4Fixtures(mock)
+				addViewStateFixtures(mock)
 
 				mock.addFixture({
 					match: {

--- a/apps/vscode-e2e/src/runTest.ts
+++ b/apps/vscode-e2e/src/runTest.ts
@@ -21,6 +21,7 @@ import { addSearchFilesResultFixtures } from "./fixtures/search-files"
 import { addSubtaskFixtures } from "./fixtures/subtasks"
 import { addUseMcpToolResultFixtures } from "./fixtures/use-mcp-tool"
 import { addWriteToFileResultFixtures } from "./fixtures/write-to-file"
+import { toolResultContains } from "./fixtures/tool-result"
 
 function getCliFlagValue(flag: string) {
 	return process.argv.find((arg, index) => process.argv[index - 1] === flag)
@@ -129,6 +130,36 @@ async function main() {
 				addUseMcpToolResultFixtures(mock)
 				addWriteToFileResultFixtures(mock)
 				addDeepSeekV4Fixtures(mock)
+
+				mock.addFixture({
+					match: {
+						predicate: (req) => toolResultContains(req, "call_modes_switch_001", []),
+					},
+					response: {
+						toolCalls: [
+							{
+								name: "attempt_completion",
+								arguments: JSON.stringify({ result: "Switched to ❓ Ask mode as requested." }),
+								id: "call_modes_post_switch_001",
+							},
+						],
+					},
+				})
+
+				mock.addFixture({
+					match: {
+						predicate: (req) => toolResultContains(req, "call_modes_switch_002", []),
+					},
+					response: {
+						toolCalls: [
+							{
+								name: "attempt_completion",
+								arguments: JSON.stringify({ result: "Switched to 🪲 Debug mode as requested." }),
+								id: "call_modes_post_switch_002",
+							},
+						],
+					},
+				})
 
 				// The modes test (switch_mode → ask) triggers a second API call whose last
 				// user message starts with <environment_details> directly — no <user_message>

--- a/apps/vscode-e2e/src/suite/view-state.test.ts
+++ b/apps/vscode-e2e/src/suite/view-state.test.ts
@@ -46,7 +46,9 @@ suite("Roo Code View State", function () {
 			}
 		}
 
-		globalThis.api.on(RooCodeEventName.TaskModeSwitched, (taskId, mode) => modeEvents.push({ taskId, mode }))
+		const modeHandler = (taskId: string, mode: string) => modeEvents.push({ taskId, mode })
+
+		globalThis.api.on(RooCodeEventName.TaskModeSwitched, modeHandler)
 		globalThis.api.on(RooCodeEventName.Message, completionHandler)
 
 		try {
@@ -110,6 +112,7 @@ suite("Roo Code View State", function () {
 				)
 			}
 		} finally {
+			globalThis.api.off(RooCodeEventName.TaskModeSwitched, modeHandler)
 			globalThis.api.off(RooCodeEventName.Message, completionHandler)
 		}
 	})

--- a/apps/vscode-e2e/src/suite/view-state.test.ts
+++ b/apps/vscode-e2e/src/suite/view-state.test.ts
@@ -1,0 +1,115 @@
+import * as assert from "assert"
+
+import { isSecretStateKey, RooCodeEventName, type ClineMessage, type GlobalState } from "@roo-code/types"
+
+import { waitUntilCompleted } from "./utils"
+import { setDefaultSuiteTimeout } from "./test-utils"
+
+const findSecretStatePath = (value: unknown, path: string[] = []): string | undefined => {
+	if (!value || typeof value !== "object") {
+		return undefined
+	}
+
+	for (const [key, nestedValue] of Object.entries(value)) {
+		const nextPath = [...path, key]
+
+		if (isSecretStateKey(key)) {
+			return nextPath.join(".")
+		}
+
+		const nestedSecretPath = findSecretStatePath(nestedValue, nextPath)
+		if (nestedSecretPath) {
+			return nestedSecretPath
+		}
+	}
+
+	return undefined
+}
+
+suite("Roo Code View State", function () {
+	setDefaultSuiteTimeout(this)
+
+	teardown(async () => {
+		try {
+			await globalThis.api.cancelCurrentTask()
+		} catch {
+			// Task might not be running.
+		}
+	})
+
+	test("sidebar and tab panel keep mode isolated through the real ContextProxy singleton", async () => {
+		const modeEvents: Array<{ taskId: string; mode: string }> = []
+		const completionHandler = ({ taskId, message }: { taskId: string; message: ClineMessage }) => {
+			if (message.type === "ask" && message.ask === "completion_result") {
+				void globalThis.api.approveTaskAsk(taskId)
+			}
+		}
+
+		globalThis.api.on(RooCodeEventName.TaskModeSwitched, (taskId, mode) => modeEvents.push({ taskId, mode }))
+		globalThis.api.on(RooCodeEventName.Message, completionHandler)
+
+		try {
+			const sidebarTaskId = await globalThis.api.startNewTask({
+				configuration: {
+					mode: "code",
+					alwaysAllowModeSwitch: true,
+					autoApprovalEnabled: true,
+					apiKey: "sidebar-secret-must-not-persist",
+				},
+				text: "Use the `switch_mode` tool to switch to ask mode.",
+			})
+			await waitUntilCompleted({ api: globalThis.api, taskId: sidebarTaskId })
+
+			const tabTaskId = await globalThis.api.startNewTask({
+				configuration: {
+					mode: "code",
+					alwaysAllowModeSwitch: true,
+					autoApprovalEnabled: true,
+					apiKey: "tab-secret-must-not-persist",
+				},
+				text: "Use the `switch_mode` tool to switch to debug mode.",
+				newTab: true,
+			})
+			await waitUntilCompleted({ api: globalThis.api, taskId: tabTaskId })
+
+			// Each task's switch must be attributed to its own taskId only.
+			assert.deepStrictEqual(
+				modeEvents.filter((event) => event.taskId === sidebarTaskId).map((event) => event.mode),
+				["ask"],
+			)
+			assert.deepStrictEqual(
+				modeEvents.filter((event) => event.taskId === tabTaskId).map((event) => event.mode),
+				["debug"],
+			)
+
+			// The tab panel's switch must not overwrite the sidebar's own state.
+			// api.getConfiguration() always reads the sidebar provider.
+			assert.strictEqual(globalThis.api.getConfiguration().mode, "ask")
+
+			const viewStates = globalThis.api.getGlobalState("viewStates") as GlobalState["viewStates"]
+			assert.ok(viewStates, "Expected persisted viewStates to exist")
+
+			const persistedEntries = Object.entries(viewStates)
+			assert.ok(persistedEntries.length >= 2, "Expected at least sidebar and tab persisted view state entries")
+			assert.ok(
+				persistedEntries.some(([, entry]) => entry.mode === "ask"),
+				"Expected one persisted view state entry for the sidebar ask mode",
+			)
+			assert.ok(
+				persistedEntries.some(([, entry]) => entry.mode === "debug"),
+				"Expected one persisted view state entry for the tab debug mode",
+			)
+
+			for (const [viewStateId, entry] of persistedEntries) {
+				const secretStatePath = findSecretStatePath(entry)
+				assert.strictEqual(
+					secretStatePath,
+					undefined,
+					`Persisted viewStates.${viewStateId} leaked secret state at ${secretStatePath}`,
+				)
+			}
+		} finally {
+			globalThis.api.off(RooCodeEventName.Message, completionHandler)
+		}
+	})
+})

--- a/apps/vscode-e2e/src/suite/view-state.test.ts
+++ b/apps/vscode-e2e/src/suite/view-state.test.ts
@@ -2,7 +2,8 @@ import * as assert from "assert"
 
 import { isSecretStateKey, RooCodeEventName, type ClineMessage, type GlobalState } from "@roo-code/types"
 
-import { waitUntilCompleted } from "./utils"
+import { getFollowupModeIsolationPlan } from "../fixtures/view-state"
+import { sleep, waitFor, waitUntilCompleted } from "./utils"
 import { setDefaultSuiteTimeout } from "./test-utils"
 
 const findSecretStatePath = (value: unknown, path: string[] = []): string | undefined => {
@@ -110,6 +111,159 @@ suite("Roo Code View State", function () {
 			}
 		} finally {
 			globalThis.api.off(RooCodeEventName.Message, completionHandler)
+		}
+	})
+	test("three panels keep follow-up option mode switches isolated across ten staggered rounds", async () => {
+		const plan = getFollowupModeIsolationPlan()
+		const modeEvents: Array<{ taskId: string; mode: string }> = []
+		const taskIds = new Map<string, string>()
+		const taskNamesById = new Map<string, string>()
+		const pendingSuggestions = new Map<string, { answer: string; mode?: string }>()
+		const answeredSuggestions = new Set<string>()
+		const suggestionKey = (taskId: string, answer: string) => `${taskId}:${answer}`
+		let releasedRounds = 0
+		let roundInFlight = false
+
+		const taskIdsInPlanOrder = () =>
+			plan.map((taskPlan) => taskIds.get(taskPlan.taskName)).filter((taskId): taskId is string => !!taskId)
+		const modeCountForTask = (taskId: string) => modeEvents.filter((event) => event.taskId === taskId).length
+
+		const maybeReleaseRound = () => {
+			if (roundInFlight || taskIds.size !== plan.length) {
+				return
+			}
+
+			const taskIdsInOrder = taskIdsInPlanOrder()
+			if (
+				taskIdsInOrder.length !== plan.length ||
+				!taskIdsInOrder.every((taskId) => pendingSuggestions.has(taskId))
+			) {
+				return
+			}
+
+			roundInFlight = true
+			releasedRounds++
+
+			for (const taskId of taskIdsInOrder) {
+				const suggestion = pendingSuggestions.get(taskId)
+				assert.ok(suggestion, `Expected pending suggestion for task ${taskId}`)
+				pendingSuggestions.delete(taskId)
+				answeredSuggestions.add(suggestionKey(taskId, suggestion.answer))
+				void globalThis.api.selectTaskFollowupSuggestion({ taskId, ...suggestion })
+			}
+		}
+
+		const messageHandler = ({ taskId, message }: { taskId: string; message: ClineMessage }) => {
+			if (message.type === "ask" && message.ask === "followup" && message.text) {
+				try {
+					const parsed = JSON.parse(message.text) as { suggest?: Array<{ answer: string; mode?: string }> }
+					const suggestion = parsed.suggest?.[0]
+
+					if (suggestion && !answeredSuggestions.has(suggestionKey(taskId, suggestion.answer))) {
+						pendingSuggestions.set(taskId, suggestion)
+						maybeReleaseRound()
+					}
+				} catch {
+					// Ignore partial or malformed follow-up payloads.
+				}
+			}
+
+			if (message.type === "ask" && message.ask === "completion_result") {
+				void globalThis.api.approveTaskAsk(taskId)
+			}
+		}
+		const modeHandler = (taskId: string, mode: string) => {
+			modeEvents.push({ taskId, mode })
+
+			if (roundInFlight && taskIdsInPlanOrder().every((id) => modeCountForTask(id) >= releasedRounds)) {
+				roundInFlight = false
+				maybeReleaseRound()
+			}
+		}
+
+		globalThis.api.on(RooCodeEventName.Message, messageHandler)
+		globalThis.api.on(RooCodeEventName.TaskModeSwitched, modeHandler)
+
+		try {
+			for (const [index, taskPlan] of plan.entries()) {
+				if (index > 0) {
+					await sleep(1_000)
+				}
+
+				const taskId = await globalThis.api.startNewTask({
+					configuration: {
+						mode: "code",
+						alwaysAllowModeSwitch: true,
+						autoApprovalEnabled: true,
+						apiKey: `followup-secret-${taskPlan.taskName}-must-not-persist`,
+					},
+					text: taskPlan.marker,
+					newTab: true,
+					preserveOpenTabs: index > 0,
+				})
+				taskIds.set(taskPlan.taskName, taskId)
+				taskNamesById.set(taskId, taskPlan.taskName)
+				maybeReleaseRound()
+			}
+
+			await waitFor(
+				() => {
+					const expectedSwitches = plan.length * 10
+					return modeEvents.length >= expectedSwitches
+				},
+				{ timeout: 30_000 },
+			).catch((error) => {
+				const counts = plan.map((taskPlan) => {
+					const taskId = taskIds.get(taskPlan.taskName)
+					return `${taskPlan.taskName}:${taskId ? modeCountForTask(taskId) : 0}`
+				})
+				throw new Error(
+					`Timed out after ${releasedRounds} coordinated rounds; mode event counts: ${counts.join(", ")}; pending suggestions: ${pendingSuggestions.size}. ${error instanceof Error ? error.message : String(error)}`,
+				)
+			})
+
+			for (let roundIndex = 0; roundIndex < 10; roundIndex++) {
+				const actualRoundModes = plan.map((taskPlan) => {
+					const taskId = taskIds.get(taskPlan.taskName)
+					assert.ok(taskId, `Expected task id for task ${taskPlan.taskName}`)
+					return modeEvents.filter((event) => event.taskId === taskId).map((event) => event.mode)[roundIndex]
+				})
+				const expectedRoundModes = plan.map((taskPlan) => {
+					const round = taskPlan.rounds[roundIndex]
+					assert.ok(round, `Expected round ${roundIndex + 1} for task ${taskPlan.taskName}`)
+					return round.mode
+				})
+
+				assert.deepStrictEqual(
+					actualRoundModes,
+					expectedRoundModes,
+					`Round ${roundIndex + 1} should count only after all three tasks switch once`,
+				)
+			}
+
+			for (const taskPlan of plan) {
+				const taskId = taskIds.get(taskPlan.taskName)
+				assert.ok(taskId, `Expected task id for task ${taskPlan.taskName}`)
+				assert.deepStrictEqual(
+					modeEvents.filter((event) => event.taskId === taskId).map((event) => event.mode),
+					taskPlan.rounds.map((round) => round.mode),
+				)
+			}
+
+			const viewStates = globalThis.api.getGlobalState("viewStates") as GlobalState["viewStates"]
+			assert.ok(viewStates, "Expected persisted viewStates to exist")
+
+			for (const [viewStateId, entry] of Object.entries(viewStates)) {
+				const secretStatePath = findSecretStatePath(entry)
+				assert.strictEqual(
+					secretStatePath,
+					undefined,
+					`Persisted viewStates.${viewStateId} leaked secret state at ${secretStatePath}`,
+				)
+			}
+		} finally {
+			globalThis.api.off(RooCodeEventName.Message, messageHandler)
+			globalThis.api.off(RooCodeEventName.TaskModeSwitched, modeHandler)
 		}
 	})
 })

--- a/packages/types/src/__tests__/index.test.ts
+++ b/packages/types/src/__tests__/index.test.ts
@@ -3,6 +3,10 @@
 import { GLOBAL_STATE_KEYS } from "../index.js"
 
 describe("GLOBAL_STATE_KEYS", () => {
+	it("should contain registered durable per-view state", () => {
+		expect(GLOBAL_STATE_KEYS).toContain("viewStates")
+	})
+
 	it("should contain provider settings keys", () => {
 		expect(GLOBAL_STATE_KEYS).toContain("autoApprovalEnabled")
 	})
@@ -13,6 +17,7 @@ describe("GLOBAL_STATE_KEYS", () => {
 
 	it("should not contain secret state keys", () => {
 		expect(GLOBAL_STATE_KEYS).not.toContain("openRouterApiKey")
+		expect(GLOBAL_STATE_KEYS).not.toContain("apiKey")
 	})
 
 	it("should contain OpenAI Compatible base URL setting", () => {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -26,6 +26,7 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 		text?: string
 		images?: string[]
 		newTab?: boolean
+		preserveOpenTabs?: boolean
 	}): Promise<string>
 	/**
 	 * Resumes a task with the given ID.
@@ -96,6 +97,11 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 	 * Programmatically approves the pending ask for a task by ID. Intended for use in tests only.
 	 */
 	approveTaskAsk(taskId: string): Promise<boolean>
+	/**
+	 * Simulates selecting a follow-up suggestion for a task by ID, including its optional mode switch.
+	 * Intended for use in tests only.
+	 */
+	selectTaskFollowupSuggestion(options: { taskId: string; answer: string; mode?: string }): Promise<boolean>
 	/**
 	 * Returns true if the API is ready to use.
 	 */

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -2,7 +2,7 @@ import type { EventEmitter } from "events"
 import type { Socket } from "net"
 
 import type { RooCodeEvents } from "./events.js"
-import type { RooCodeSettings } from "./global-settings.js"
+import type { GlobalState, RooCodeSettings } from "./global-settings.js"
 import type { HistoryItem } from "./history.js"
 import type { ProviderSettingsEntry, ProviderSettings } from "./provider-settings.js"
 import type { IpcMessage, IpcServerEvents } from "./ipc.js"
@@ -93,6 +93,10 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 	 */
 	approveCurrentAsk(): Promise<void>
 	/**
+	 * Programmatically approves the pending ask for a task by ID. Intended for use in tests only.
+	 */
+	approveTaskAsk(taskId: string): Promise<boolean>
+	/**
 	 * Returns true if the API is ready to use.
 	 */
 	isReady(): boolean
@@ -106,6 +110,10 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 	 * @param values An object containing key-value pairs to set.
 	 */
 	setConfiguration(values: RooCodeSettings): Promise<void>
+	/**
+	 * Returns a value from VS Code globalState. Intended for use in tests only.
+	 */
+	getGlobalState<K extends keyof GlobalState>(key: K): GlobalState[K]
 	/**
 	 * Returns a list of all configured profile names
 	 * @returns Array of profile names

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -21,6 +21,7 @@ export interface RooCodeAPI extends EventEmitter<RooCodeAPIEvents> {
 		text,
 		images,
 		newTab,
+		preserveOpenTabs,
 	}: {
 		configuration?: RooCodeSettings
 		text?: string

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -98,6 +98,15 @@ export const MAX_CHECKPOINT_TIMEOUT_SECONDS = 60
 export const DEFAULT_CHECKPOINT_TIMEOUT_SECONDS = 15
 
 /**
+ * Persisted non-secret selections for a stable webview instance.
+ */
+export const viewStateSchema = z.object({
+	mode: z.string().optional(),
+	currentApiConfigName: z.string().optional(),
+	updatedAt: z.number().optional(),
+})
+
+/**
  * GlobalSettings
  */
 
@@ -105,6 +114,7 @@ export const globalSettingsSchema = z.object({
 	currentApiConfigName: z.string().optional(),
 	listApiConfigMeta: z.array(providerSettingsEntrySchema).optional(),
 	pinnedApiConfigs: z.record(z.string(), z.boolean()).optional(),
+	viewStates: z.record(z.string(), viewStateSchema).optional(),
 
 	lastShownAnnouncementId: z.string().optional(),
 	customInstructions: z.string().optional(),

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -632,6 +632,7 @@ export interface WebviewMessage {
 		| "openRuleFile"
 		| "openRulesDirectory"
 	text?: string
+	viewStateId?: string
 	taskId?: string
 	editedMessageContent?: string
 	tab?: "settings" | "history" | "mcp" | "modes" | "chat" | "marketplace" | "cloud"

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -175,6 +175,7 @@ export class ClineProvider
 	private static activeInstances: Set<ClineProvider> = new Set()
 	private static nextViewId = 0
 	private static readonly MAX_PERSISTED_VIEW_STATES = 50
+	private static persistedViewStateWriteQueue: Promise<void> = Promise.resolve()
 	private disposables: vscode.Disposable[] = []
 	private webviewDisposables: vscode.Disposable[] = []
 	private view?: vscode.WebviewView | vscode.WebviewPanel
@@ -445,51 +446,63 @@ export class ClineProvider
 		}
 	}
 
-	private getPersistedViewStates(): Record<string, PersistedViewState> {
-		const viewStates = this.contextProxy.getValue("viewStates")
+	private getPersistedViewStates(options: { fresh?: boolean } = {}): Record<string, PersistedViewState> {
+		const viewStates = options.fresh
+			? this.context.globalState.get<GlobalState["viewStates"]>("viewStates")
+			: this.contextProxy.getValue("viewStates")
 
 		if (!viewStates || typeof viewStates !== "object" || Array.isArray(viewStates)) {
 			return {}
 		}
 
-		return viewStates
+		return { ...viewStates }
 	}
 
 	private async savePersistedViewState(values: Partial<PersistedViewState>): Promise<void> {
-		const states = this.getPersistedViewStates()
-		const current = states[this.viewStateId] ?? {}
-		const next: PersistedViewState = { ...current }
+		const write = ClineProvider.persistedViewStateWriteQueue.then(async () => {
+			const states = this.getPersistedViewStates({ fresh: true })
+			const current = states[this.viewStateId] ?? {}
+			const next: PersistedViewState = { ...current }
 
-		if ("mode" in values) {
-			if (values.mode === undefined || values.mode === null) {
-				delete next.mode
-			} else {
-				next.mode = values.mode
+			if ("mode" in values) {
+				if (values.mode === undefined || values.mode === null) {
+					delete next.mode
+				} else {
+					next.mode = values.mode
+				}
 			}
-		}
 
-		if ("currentApiConfigName" in values) {
-			if (values.currentApiConfigName === undefined || values.currentApiConfigName === null) {
-				delete next.currentApiConfigName
-			} else {
-				next.currentApiConfigName = values.currentApiConfigName
+			if ("currentApiConfigName" in values) {
+				if (values.currentApiConfigName === undefined || values.currentApiConfigName === null) {
+					delete next.currentApiConfigName
+				} else {
+					next.currentApiConfigName = values.currentApiConfigName
+				}
 			}
-		}
 
-		if (!next.mode && !next.currentApiConfigName) {
-			delete states[this.viewStateId]
-		} else {
-			next.updatedAt = values.updatedAt ?? Date.now()
-			states[this.viewStateId] = next
-		}
+			if (!next.mode && !next.currentApiConfigName) {
+				delete states[this.viewStateId]
+			} else {
+				next.updatedAt = values.updatedAt ?? Date.now()
+				states[this.viewStateId] = next
+			}
 
-		await this.contextProxy.setValue("viewStates", this.prunePersistedViewStates(states))
+			await this.contextProxy.setValue("viewStates", this.prunePersistedViewStates(states))
+		})
+
+		ClineProvider.persistedViewStateWriteQueue = write.catch(() => {})
+		await write
 	}
 
 	private async clearPersistedViewState(viewStateId = this.viewStateId): Promise<void> {
-		const states = this.getPersistedViewStates()
-		delete states[viewStateId]
-		await this.contextProxy.setValue("viewStates", states)
+		const write = ClineProvider.persistedViewStateWriteQueue.then(async () => {
+			const states = this.getPersistedViewStates({ fresh: true })
+			delete states[viewStateId]
+			await this.contextProxy.setValue("viewStates", states)
+		})
+
+		ClineProvider.persistedViewStateWriteQueue = write.catch(() => {})
+		await write
 	}
 
 	private prunePersistedViewStates(states: Record<string, PersistedViewState>): Record<string, PersistedViewState> {
@@ -3076,6 +3089,7 @@ export class ClineProvider
 	public async setValue<K extends keyof RooCodeSettings>(key: K, value: RooCodeSettings[K]) {
 		await this.contextProxy.setValue(key, value)
 		this._updateViewLocalStateFromMutation({ [key]: value })
+		await this._persistViewLocalStateFromMutation({ [key]: value })
 	}
 
 	public getValue<K extends keyof RooCodeSettings>(key: K) {
@@ -3089,6 +3103,7 @@ export class ClineProvider
 	public async setValues(values: RooCodeSettings) {
 		await this.contextProxy.setValues(values)
 		this._updateViewLocalStateFromMutation(values)
+		await this._persistViewLocalStateFromMutation(values)
 	}
 
 	/**
@@ -3135,6 +3150,24 @@ export class ClineProvider
 				...(this.viewLocalState.apiConfiguration ?? {}),
 				...providerSettingsUpdate,
 			}
+		}
+	}
+
+	private async _persistViewLocalStateFromMutation(
+		values: Partial<RooCodeSettings> & Partial<ExtensionState>,
+	): Promise<void> {
+		const persistedValues: Partial<PersistedViewState> = {}
+
+		if ("mode" in values) {
+			persistedValues.mode = values.mode as PersistedViewState["mode"]
+		}
+
+		if ("currentApiConfigName" in values) {
+			persistedValues.currentApiConfigName = values.currentApiConfigName
+		}
+
+		if ("mode" in persistedValues || "currentApiConfigName" in persistedValues) {
+			await this.savePersistedViewState(persistedValues)
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1845,6 +1845,8 @@ export class ClineProvider
 					this.updateGlobalState("currentApiConfigName", name),
 					this.providerSettingsManager.setModeConfig(mode, id),
 					this.contextProxy.setProviderSettings(providerSettings),
+					this.saveViewState("currentApiConfigName", name),
+					this.saveViewState("apiConfiguration", providerSettings),
 				])
 
 				this._updateViewLocalStateFromMutation({
@@ -1947,6 +1949,8 @@ export class ClineProvider
 			this.contextProxy.setValue("listApiConfigMeta", listApiConfigMeta),
 			this.contextProxy.setValue("currentApiConfigName", name),
 			this.contextProxy.setProviderSettings(providerSettings),
+			this.saveViewState("currentApiConfigName", name),
+			this.saveViewState("apiConfiguration", providerSettings),
 		])
 
 		this._updateViewLocalStateFromMutation({

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -898,15 +898,6 @@ export class ClineProvider
 		this.customModesManager?.dispose()
 		this.taskHistoryStore.dispose()
 		this.flushGlobalStateWriteThrough()
-		if (this.renderContext === "editor") {
-			try {
-				await this.clearPersistedViewState()
-			} catch (error) {
-				this.log(
-					`[dispose] Failed to clear persisted view state for ${this.viewStateId}: ${error instanceof Error ? error.message : String(error)}`,
-				)
-			}
-		}
 		this.log("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -120,6 +120,8 @@ import { REQUESTY_BASE_URL } from "../../shared/utils/requesty"
 import { validateAndFixToolResultIds } from "../task/validateToolResultIds"
 import { PendingEditOperationStore, type PendingEditOperationInput } from "./PendingEditOperationStore"
 
+type PersistedViewState = NonNullable<GlobalState["viewStates"]>[string]
+
 /**
  * https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
  * https://github.com/KumarVariable/vscode-extension-sidebar-html/blob/master/src/customSidebarViewProvider.ts
@@ -172,6 +174,7 @@ export class ClineProvider
 	public static readonly tabPanelId = `${Package.name}.TabPanelProvider`
 	private static activeInstances: Set<ClineProvider> = new Set()
 	private static nextViewId = 0
+	private static readonly MAX_PERSISTED_VIEW_STATES = 50
 	private disposables: vscode.Disposable[] = []
 	private webviewDisposables: vscode.Disposable[] = []
 	private view?: vscode.WebviewView | vscode.WebviewPanel
@@ -442,13 +445,59 @@ export class ClineProvider
 		}
 	}
 
-	/**
-	 * Derive a view-specific ContextProxy key for persisting view-local state.
-	 * Uses a stable per-view id so each restored tab reads and writes its own values
-	 * independent of provider construction order.
-	 */
-	private viewStateKeyFor(key: "mode" | "currentApiConfigName" | "apiConfiguration"): string {
-		return `__view_state_${this.viewStateId}_${key}`
+	private getPersistedViewStates(): Record<string, PersistedViewState> {
+		const viewStates = this.contextProxy.getValue("viewStates")
+
+		if (!viewStates || typeof viewStates !== "object" || Array.isArray(viewStates)) {
+			return {}
+		}
+
+		return viewStates
+	}
+
+	private async savePersistedViewState(values: Partial<PersistedViewState>): Promise<void> {
+		const states = this.getPersistedViewStates()
+		const current = states[this.viewStateId] ?? {}
+		const next: PersistedViewState = { ...current }
+
+		if ("mode" in values) {
+			if (values.mode === undefined || values.mode === null) {
+				delete next.mode
+			} else {
+				next.mode = values.mode
+			}
+		}
+
+		if ("currentApiConfigName" in values) {
+			if (values.currentApiConfigName === undefined || values.currentApiConfigName === null) {
+				delete next.currentApiConfigName
+			} else {
+				next.currentApiConfigName = values.currentApiConfigName
+			}
+		}
+
+		if (!next.mode && !next.currentApiConfigName) {
+			delete states[this.viewStateId]
+		} else {
+			next.updatedAt = values.updatedAt ?? Date.now()
+			states[this.viewStateId] = next
+		}
+
+		await this.contextProxy.setValue("viewStates", this.prunePersistedViewStates(states))
+	}
+
+	private async clearPersistedViewState(viewStateId = this.viewStateId): Promise<void> {
+		const states = this.getPersistedViewStates()
+		delete states[viewStateId]
+		await this.contextProxy.setValue("viewStates", states)
+	}
+
+	private prunePersistedViewStates(states: Record<string, PersistedViewState>): Record<string, PersistedViewState> {
+		return Object.fromEntries(
+			Object.entries(states)
+				.sort(([, a], [, b]) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+				.slice(0, ClineProvider.MAX_PERSISTED_VIEW_STATES),
+		)
 	}
 
 	public async setViewStateId(viewStateId: string | undefined): Promise<void> {
@@ -463,18 +512,30 @@ export class ClineProvider
 	}
 
 	/**
-	 * Loads persisted values from stable per-view keys into the view-local state buffer.
-	 * Missing keys are intentionally left unset so getState() falls back to shared ContextProxy values.
+	 * Loads non-secret persisted selections from the registered viewStates map.
+	 * Missing entries are intentionally left unset so getState() falls back to shared ContextProxy values.
 	 */
 	private async loadViewState(): Promise<void> {
 		try {
+			const persisted = this.getPersistedViewStates()[this.viewStateId]
 			const loadedState: Partial<ExtensionState> = {}
 
-			for (const key of ["mode", "currentApiConfigName", "apiConfiguration"] as const) {
-				const value = this.contextProxy.getValue(this.viewStateKeyFor(key) as any)
+			if (persisted?.mode) {
+				loadedState.mode = persisted.mode as Mode
+			}
 
-				if (value !== undefined && value !== null) {
-					loadedState[key] = value as any
+			if (persisted?.currentApiConfigName) {
+				loadedState.currentApiConfigName = persisted.currentApiConfigName
+
+				try {
+					const { name: _name, ...apiConfiguration } = await this.providerSettingsManager.getProfile({
+						name: persisted.currentApiConfigName,
+					})
+					loadedState.apiConfiguration = apiConfiguration as ProviderSettings
+				} catch (error) {
+					this.log(
+						`[loadViewState] Unable to resolve API profile '${persisted.currentApiConfigName}' for viewId ${this.viewId}: ${error instanceof Error ? error.message : String(error)}`,
+					)
 				}
 			}
 
@@ -488,22 +549,19 @@ export class ClineProvider
 	}
 
 	/**
-	 * Save a single view-local state value and sync to global state using a view-specific key.
-	 * This allows each Provider instance to have its own mode/apiConfig for parallel mode support.
+	 * Save a single view-local state value. Only non-secret selections are persisted durably.
 	 */
 	private async saveViewState(key: keyof ExtensionState, value: any): Promise<void> {
-		// Update local cache first. Undefined/null clears should not leave a local override behind.
 		if (value === undefined || value === null) {
 			delete this.viewLocalState[key]
 		} else {
 			this.viewLocalState[key] = value
 		}
 
-		// Persist to view-specific ContextProxy key for mode/currentApiConfigName/apiConfiguration,
-		// so recreated views restore their own values instead of the last writer's shared state.
-		if (key === "mode" || key === "currentApiConfigName" || key === "apiConfiguration") {
-			const viewKey = this.viewStateKeyFor(key as "mode" | "currentApiConfigName" | "apiConfiguration")
-			await this.contextProxy.setValue(viewKey as any, value)
+		if (key === "mode") {
+			await this.savePersistedViewState({ mode: value })
+		} else if (key === "currentApiConfigName") {
+			await this.savePersistedViewState({ currentApiConfigName: value })
 		}
 
 		this.log(`[saveViewState] Saved ${String(key)} for viewId ${this.viewId}`)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -459,9 +459,10 @@ export class ClineProvider
 	}
 
 	private async savePersistedViewState(values: Partial<PersistedViewState>): Promise<void> {
+		const viewStateId = this.viewStateId
 		const write = ClineProvider.persistedViewStateWriteQueue.then(async () => {
 			const states = this.getPersistedViewStates({ fresh: true })
-			const current = states[this.viewStateId] ?? {}
+			const current = states[viewStateId] ?? {}
 			const next: PersistedViewState = { ...current }
 
 			if ("mode" in values) {
@@ -481,10 +482,10 @@ export class ClineProvider
 			}
 
 			if (!next.mode && !next.currentApiConfigName) {
-				delete states[this.viewStateId]
+				delete states[viewStateId]
 			} else {
 				next.updatedAt = values.updatedAt ?? Date.now()
-				states[this.viewStateId] = next
+				states[viewStateId] = next
 			}
 
 			await this.contextProxy.setValue("viewStates", this.prunePersistedViewStates(states))
@@ -565,16 +566,16 @@ export class ClineProvider
 	 * Save a single view-local state value. Only non-secret selections are persisted durably.
 	 */
 	private async saveViewState(key: keyof ExtensionState, value: any): Promise<void> {
-		if (value === undefined || value === null) {
-			delete this.viewLocalState[key]
-		} else {
-			this.viewLocalState[key] = value
-		}
-
 		if (key === "mode") {
 			await this.savePersistedViewState({ mode: value })
 		} else if (key === "currentApiConfigName") {
 			await this.savePersistedViewState({ currentApiConfigName: value })
+		}
+
+		if (value === undefined || value === null) {
+			delete this.viewLocalState[key]
+		} else {
+			this.viewLocalState[key] = value
 		}
 
 		this.log(`[saveViewState] Saved ${String(key)} for viewId ${this.viewId}`)
@@ -906,6 +907,15 @@ export class ClineProvider
 		this.customModesManager?.dispose()
 		this.taskHistoryStore.dispose()
 		this.flushGlobalStateWriteThrough()
+		if (this.renderContext === "editor") {
+			try {
+				await this.clearPersistedViewState()
+			} catch (error) {
+				this.log(
+					`[dispose] Failed to clear persisted view state for ${this.viewStateId}: ${error instanceof Error ? error.message : String(error)}`,
+				)
+			}
+		}
 		this.log("Disposed all disposables")
 		ClineProvider.activeInstances.delete(this)
 
@@ -3150,10 +3160,13 @@ export class ClineProvider
 				return acc
 			}, {} as ProviderSettings)
 
-			this.viewLocalState.apiConfiguration = {
-				...(this.viewLocalState.apiConfiguration ?? {}),
-				...providerSettingsUpdate,
-			}
+			this.viewLocalState.apiConfiguration =
+				"apiProvider" in providerSettingsUpdate
+					? providerSettingsUpdate
+					: {
+							...(this.viewLocalState.apiConfiguration ?? {}),
+							...providerSettingsUpdate,
+						}
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -51,6 +51,7 @@ import {
 	getModelId,
 	isRetiredProvider,
 	providerIdentifiers,
+	PROVIDER_SETTINGS_KEYS,
 } from "@roo-code/types"
 import { RateLimitClock, createRateLimitClock } from "../task/RateLimitClock"
 import { TaskRegistry } from "../task/TaskRegistry"
@@ -170,6 +171,7 @@ export class ClineProvider
 	public static readonly sideBarId = `${Package.name}.SidebarProvider`
 	public static readonly tabPanelId = `${Package.name}.TabPanelProvider`
 	private static activeInstances: Set<ClineProvider> = new Set()
+	private static nextViewId = 0
 	private disposables: vscode.Disposable[] = []
 	private webviewDisposables: vscode.Disposable[] = []
 	private view?: vscode.WebviewView | vscode.WebviewPanel
@@ -213,6 +215,25 @@ export class ClineProvider
 	 */
 	private clineMessagesSeq = 0
 
+	/**
+	 * Unique identifier for this provider instance's view.
+	 * Based on renderContext and a monotonically increasing counter to ensure uniqueness across multiple instances.
+	 */
+	public readonly viewId: string
+
+	/**
+	 * Stable identifier for persisted per-view state keys.
+	 * Defaults to viewId until the webview reports its VS Code-persisted id.
+	 */
+	private viewStateId: string
+
+	/**
+	 * Local state buffer for this specific view instance.
+	 * Used to isolate mode, apiConfiguration, and other fields from the shared ContextProxy singleton
+	 * when running in parallel (multi-tab) mode.
+	 */
+	private viewLocalState: Partial<ExtensionState> = {}
+
 	public isViewLaunched = false
 	public settingsImportedAt?: number
 	public readonly latestAnnouncementId = "jul-2026-v3.74.0-openai-provider-workflows" // v3.74.0 OpenAI controls, provider reliability, and smoother workflows
@@ -227,13 +248,16 @@ export class ClineProvider
 		mdmService?: MdmService,
 	) {
 		super()
+		// Initialize viewId based on renderContext and monotonically increasing instance identifier for uniqueness.
+		// activeInstances is used for visibility/iteration checks, so we keep tracking instances separately.
+		this.viewId = `${renderContext}-${ClineProvider.nextViewId++}`
+		this.viewStateId = this.viewId
+		ClineProvider.activeInstances.add(this)
 		this.currentWorkspacePath = getWorkspacePath()
 		this.pendingEditOperations = new PendingEditOperationStore(
 			ClineProvider.PENDING_OPERATION_TIMEOUT_MS,
 			(message) => this.log(message),
 		)
-
-		ClineProvider.activeInstances.add(this)
 
 		this.mdmService = mdmService
 		void this.updateGlobalState("codebaseIndexModels", EMBEDDING_MODEL_PROFILES)
@@ -264,6 +288,9 @@ export class ClineProvider
 		this.customModesManager = new CustomModesManager(this.context, async () => {
 			await this.postStateToWebviewWithoutClineMessages()
 		})
+
+		// Load initial state from global state into viewLocalState buffer after dependencies used by getState are ready.
+		void this.loadViewState()
 
 		// Initialize MCP Hub through the singleton manager
 		McpServerManager.getInstance(this.context, this)
@@ -413,6 +440,73 @@ export class ClineProvider
 		} catch (error) {
 			this.log(`[initializeTaskHistoryStore] Error: ${error instanceof Error ? error.message : String(error)}`)
 		}
+	}
+
+	/**
+	 * Derive a view-specific ContextProxy key for persisting view-local state.
+	 * Uses a stable per-view id so each restored tab reads and writes its own values
+	 * independent of provider construction order.
+	 */
+	private viewStateKeyFor(key: "mode" | "currentApiConfigName" | "apiConfiguration"): string {
+		return `__view_state_${this.viewStateId}_${key}`
+	}
+
+	public async setViewStateId(viewStateId: string | undefined): Promise<void> {
+		const normalizedViewStateId = viewStateId?.trim()
+
+		if (!normalizedViewStateId || normalizedViewStateId === this.viewStateId) {
+			return
+		}
+
+		this.viewStateId = normalizedViewStateId.replace(/[^A-Za-z0-9_-]/g, "_")
+		await this.loadViewState()
+	}
+
+	/**
+	 * Loads persisted values from stable per-view keys into the view-local state buffer.
+	 * Missing keys are intentionally left unset so getState() falls back to shared ContextProxy values.
+	 */
+	private async loadViewState(): Promise<void> {
+		try {
+			const loadedState: Partial<ExtensionState> = {}
+
+			for (const key of ["mode", "currentApiConfigName", "apiConfiguration"] as const) {
+				const value = this.contextProxy.getValue(this.viewStateKeyFor(key) as any)
+
+				if (value !== undefined && value !== null) {
+					loadedState[key] = value as any
+				}
+			}
+
+			this.viewLocalState = loadedState
+			this.log(`[loadViewState] Loaded state for viewId ${this.viewId}`)
+		} catch (error) {
+			this.log(
+				`[loadViewState] Error loading state for viewId ${this.viewId}: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+	}
+
+	/**
+	 * Save a single view-local state value and sync to global state using a view-specific key.
+	 * This allows each Provider instance to have its own mode/apiConfig for parallel mode support.
+	 */
+	private async saveViewState(key: keyof ExtensionState, value: any): Promise<void> {
+		// Update local cache first. Undefined/null clears should not leave a local override behind.
+		if (value === undefined || value === null) {
+			delete this.viewLocalState[key]
+		} else {
+			this.viewLocalState[key] = value
+		}
+
+		// Persist to view-specific ContextProxy key for mode/currentApiConfigName/apiConfiguration,
+		// so recreated views restore their own values instead of the last writer's shared state.
+		if (key === "mode" || key === "currentApiConfigName" || key === "apiConfiguration") {
+			const viewKey = this.viewStateKeyFor(key as "mode" | "currentApiConfigName" | "apiConfiguration")
+			await this.contextProxy.setValue(viewKey as any, value)
+		}
+
+		this.log(`[saveViewState] Saved ${String(key)} for viewId ${this.viewId}`)
 	}
 
 	/**
@@ -1089,6 +1183,7 @@ export class ClineProvider
 			}
 
 			await this.updateGlobalState("mode", historyItem.mode)
+			this.viewLocalState.mode = historyItem.mode
 
 			// Load the saved API config for the restored mode if it exists.
 			// Skip mode-based profile activation if historyItem.apiConfigName exists,
@@ -1539,6 +1634,7 @@ export class ClineProvider
 		}
 
 		await this.updateGlobalState("mode", newMode)
+		this._updateViewLocalStateFromMutation({ mode: newMode })
 
 		this.emit(RooCodeEventName.ModeChanged, newMode)
 
@@ -2614,12 +2710,18 @@ export class ClineProvider
 		>
 	> {
 		const stateValues = this.contextProxy.getValues()
+
+		// Merge viewLocalState on top of global state so a provider can serve
+		// state values scoped to its own view while preserving ContextProxy defaults.
+		const mergedStateValues = { ...stateValues, ...this.viewLocalState }
+
 		const customModes = await this.customModesManager.getCustomModes()
 
 		// Determine apiProvider with the same logic as before, while filtering retired providers.
+		// Use mergedStateValues to prioritize viewLocalState for parallel mode support
 		const apiProvider: ProviderName =
-			stateValues.apiProvider && !isRetiredProvider(stateValues.apiProvider)
-				? stateValues.apiProvider
+			mergedStateValues.apiProvider && !isRetiredProvider(mergedStateValues.apiProvider)
+				? (mergedStateValues.apiProvider as ProviderName)
 				: "anthropic"
 
 		// Build the apiConfiguration object combining state values and secrets.
@@ -2681,115 +2783,118 @@ export class ClineProvider
 
 		// Return the same structure as before.
 		return {
-			apiConfiguration: providerSettings,
-			lastShownAnnouncementId: stateValues.lastShownAnnouncementId,
-			customInstructions: stateValues.customInstructions,
-			apiModelId: stateValues.apiModelId,
-			alwaysAllowReadOnly: stateValues.alwaysAllowReadOnly ?? false,
-			alwaysAllowReadOnlyOutsideWorkspace: stateValues.alwaysAllowReadOnlyOutsideWorkspace ?? false,
-			alwaysAllowWrite: stateValues.alwaysAllowWrite ?? false,
-			alwaysAllowWriteOutsideWorkspace: stateValues.alwaysAllowWriteOutsideWorkspace ?? false,
-			alwaysAllowWriteProtected: stateValues.alwaysAllowWriteProtected ?? false,
-			alwaysAllowExecute: stateValues.alwaysAllowExecute ?? false,
-			alwaysAllowMcp: stateValues.alwaysAllowMcp ?? false,
-			alwaysAllowModeSwitch: stateValues.alwaysAllowModeSwitch ?? false,
-			alwaysAllowSubtasks: stateValues.alwaysAllowSubtasks ?? false,
-			alwaysAllowFollowupQuestions: stateValues.alwaysAllowFollowupQuestions ?? false,
-			followupAutoApproveTimeoutMs: stateValues.followupAutoApproveTimeoutMs ?? 60000,
-			diagnosticsEnabled: stateValues.diagnosticsEnabled ?? true,
-			allowedMaxRequests: stateValues.allowedMaxRequests,
-			allowedMaxCost: stateValues.allowedMaxCost,
-			autoCondenseContext: stateValues.autoCondenseContext ?? true,
-			autoCondenseContextPercent: stateValues.autoCondenseContextPercent ?? 100,
+			apiConfiguration: {
+				...providerSettings,
+				...mergedStateValues.apiConfiguration,
+			},
+			lastShownAnnouncementId: mergedStateValues.lastShownAnnouncementId,
+			customInstructions: mergedStateValues.customInstructions,
+			apiModelId: mergedStateValues.apiModelId,
+			alwaysAllowReadOnly: mergedStateValues.alwaysAllowReadOnly ?? false,
+			alwaysAllowReadOnlyOutsideWorkspace: mergedStateValues.alwaysAllowReadOnlyOutsideWorkspace ?? false,
+			alwaysAllowWrite: mergedStateValues.alwaysAllowWrite ?? false,
+			alwaysAllowWriteOutsideWorkspace: mergedStateValues.alwaysAllowWriteOutsideWorkspace ?? false,
+			alwaysAllowWriteProtected: mergedStateValues.alwaysAllowWriteProtected ?? false,
+			alwaysAllowExecute: mergedStateValues.alwaysAllowExecute ?? false,
+			alwaysAllowMcp: mergedStateValues.alwaysAllowMcp ?? false,
+			alwaysAllowModeSwitch: mergedStateValues.alwaysAllowModeSwitch ?? false,
+			alwaysAllowSubtasks: mergedStateValues.alwaysAllowSubtasks ?? false,
+			alwaysAllowFollowupQuestions: mergedStateValues.alwaysAllowFollowupQuestions ?? false,
+			followupAutoApproveTimeoutMs: mergedStateValues.followupAutoApproveTimeoutMs ?? 60000,
+			diagnosticsEnabled: mergedStateValues.diagnosticsEnabled ?? true,
+			allowedMaxRequests: mergedStateValues.allowedMaxRequests,
+			allowedMaxCost: mergedStateValues.allowedMaxCost,
+			autoCondenseContext: mergedStateValues.autoCondenseContext ?? true,
+			autoCondenseContextPercent: mergedStateValues.autoCondenseContextPercent ?? 100,
 			taskHistory: this.taskHistoryStore.getAll(),
-			allowedCommands: stateValues.allowedCommands,
-			deniedCommands: stateValues.deniedCommands,
-			soundEnabled: stateValues.soundEnabled ?? false,
-			ttsEnabled: stateValues.ttsEnabled ?? false,
-			ttsSpeed: stateValues.ttsSpeed ?? 1.0,
-			enableCheckpoints: stateValues.enableCheckpoints ?? true,
-			checkpointTimeout: stateValues.checkpointTimeout ?? DEFAULT_CHECKPOINT_TIMEOUT_SECONDS,
-			soundVolume: stateValues.soundVolume,
-			writeDelayMs: stateValues.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS,
-			diffFuzzyThreshold: stateValues.diffFuzzyThreshold ?? DEFAULT_DIFF_FUZZY_THRESHOLD,
+			allowedCommands: mergedStateValues.allowedCommands,
+			deniedCommands: mergedStateValues.deniedCommands,
+			soundEnabled: mergedStateValues.soundEnabled ?? false,
+			ttsEnabled: mergedStateValues.ttsEnabled ?? false,
+			ttsSpeed: mergedStateValues.ttsSpeed ?? 1.0,
+			enableCheckpoints: mergedStateValues.enableCheckpoints ?? true,
+			checkpointTimeout: mergedStateValues.checkpointTimeout ?? DEFAULT_CHECKPOINT_TIMEOUT_SECONDS,
+			soundVolume: mergedStateValues.soundVolume,
+			writeDelayMs: mergedStateValues.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS,
+			diffFuzzyThreshold: mergedStateValues.diffFuzzyThreshold ?? DEFAULT_DIFF_FUZZY_THRESHOLD,
 			terminalShellIntegrationTimeout:
-				stateValues.terminalShellIntegrationTimeout ?? Terminal.defaultShellIntegrationTimeout,
-			terminalShellIntegrationDisabled: stateValues.terminalShellIntegrationDisabled ?? true,
-			terminalCommandDelay: stateValues.terminalCommandDelay ?? 0,
-			terminalPowershellCounter: stateValues.terminalPowershellCounter ?? false,
-			terminalZshClearEolMark: stateValues.terminalZshClearEolMark ?? true,
-			terminalZshOhMy: stateValues.terminalZshOhMy ?? false,
-			terminalZshP10k: stateValues.terminalZshP10k ?? false,
-			terminalZdotdir: stateValues.terminalZdotdir ?? false,
-			terminalProfile: stateValues.terminalProfile,
-			mode: stateValues.mode ?? defaultModeSlug,
-			language: stateValues.language ?? formatLanguage(vscode.env.language),
-			mcpEnabled: stateValues.mcpEnabled ?? true,
+				mergedStateValues.terminalShellIntegrationTimeout ?? Terminal.defaultShellIntegrationTimeout,
+			terminalShellIntegrationDisabled: mergedStateValues.terminalShellIntegrationDisabled ?? true,
+			terminalCommandDelay: mergedStateValues.terminalCommandDelay ?? 0,
+			terminalPowershellCounter: mergedStateValues.terminalPowershellCounter ?? false,
+			terminalZshClearEolMark: mergedStateValues.terminalZshClearEolMark ?? true,
+			terminalZshOhMy: mergedStateValues.terminalZshOhMy ?? false,
+			terminalZshP10k: mergedStateValues.terminalZshP10k ?? false,
+			terminalZdotdir: mergedStateValues.terminalZdotdir ?? false,
+			terminalProfile: mergedStateValues.terminalProfile,
+			mode: (mergedStateValues.mode as Mode) ?? defaultModeSlug,
+			language: mergedStateValues.language ?? formatLanguage(vscode.env.language),
+			mcpEnabled: mergedStateValues.mcpEnabled ?? true,
 			mcpServers: this.mcpHub?.getAllServers() ?? [],
-			currentApiConfigName: stateValues.currentApiConfigName ?? "default",
-			listApiConfigMeta: stateValues.listApiConfigMeta ?? [],
-			pinnedApiConfigs: stateValues.pinnedApiConfigs ?? {},
-			modeApiConfigs: stateValues.modeApiConfigs ?? ({} as Record<Mode, string>),
-			customModePrompts: stateValues.customModePrompts ?? {},
-			customSupportPrompts: stateValues.customSupportPrompts ?? {},
-			enhancementApiConfigId: stateValues.enhancementApiConfigId,
-			experiments: stateValues.experiments ?? experimentDefault,
-			autoApprovalEnabled: stateValues.autoApprovalEnabled ?? false,
+			currentApiConfigName: mergedStateValues.currentApiConfigName ?? "default",
+			listApiConfigMeta: mergedStateValues.listApiConfigMeta ?? [],
+			pinnedApiConfigs: mergedStateValues.pinnedApiConfigs ?? {},
+			modeApiConfigs: (mergedStateValues.modeApiConfigs as Record<Mode, string>) ?? ({} as Record<Mode, string>),
+			customModePrompts: mergedStateValues.customModePrompts ?? {},
+			customSupportPrompts: mergedStateValues.customSupportPrompts ?? {},
+			enhancementApiConfigId: mergedStateValues.enhancementApiConfigId,
+			experiments: mergedStateValues.experiments ?? experimentDefault,
+			autoApprovalEnabled: mergedStateValues.autoApprovalEnabled ?? false,
 			customModes,
-			maxOpenTabsContext: stateValues.maxOpenTabsContext ?? 20,
-			maxWorkspaceFiles: stateValues.maxWorkspaceFiles ?? 200,
-			disabledTools: stateValues.disabledTools,
-			telemetrySetting: stateValues.telemetrySetting || "unset",
-			showRooIgnoredFiles: stateValues.showRooIgnoredFiles ?? false,
-			enableSubfolderRules: stateValues.enableSubfolderRules ?? false,
-			maxImageFileSize: stateValues.maxImageFileSize ?? 5,
-			maxTotalImageSize: stateValues.maxTotalImageSize ?? 20,
-			historyPreviewCollapsed: stateValues.historyPreviewCollapsed ?? false,
-			reasoningBlockCollapsed: stateValues.reasoningBlockCollapsed ?? true,
-			chatFontSize: stateValues.chatFontSize,
-			enterBehavior: stateValues.enterBehavior ?? "send",
+			maxOpenTabsContext: mergedStateValues.maxOpenTabsContext ?? 20,
+			maxWorkspaceFiles: mergedStateValues.maxWorkspaceFiles ?? 200,
+			disabledTools: mergedStateValues.disabledTools,
+			telemetrySetting: mergedStateValues.telemetrySetting || "unset",
+			showRooIgnoredFiles: mergedStateValues.showRooIgnoredFiles ?? false,
+			enableSubfolderRules: mergedStateValues.enableSubfolderRules ?? false,
+			maxImageFileSize: mergedStateValues.maxImageFileSize ?? 5,
+			maxTotalImageSize: mergedStateValues.maxTotalImageSize ?? 20,
+			historyPreviewCollapsed: mergedStateValues.historyPreviewCollapsed ?? false,
+			reasoningBlockCollapsed: mergedStateValues.reasoningBlockCollapsed ?? true,
+			chatFontSize: mergedStateValues.chatFontSize,
+			enterBehavior: mergedStateValues.enterBehavior ?? "send",
 			cloudUserInfo,
 			cloudIsAuthenticated,
 			sharingEnabled,
 			publicSharingEnabled,
 			organizationAllowList,
 			organizationSettingsVersion,
-			customCondensingPrompt: stateValues.customCondensingPrompt,
-			codebaseIndexModels: stateValues.codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
+			customCondensingPrompt: mergedStateValues.customCondensingPrompt,
+			codebaseIndexModels: mergedStateValues.codebaseIndexModels ?? EMBEDDING_MODEL_PROFILES,
 			codebaseIndexConfig: {
-				codebaseIndexEnabled: stateValues.codebaseIndexConfig?.codebaseIndexEnabled ?? false,
+				codebaseIndexEnabled: mergedStateValues.codebaseIndexConfig?.codebaseIndexEnabled ?? false,
 				codebaseIndexQdrantUrl:
-					stateValues.codebaseIndexConfig?.codebaseIndexQdrantUrl ?? "http://localhost:6333",
+					mergedStateValues.codebaseIndexConfig?.codebaseIndexQdrantUrl ?? "http://localhost:6333",
 				codebaseIndexEmbedderProvider:
-					stateValues.codebaseIndexConfig?.codebaseIndexEmbedderProvider ?? "openai",
-				codebaseIndexEmbedderBaseUrl: stateValues.codebaseIndexConfig?.codebaseIndexEmbedderBaseUrl ?? "",
-				codebaseIndexEmbedderModelId: stateValues.codebaseIndexConfig?.codebaseIndexEmbedderModelId ?? "",
+					mergedStateValues.codebaseIndexConfig?.codebaseIndexEmbedderProvider ?? "openai",
+				codebaseIndexEmbedderBaseUrl: mergedStateValues.codebaseIndexConfig?.codebaseIndexEmbedderBaseUrl ?? "",
+				codebaseIndexEmbedderModelId: mergedStateValues.codebaseIndexConfig?.codebaseIndexEmbedderModelId ?? "",
 				codebaseIndexEmbedderModelDimension:
-					stateValues.codebaseIndexConfig?.codebaseIndexEmbedderModelDimension,
+					mergedStateValues.codebaseIndexConfig?.codebaseIndexEmbedderModelDimension,
 				codebaseIndexOpenAiCompatibleBaseUrl:
-					stateValues.codebaseIndexConfig?.codebaseIndexOpenAiCompatibleBaseUrl,
-				codebaseIndexSearchMaxResults: stateValues.codebaseIndexConfig?.codebaseIndexSearchMaxResults,
-				codebaseIndexSearchMinScore: stateValues.codebaseIndexConfig?.codebaseIndexSearchMinScore,
-				codebaseIndexBedrockRegion: stateValues.codebaseIndexConfig?.codebaseIndexBedrockRegion,
-				codebaseIndexBedrockProfile: stateValues.codebaseIndexConfig?.codebaseIndexBedrockProfile,
+					mergedStateValues.codebaseIndexConfig?.codebaseIndexOpenAiCompatibleBaseUrl,
+				codebaseIndexSearchMaxResults: mergedStateValues.codebaseIndexConfig?.codebaseIndexSearchMaxResults,
+				codebaseIndexSearchMinScore: mergedStateValues.codebaseIndexConfig?.codebaseIndexSearchMinScore,
+				codebaseIndexBedrockRegion: mergedStateValues.codebaseIndexConfig?.codebaseIndexBedrockRegion,
+				codebaseIndexBedrockProfile: mergedStateValues.codebaseIndexConfig?.codebaseIndexBedrockProfile,
 				codebaseIndexOpenRouterSpecificProvider:
-					stateValues.codebaseIndexConfig?.codebaseIndexOpenRouterSpecificProvider,
+					mergedStateValues.codebaseIndexConfig?.codebaseIndexOpenRouterSpecificProvider,
 			},
-			profileThresholds: stateValues.profileThresholds ?? {},
+			profileThresholds: mergedStateValues.profileThresholds ?? {},
 			lockApiConfigAcrossModes: this.context.workspaceState.get("lockApiConfigAcrossModes", false),
-			includeDiagnosticMessages: stateValues.includeDiagnosticMessages ?? true,
-			maxDiagnosticMessages: stateValues.maxDiagnosticMessages ?? 50,
-			includeTaskHistoryInEnhance: stateValues.includeTaskHistoryInEnhance ?? true,
-			includeCurrentTime: stateValues.includeCurrentTime ?? true,
-			includeCurrentCost: stateValues.includeCurrentCost ?? true,
-			maxGitStatusFiles: stateValues.maxGitStatusFiles ?? 0,
+			includeDiagnosticMessages: mergedStateValues.includeDiagnosticMessages ?? true,
+			maxDiagnosticMessages: mergedStateValues.maxDiagnosticMessages ?? 50,
+			includeTaskHistoryInEnhance: mergedStateValues.includeTaskHistoryInEnhance ?? true,
+			includeCurrentTime: mergedStateValues.includeCurrentTime ?? true,
+			includeCurrentCost: mergedStateValues.includeCurrentCost ?? true,
+			maxGitStatusFiles: mergedStateValues.maxGitStatusFiles ?? 0,
 			taskSyncEnabled,
-			imageGenerationProvider: stateValues.imageGenerationProvider,
-			openRouterImageApiKey: stateValues.openRouterImageApiKey,
-			openRouterImageGenerationSelectedModel: stateValues.openRouterImageGenerationSelectedModel,
-			autoCloseZooOpenedFiles: stateValues.autoCloseZooOpenedFiles,
-			autoCloseZooOpenedFilesAfterUserEdited: stateValues.autoCloseZooOpenedFilesAfterUserEdited,
-			autoCloseZooOpenedNewFiles: stateValues.autoCloseZooOpenedNewFiles,
+			imageGenerationProvider: mergedStateValues.imageGenerationProvider,
+			openRouterImageApiKey: mergedStateValues.openRouterImageApiKey,
+			openRouterImageGenerationSelectedModel: mergedStateValues.openRouterImageGenerationSelectedModel,
+			autoCloseZooOpenedFiles: mergedStateValues.autoCloseZooOpenedFiles,
+			autoCloseZooOpenedFilesAfterUserEdited: mergedStateValues.autoCloseZooOpenedFilesAfterUserEdited,
+			autoCloseZooOpenedNewFiles: mergedStateValues.autoCloseZooOpenedNewFiles,
 		}
 	}
 
@@ -2892,6 +2997,7 @@ export class ClineProvider
 
 	public async setValue<K extends keyof RooCodeSettings>(key: K, value: RooCodeSettings[K]) {
 		await this.contextProxy.setValue(key, value)
+		this._updateViewLocalStateFromMutation({ [key]: value })
 	}
 
 	public getValue<K extends keyof RooCodeSettings>(key: K) {
@@ -2904,6 +3010,61 @@ export class ClineProvider
 
 	public async setValues(values: RooCodeSettings) {
 		await this.contextProxy.setValues(values)
+		this._updateViewLocalStateFromMutation(values)
+	}
+
+	/**
+	 * Update or invalidate viewLocalState when ContextProxy is mutated via setValues, setValue,
+	 * profile upsert/activation/deletion, or resetState. This ensures the local cache stays in
+	 * sync with global state changes that would otherwise be invisible behind mergedStateValues.
+	 */
+	private _updateViewLocalStateFromMutation(values: Partial<RooCodeSettings>): void {
+		if ("mode" in values) {
+			const val = values.mode
+			if (val === undefined || val === null) {
+				delete this.viewLocalState.mode
+			} else {
+				this.viewLocalState.mode = val as any
+			}
+		}
+
+		if ("currentApiConfigName" in values) {
+			const val = values.currentApiConfigName
+			if (val === undefined || val === null) {
+				delete this.viewLocalState.currentApiConfigName
+			} else {
+				this.viewLocalState.currentApiConfigName = val as any
+			}
+		}
+
+		if ("apiConfiguration" in values) {
+			const val = (values as any).apiConfiguration
+			if (val === undefined || val === null) {
+				delete this.viewLocalState.apiConfiguration
+			} else {
+				this.viewLocalState.apiConfiguration = val
+			}
+		} else if (PROVIDER_SETTINGS_KEYS.some((key) => key in values)) {
+			const providerSettingsUpdate = PROVIDER_SETTINGS_KEYS.reduce((acc, key) => {
+				if (key in values) {
+					return { ...acc, [key]: values[key as keyof RooCodeSettings] }
+				}
+
+				return acc
+			}, {} as ProviderSettings)
+
+			this.viewLocalState.apiConfiguration = {
+				...(this.viewLocalState.apiConfiguration ?? {}),
+				...providerSettingsUpdate,
+			}
+		}
+	}
+
+	/**
+	 * Clear view-local state cache so that getState() falls back to ContextProxy defaults.
+	 */
+	private _clearViewLocalState(): void {
+		this.viewLocalState = {}
 	}
 
 	// dev
@@ -2932,6 +3093,7 @@ export class ClineProvider
 		}
 
 		await this.contextProxy.resetAllState()
+
 		await this.providerSettingsManager.resetAllConfigs()
 		await this.customModesManager.resetCustomModes()
 		await this.removeClineFromStack()

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1825,12 +1825,20 @@ export class ClineProvider
 				// this.contextProxy.setValues({ ...providerSettings, listApiConfigMeta: ..., currentApiConfigName: ... })
 				// We should probably switch to that and verify that it works.
 				// I left the original implementation in just to be safe.
+				const listApiConfigMeta = await this.providerSettingsManager.listConfig()
+
 				await Promise.all([
-					this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
+					this.updateGlobalState("listApiConfigMeta", listApiConfigMeta),
 					this.updateGlobalState("currentApiConfigName", name),
 					this.providerSettingsManager.setModeConfig(mode, id),
 					this.contextProxy.setProviderSettings(providerSettings),
 				])
+
+				this._updateViewLocalStateFromMutation({
+					listApiConfigMeta,
+					currentApiConfigName: name,
+					apiConfiguration: providerSettings,
+				})
 
 				// Change the provider for the current task.
 				// TODO: We should rename `buildApiHandler` for clarity (e.g. `getProviderClient`).
@@ -1870,6 +1878,11 @@ export class ClineProvider
 
 		await this.contextProxy.setValues({
 			...globalSettings,
+			currentApiConfigName: profileToActivate,
+			listApiConfigMeta: entries,
+		})
+
+		this._updateViewLocalStateFromMutation({
 			currentApiConfigName: profileToActivate,
 			listApiConfigMeta: entries,
 		})
@@ -1915,11 +1928,19 @@ export class ClineProvider
 		const persistTaskHistory = options?.persistTaskHistory ?? true
 
 		// See `upsertProviderProfile` for a description of what this is doing.
+		const listApiConfigMeta = await this.providerSettingsManager.listConfig()
+
 		await Promise.all([
-			this.contextProxy.setValue("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
+			this.contextProxy.setValue("listApiConfigMeta", listApiConfigMeta),
 			this.contextProxy.setValue("currentApiConfigName", name),
 			this.contextProxy.setProviderSettings(providerSettings),
 		])
+
+		this._updateViewLocalStateFromMutation({
+			listApiConfigMeta,
+			currentApiConfigName: name,
+			apiConfiguration: providerSettings,
+		})
 
 		const { mode } = await this.getState()
 
@@ -3075,7 +3096,7 @@ export class ClineProvider
 	 * profile upsert/activation/deletion, or resetState. This ensures the local cache stays in
 	 * sync with global state changes that would otherwise be invisible behind mergedStateValues.
 	 */
-	private _updateViewLocalStateFromMutation(values: Partial<RooCodeSettings>): void {
+	private _updateViewLocalStateFromMutation(values: Partial<RooCodeSettings> & Partial<ExtensionState>): void {
 		if ("mode" in values) {
 			const val = values.mode
 			if (val === undefined || val === null) {
@@ -3150,6 +3171,9 @@ export class ClineProvider
 		}
 
 		await this.contextProxy.resetAllState()
+
+		// Clear view-local state cache so getState() falls back to ContextProxy defaults.
+		this._clearViewLocalState()
 
 		await this.providerSettingsManager.resetAllConfigs()
 		await this.customModesManager.resetCustomModes()

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -3097,7 +3097,7 @@ export class ClineProvider
 	}
 
 	public getValues() {
-		return this.contextProxy.getValues()
+		return { ...this.contextProxy.getValues(), ...this.viewLocalState }
 	}
 
 	public async setValues(values: RooCodeSettings) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -566,17 +566,8 @@ export class ClineProvider
 	 * Save a single view-local state value. Only non-secret selections are persisted durably.
 	 */
 	private async saveViewState(key: keyof ExtensionState, value: any): Promise<void> {
-		if (key === "mode") {
-			await this.savePersistedViewState({ mode: value })
-		} else if (key === "currentApiConfigName") {
-			await this.savePersistedViewState({ currentApiConfigName: value })
-		}
-
-		if (value === undefined || value === null) {
-			delete this.viewLocalState[key]
-		} else {
-			this.viewLocalState[key] = value
-		}
+		await this._saveViewLocalStateFromMutation({ [key]: value } as Partial<RooCodeSettings> &
+			Partial<ExtensionState>)
 
 		this.log(`[saveViewState] Saved ${String(key)} for viewId ${this.viewId}`)
 	}
@@ -1855,11 +1846,9 @@ export class ClineProvider
 					this.updateGlobalState("currentApiConfigName", name),
 					this.providerSettingsManager.setModeConfig(mode, id),
 					this.contextProxy.setProviderSettings(providerSettings),
-					this.saveViewState("currentApiConfigName", name),
-					this.saveViewState("apiConfiguration", providerSettings),
 				])
 
-				this._updateViewLocalStateFromMutation({
+				await this._saveViewLocalStateFromMutation({
 					listApiConfigMeta,
 					currentApiConfigName: name,
 					apiConfiguration: providerSettings,
@@ -1959,11 +1948,9 @@ export class ClineProvider
 			this.contextProxy.setValue("listApiConfigMeta", listApiConfigMeta),
 			this.contextProxy.setValue("currentApiConfigName", name),
 			this.contextProxy.setProviderSettings(providerSettings),
-			this.saveViewState("currentApiConfigName", name),
-			this.saveViewState("apiConfiguration", providerSettings),
 		])
 
-		this._updateViewLocalStateFromMutation({
+		await this._saveViewLocalStateFromMutation({
 			listApiConfigMeta,
 			currentApiConfigName: name,
 			apiConfiguration: providerSettings,
@@ -3102,8 +3089,7 @@ export class ClineProvider
 
 	public async setValue<K extends keyof RooCodeSettings>(key: K, value: RooCodeSettings[K]) {
 		await this.contextProxy.setValue(key, value)
-		this._updateViewLocalStateFromMutation({ [key]: value })
-		await this._persistViewLocalStateFromMutation({ [key]: value })
+		await this._saveViewLocalStateFromMutation({ [key]: value })
 	}
 
 	public getValue<K extends keyof RooCodeSettings>(key: K) {
@@ -3116,8 +3102,14 @@ export class ClineProvider
 
 	public async setValues(values: RooCodeSettings) {
 		await this.contextProxy.setValues(values)
-		this._updateViewLocalStateFromMutation(values)
+		await this._saveViewLocalStateFromMutation(values)
+	}
+
+	private async _saveViewLocalStateFromMutation(
+		values: Partial<RooCodeSettings> & Partial<ExtensionState>,
+	): Promise<void> {
 		await this._persistViewLocalStateFromMutation(values)
+		this._updateViewLocalStateFromMutation(values)
 	}
 
 	/**

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1691,8 +1691,7 @@ export class ClineProvider
 			}
 		}
 
-		await this.updateGlobalState("mode", newMode)
-		this._updateViewLocalStateFromMutation({ mode: newMode })
+		await this.saveViewState("mode", newMode)
 
 		this.emit(RooCodeEventName.ModeChanged, newMode)
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -736,7 +736,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 	})
 
 	describe("saveViewState", () => {
-		it("should update viewLocalState when saveViewState is called", async () => {
+		it("should update viewLocalState and persist mode through registered viewStates", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 
 			const contextProxySpy = vi.spyOn(provider.contextProxy, "setValue")
@@ -744,37 +744,52 @@ describe("ClineProvider - Parallel Mode Support", () => {
 
 			await (provider as any).saveViewState("mode", "architect")
 
-			// Verify viewLocalState was updated
 			expect((provider as any).viewLocalState.mode).toBe("architect")
-
-			// saveViewState uses the stable per-view id, not the construction-order viewId suffix.
-			expect(contextProxySpy).toHaveBeenCalledWith("__view_state_stable-sidebar-view_mode", "architect")
-			expect(contextProxySpy).not.toHaveBeenCalledWith(`__view_state_${provider.viewId}_mode`, expect.anything())
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				"stable-sidebar-view": { mode: "architect" },
+			})
+			expect(contextProxySpy).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					"stable-sidebar-view": expect.objectContaining({
+						mode: "architect",
+						updatedAt: expect.any(Number),
+					}),
+				}),
+			)
+			expect(contextProxySpy).not.toHaveBeenCalledWith("__view_state_stable-sidebar-view_mode", expect.anything())
 
 			await provider.dispose()
 		})
 
-		it("should update viewLocalState for currentApiConfigName", async () => {
+		it("should update viewLocalState and persist currentApiConfigName through registered viewStates", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 
+			await (provider as any).setViewStateId("stable-sidebar-view")
 			await (provider as any).saveViewState("currentApiConfigName", "my-profile")
 
 			expect((provider as any).viewLocalState.currentApiConfigName).toBe("my-profile")
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				"stable-sidebar-view": { currentApiConfigName: "my-profile" },
+			})
 
 			await provider.dispose()
 		})
 
-		it("should update viewLocalState for apiConfiguration", async () => {
+		it("should update viewLocalState for apiConfiguration without persisting provider settings or secrets", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 
 			const testApiConfig = {
 				apiProvider: "openrouter" as const,
 				openRouterModelId: "claude-3.5-sonnet",
+				openRouterApiKey: "secret-key",
 			}
 
+			await (provider as any).setViewStateId("stable-sidebar-view")
 			await (provider as any).saveViewState("apiConfiguration", testApiConfig)
 
 			expect((provider as any).viewLocalState.apiConfiguration).toEqual(testApiConfig)
+			expect(provider.contextProxy.getValue("viewStates" as any)).toBeUndefined()
 
 			await provider.dispose()
 		})
@@ -823,15 +838,13 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await provider.dispose()
 		})
 
-		it("should update viewLocalState when stable per-view values are loaded manually", async () => {
+		it("should restore mode and currentApiConfigName from hydrated viewStates after extension reload", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 			const stableViewId = "stable-sidebar-view"
 
-			await provider.contextProxy.setValue(`__view_state_${stableViewId}_mode` as any, "architect")
-			await provider.contextProxy.setValue(
-				`__view_state_${stableViewId}_currentApiConfigName` as any,
-				"new-profile",
-			)
+			await provider.contextProxy.setValue("viewStates" as any, {
+				[stableViewId]: { mode: "architect", currentApiConfigName: "new-profile", updatedAt: 123 },
+			})
 
 			await (provider as any).setViewStateId(stableViewId)
 
@@ -842,23 +855,19 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await provider.dispose()
 		})
 
-		it("should restore mode, current API config name, and API configuration from stable per-view state", async () => {
+		it("should resolve API configuration from the persisted profile selection", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
 			const stableViewId = "stable-editor-tab-a"
-			const persistedApiConfiguration = {
-				apiProvider: "openrouter" as const,
+			const getProfileSpy = vi.spyOn(provider.providerSettingsManager, "getProfile").mockResolvedValue({
+				name: "profile-a",
+				id: "profile-a-id",
+				apiProvider: "openrouter",
 				openRouterModelId: "openrouter/anthropic/claude-sonnet-4",
-			}
+			} as any)
 
-			await provider.contextProxy.setValue(`__view_state_${stableViewId}_mode` as any, "architect")
-			await provider.contextProxy.setValue(
-				`__view_state_${stableViewId}_currentApiConfigName` as any,
-				"profile-a",
-			)
-			await provider.contextProxy.setValue(
-				`__view_state_${stableViewId}_apiConfiguration` as any,
-				persistedApiConfiguration,
-			)
+			await provider.contextProxy.setValue("viewStates" as any, {
+				[stableViewId]: { mode: "architect", currentApiConfigName: "profile-a", updatedAt: 123 },
+			})
 			await provider.contextProxy.setValue("mode" as any, "debugger")
 			await provider.contextProxy.setValue("currentApiConfigName" as any, "profile-b")
 			await provider.contextProxy.setValue("apiConfiguration" as any, { apiProvider: "anthropic" })
@@ -866,9 +875,32 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await (provider as any).setViewStateId(stableViewId)
 			const state = await provider.getState()
 
+			expect(getProfileSpy).toHaveBeenCalledWith({ name: "profile-a" })
 			expect(state.mode).toBe("architect")
 			expect(state.currentApiConfigName).toBe("profile-a")
-			expect(state.apiConfiguration).toMatchObject(persistedApiConfiguration)
+			expect(state.apiConfiguration).toMatchObject({
+				apiProvider: "openrouter",
+				openRouterModelId: "openrouter/anthropic/claude-sonnet-4",
+			})
+
+			await provider.dispose()
+		})
+
+		it("should not throw when a persisted profile selection cannot be resolved", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+			const stableViewId = "stable-editor-tab-a"
+			vi.spyOn(provider.providerSettingsManager, "getProfile").mockRejectedValue(new Error("missing profile"))
+
+			await provider.contextProxy.setValue("viewStates" as any, {
+				[stableViewId]: { mode: "architect", currentApiConfigName: "deleted-profile", updatedAt: 123 },
+			})
+
+			await expect((provider as any).setViewStateId(stableViewId)).resolves.toBeUndefined()
+			const state = await provider.getState()
+
+			expect(state.mode).toBe("architect")
+			expect(state.currentApiConfigName).toBe("deleted-profile")
+			expect(state.apiConfiguration.apiProvider).toBe("anthropic")
 
 			await provider.dispose()
 		})
@@ -886,6 +918,27 @@ describe("ClineProvider - Parallel Mode Support", () => {
 
 			expect((provider as any).viewLocalState.mode).toBe("architect")
 			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Error loading state"))
+
+			await provider.dispose()
+		})
+	})
+
+	describe("persisted view state pruning", () => {
+		it("should keep the newest 50 persisted view states", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const states = Object.fromEntries(
+				Array.from({ length: 55 }, (_, index) => [
+					`view-${index}`,
+					{ mode: `mode-${index}`, updatedAt: index },
+				]),
+			)
+
+			const pruned = (provider as any).prunePersistedViewStates(states)
+
+			expect(Object.keys(pruned)).toHaveLength(50)
+			expect(pruned["view-54"]).toBeDefined()
+			expect(pruned["view-5"]).toBeDefined()
+			expect(pruned["view-4"]).toBeUndefined()
 
 			await provider.dispose()
 		})

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -691,12 +691,12 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			)
 			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
 
-			// Access viewLocalState via private property for testing
+			await (provider1 as any).saveViewState("mode", "architect")
+
 			const state1 = await provider1.getState()
 			const state2 = await provider2.getState()
 
-			// Both should start with the same default mode from global state
-			expect(state1.mode).toBe("code")
+			expect(state1.mode).toBe("architect")
 			expect(state2.mode).toBe("code")
 
 			await provider1.dispose()
@@ -842,6 +842,31 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			)
 
 			await provider.dispose()
+		})
+		it("should merge concurrent persisted updates from separate provider instances without lost viewStates", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			await (provider1 as any).setViewStateId("stable-sidebar-view")
+			await (provider2 as any).setViewStateId("stable-editor-view")
+
+			await Promise.all([
+				(provider1 as any).saveViewState("mode", "architect"),
+				(provider2 as any).saveViewState("currentApiConfigName", "editor-profile"),
+			])
+
+			expect(mockContext.globalState.get("viewStates" as any)).toMatchObject({
+				"stable-sidebar-view": { mode: "architect" },
+				"stable-editor-view": { currentApiConfigName: "editor-profile" },
+			})
+
+			await provider1.dispose()
+			await provider2.dispose()
 		})
 	})
 
@@ -1039,6 +1064,32 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			expect(state.apiConfiguration.apiProvider).toBe("bedrock")
 			expect(state.apiConfiguration.awsBedrockEndpoint).toBe("http://127.0.0.1:4567")
 			expect((provider as any).viewLocalState.apiConfiguration.apiProvider).toBe("bedrock")
+
+			await provider.dispose()
+		})
+
+		it("should persist setValue mutations for view-local mode", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).setViewStateId("stable-sidebar-view")
+			await provider.setValue("mode" as any, "architect" as any)
+
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				"stable-sidebar-view": { mode: "architect" },
+			})
+
+			await provider.dispose()
+		})
+
+		it("should persist setValues mutations for view-local API profile", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).setViewStateId("stable-sidebar-view")
+			await provider.setValues({ currentApiConfigName: "profile-from-set-values" } as any)
+
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				"stable-sidebar-view": { currentApiConfigName: "profile-from-set-values" },
+			})
 
 			await provider.dispose()
 		})

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1,4 +1,4 @@
-﻿// pnpm --filter roo-cline test core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+// pnpm --filter roo-cline test core/webview/__tests__/ClineProvider.parallelMode.spec.ts
 
 import * as vscode from "vscode"
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1195,6 +1195,37 @@ describe("ClineProvider - Parallel Mode Support", () => {
 		})
 	})
 
+	describe("provider profile activation", () => {
+		it("should sync view-local apiConfiguration when activating an upserted profile", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			await (provider as any).saveViewState("apiConfiguration", {
+				apiProvider: "openrouter",
+				openRouterModelId: "openai/gpt-4.1",
+			})
+
+			const providerSettings = {
+				apiProvider: "zai" as const,
+				zaiApiKey: "mock-key",
+				zaiApiLine: "international_api" as const,
+				apiModelId: "glm-5.1",
+			}
+			vi.spyOn(provider.providerSettingsManager, "saveConfig").mockResolvedValue("zai-profile-id")
+			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValue([
+				{ name: "default", id: "zai-profile-id", apiProvider: "zai" },
+			])
+
+			await provider.upsertProviderProfile("default", providerSettings, true)
+
+			const state = await provider.getState()
+			expect(state.currentApiConfigName).toBe("default")
+			expect(state.apiConfiguration).toMatchObject(providerSettings)
+			expect(state.apiConfiguration.apiProvider).toBe("zai")
+			expect((provider as any).viewLocalState.apiConfiguration).toMatchObject(providerSettings)
+
+			await provider.dispose()
+		})
+	})
+
 	describe("handleModeSwitch integration", () => {
 		it("should update viewLocalState.mode when handleModeSwitch is called", async () => {
 			const postMessage = vi.fn()

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1,0 +1,1021 @@
+﻿// pnpm --filter roo-cline test core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+
+import * as vscode from "vscode"
+
+import { type ExtensionMessage, type ExtensionState, RooCodeEventName } from "@roo-code/types"
+
+import { defaultModeSlug } from "../../../shared/modes"
+import { ContextProxy } from "../../config/ContextProxy"
+import { ClineProvider } from "../ClineProvider"
+import { TelemetryService } from "@roo-code/telemetry"
+
+// Mock p-wait-for
+vi.mock("p-wait-for", () => ({
+	__esModule: true,
+	default: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock fs/promises
+vi.mock("fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs/promises")>()
+	const mocked = {
+		mkdir: vi.fn().mockResolvedValue(undefined),
+		writeFile: vi.fn().mockResolvedValue(undefined),
+		readFile: vi.fn().mockResolvedValue(""),
+		unlink: vi.fn().mockResolvedValue(undefined),
+		rmdir: vi.fn().mockResolvedValue(undefined),
+	}
+
+	return {
+		...actual,
+		...mocked,
+		default: {
+			...actual,
+			...mocked,
+		},
+	}
+})
+
+// Mock axios
+vi.mock("axios", () => ({
+	default: {
+		get: vi.fn().mockResolvedValue({ data: { data: [] } }),
+		post: vi.fn(),
+	},
+	get: vi.fn().mockResolvedValue({ data: { data: [] } }),
+	post: vi.fn(),
+}))
+
+// Mock safeWriteJson
+vi.mock("../../../utils/safeWriteJson", () => ({
+	safeWriteJson: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock path utils
+vi.mock("../../../utils/path", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../utils/path")>()
+	return {
+		...actual,
+		getWorkspacePath: vi.fn().mockReturnValue(""),
+	}
+})
+
+// Mock storage utils
+vi.mock("../../../utils/storage", () => ({
+	getSettingsDirectoryPath: vi.fn().mockResolvedValue("/test/settings/path"),
+	getTaskDirectoryPath: vi.fn().mockResolvedValue("/test/task/path"),
+	getGlobalStoragePath: vi.fn().mockResolvedValue("/test/storage/path"),
+}))
+
+// Mock MCP types
+vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
+	CallToolResultSchema: {},
+	ListResourcesResultSchema: {},
+	ListResourceTemplatesResultSchema: {},
+	ListToolsResultSchema: {},
+	ReadResourceResultSchema: {},
+	ErrorCode: {
+		InvalidRequest: "InvalidRequest",
+		MethodNotFound: "MethodNotFound",
+		InternalError: "InternalError",
+	},
+	McpError: class McpError extends Error {
+		code: string
+		constructor(code: string, message: string) {
+			super(message)
+			this.name = "McpError"
+			this.code = code
+		}
+	},
+}))
+
+// Mock delay
+vi.mock("delay", () => {
+	const delayFn = (_ms: number) => Promise.resolve()
+	delayFn.createDelay = () => delayFn
+	delayFn.reject = () => Promise.reject(new Error("Delay rejected"))
+	delayFn.range = () => Promise.resolve()
+	return { default: delayFn }
+})
+
+// Mock MCP client
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+	__esModule: true,
+	Client: vi.fn().mockImplementation(function () {
+		return {
+			connect: vi.fn().mockResolvedValue(undefined),
+			close: vi.fn().mockResolvedValue(undefined),
+			listTools: vi.fn().mockResolvedValue({ tools: [] }),
+			callTool: vi.fn().mockResolvedValue({ content: [] }),
+		}
+	}),
+}))
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+	__esModule: true,
+	StdioClientTransport: vi.fn().mockImplementation(function () {
+		return {
+			connect: vi.fn().mockResolvedValue(undefined),
+			close: vi.fn().mockResolvedValue(undefined),
+		}
+	}),
+}))
+
+const { onDidChangeConfigurationMock } = vi.hoisted(() => {
+	const onDidChangeConfigurationMock = vi.fn((handler: (e: any) => any) => {
+		const disposable = {
+			dispose: vi.fn(),
+		}
+		const checkedKeys: string[] = []
+		void handler({
+			affectsConfiguration: (key: string) => {
+				checkedKeys.push(key)
+				return false
+			},
+		})
+
+		if (checkedKeys.includes("workbench.colorTheme")) {
+			onDidChangeConfigurationMock.mock.calls.pop()
+		}
+
+		return disposable
+	})
+
+	return { onDidChangeConfigurationMock }
+})
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	ExtensionContext: vi.fn(),
+	OutputChannel: vi.fn(),
+	WebviewView: vi.fn(),
+	EventEmitter: vi.fn().mockImplementation(function () {
+		return {
+			event: vi.fn(),
+			fire: vi.fn(),
+			dispose: vi.fn(),
+		}
+	}),
+	Uri: {
+		joinPath: vi.fn(),
+		file: vi.fn(),
+	},
+	CodeActionKind: {
+		QuickFix: { value: "quickfix" },
+		RefactorRewrite: { value: "refactor.rewrite" },
+	},
+	Range: class Range {
+		constructor(
+			readonly startLine: number,
+			readonly startCharacter: number,
+			readonly endLine: number,
+			readonly endCharacter: number,
+		) {}
+	},
+	commands: {
+		executeCommand: vi.fn().mockResolvedValue(undefined),
+	},
+	workspace: {
+		getConfiguration: vi.fn().mockReturnValue({
+			get: vi.fn().mockReturnValue([]),
+			update: vi.fn(),
+		}),
+		getWorkspaceFolder: vi.fn(),
+		createFileSystemWatcher: vi.fn().mockReturnValue({
+			onDidCreate: vi.fn(),
+			onDidDelete: vi.fn(),
+			dispose: vi.fn(),
+		}),
+		onDidChangeConfiguration: onDidChangeConfigurationMock,
+		onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+		onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+		onDidOpenTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+		onDidCloseTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+	},
+	window: {
+		showInformationMessage: vi.fn(),
+		showWarningMessage: vi.fn(),
+		showErrorMessage: vi.fn(),
+		activeTextEditor: undefined,
+		onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
+		createTextEditorDecorationType: vi.fn().mockReturnValue({}),
+		tabGroups: {
+			onDidChangeTabs: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+		},
+	},
+	env: {
+		uriScheme: "vscode",
+		language: "en",
+		appName: "Visual Studio Code",
+	},
+	ExtensionMode: {
+		Production: 1,
+		Development: 2,
+		Test: 3,
+	},
+	version: "1.85.0",
+}))
+
+// Mock TTS utils
+vi.mock("../../../utils/tts", () => ({
+	setTtsEnabled: vi.fn(),
+	setTtsSpeed: vi.fn(),
+}))
+
+// Mock API
+vi.mock("../../../api", () => ({
+	buildApiHandler: vi.fn().mockReturnValue({
+		getModel: vi.fn().mockReturnValue({
+			id: "claude-3-sonnet",
+		}),
+	}),
+}))
+
+// Mock system prompt
+vi.mock("../../prompts/system", () => ({
+	SYSTEM_PROMPT: vi.fn().mockResolvedValue("mocked system prompt"),
+	codeMode: "code",
+}))
+
+// Mock WorkspaceTracker - simple mock that works (same pattern as sticky-mode.spec.ts)
+vi.mock("../../../integrations/workspace/WorkspaceTracker", () => ({
+	default: vi.fn().mockImplementation(function () {
+		return {
+			initializeFilePaths: vi.fn(),
+			dispose: vi.fn(),
+		}
+	}),
+}))
+// Mock ContextProxy for viewLocalState tests
+vi.mock("../../config/ContextProxy", () => {
+	const defaultState = {
+		mode: "code",
+		currentApiConfigName: "default",
+		apiConfiguration: {},
+		customModePrompts: {},
+		modeApiConfigs: {},
+		listApiConfigMeta: [],
+		pinnedApiConfigs: {},
+	}
+
+	class MockContextProxy {
+		public globalStorageUri: { fsPath: string }
+		public extensionUri: { fsPath: string }
+		public extensionMode = 1
+
+		constructor(public context: any) {
+			this.globalStorageUri = context?.globalStorageUri ?? { fsPath: "/test/storage/path" }
+			this.extensionUri = context?.extensionUri ?? { fsPath: "/test/path" }
+		}
+
+		getValues = vi.fn().mockImplementation(() => ({
+			...defaultState,
+			mode: this.context?.globalState?.get("mode") ?? defaultState.mode,
+			currentApiConfigName:
+				this.context?.globalState?.get("currentApiConfigName") ?? defaultState.currentApiConfigName,
+			apiConfiguration: this.context?.globalState?.get("apiConfiguration") ?? defaultState.apiConfiguration,
+			customModePrompts: this.context?.globalState?.get("customModePrompts") ?? defaultState.customModePrompts,
+			modeApiConfigs: this.context?.globalState?.get("modeApiConfigs") ?? defaultState.modeApiConfigs,
+			listApiConfigMeta: this.context?.globalState?.get("listApiConfigMeta") ?? defaultState.listApiConfigMeta,
+			pinnedApiConfigs: this.context?.globalState?.get("pinnedApiConfigs") ?? defaultState.pinnedApiConfigs,
+		}))
+		getValue = vi.fn().mockImplementation((key: string) => this.context?.globalState?.get(key))
+		getProviderSettings = vi.fn().mockReturnValue({ apiProvider: "anthropic" })
+		setValue = vi.fn().mockImplementation((key: string, value: any) => {
+			return this.context?.globalState?.update?.(key, value) ?? Promise.resolve()
+		})
+		setValues = vi.fn().mockImplementation((values: Record<string, any>) => {
+			return Promise.all(Object.entries(values).map(([key, value]) => this.setValue(key, value))).then(
+				() => undefined,
+			)
+		})
+		setProviderSettings = vi.fn().mockImplementation((settings: Record<string, any>) => this.setValues(settings))
+	}
+	return { ContextProxy: MockContextProxy }
+})
+
+// Mock Task
+vi.mock("../../task/Task", () => ({
+	Task: vi.fn().mockImplementation(function (options: any) {
+		return {
+			api: undefined,
+			abortTask: vi.fn(),
+			handleWebviewAskResponse: vi.fn(),
+			clineMessages: [],
+			apiConversationHistory: [],
+			overwriteClineMessages: vi.fn(),
+			overwriteApiConversationHistory: vi.fn(),
+			getTaskNumber: vi.fn().mockReturnValue(0),
+			setTaskNumber: vi.fn(),
+			setParentTask: vi.fn(),
+			setRootTask: vi.fn(),
+			taskId: options?.historyItem?.id || "test-task-id",
+			emit: vi.fn(),
+		}
+	}),
+}))
+
+// Mock extract-text
+vi.mock("../../../integrations/misc/extract-text", () => ({
+	extractTextFromFile: vi.fn().mockImplementation(async (_filePath: string) => {
+		const content = "const x = 1;\nconst y = 2;\nconst z = 3;"
+		const lines = content.split("\n")
+		return lines.map((line, index) => `${index + 1} | ${line}`).join("\n")
+	}),
+}))
+
+// Mock model cache
+vi.mock("../../../api/providers/fetchers/modelCache", () => ({
+	getModels: vi.fn().mockResolvedValue({}),
+	flushModels: vi.fn(),
+	getModelsFromCache: vi.fn().mockReturnValue(undefined),
+}))
+
+// Mock cloud service
+vi.mock("@roo-code/cloud", () => ({
+	CloudService: {
+		hasInstance: vi.fn().mockReturnValue(true),
+		get instance() {
+			return {
+				isAuthenticated: vi.fn().mockReturnValue(false),
+				getAllowList: vi.fn().mockResolvedValue([]),
+				getUserInfo: vi.fn().mockReturnValue(null),
+				getOrganizationSettings: vi.fn().mockReturnValue(null),
+				off: vi.fn(),
+			}
+		},
+	},
+	getRooCodeApiUrl: vi.fn().mockReturnValue("https://app.roocode.com"),
+}))
+
+// Mock modes
+vi.mock("../../../shared/modes", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../shared/modes")>()
+	return {
+		...actual,
+		modes: [
+			{
+				slug: "code",
+				name: "Code Mode",
+				roleDefinition: "You are a code assistant",
+				groups: ["read", "edit"],
+			},
+			{
+				slug: "architect",
+				name: "Architect Mode",
+				roleDefinition: "You are an architect",
+				groups: ["read", "edit"],
+			},
+			{
+				slug: "debugger",
+				name: "Debugger Mode",
+				roleDefinition: "You are a debugger",
+				groups: ["read", "edit"],
+			},
+			{
+				slug: "ask",
+				name: "Ask Mode",
+				roleDefinition: "You are a helpful assistant",
+				groups: ["read"],
+			},
+		],
+		getModeBySlug: vi.fn().mockImplementation((slug: string) => {
+			return actual.modes?.find((m) => m.slug === slug) ?? null
+		}),
+		defaultModeSlug: "code",
+	}
+})
+
+// Mock custom instructions
+vi.mock("../../prompts/sections/custom-instructions", () => ({
+	addCustomInstructions: vi.fn().mockResolvedValue("Combined instructions"),
+}))
+
+// Mock zoo-code-auth
+vi.mock("../../../services/zoo-code-auth", () => ({
+	getZooCodeBaseUrl: vi.fn(() => "https://www.zoocode.dev"),
+	getCachedZooCodeToken: vi.fn(),
+	handleAuthCallback: vi.fn(),
+	setZooCodeUserInfo: vi.fn(),
+	disconnectZooCode: vi.fn(),
+}))
+
+// Mock diff strategy
+vi.mock("../diff/strategies/multi-search-replace", () => ({
+	MultiSearchReplaceDiffStrategy: vi.fn().mockImplementation(function () {
+		return {
+			getToolDescription: () => "test",
+			getName: () => "test-strategy",
+			applyDiff: vi.fn(),
+		}
+	}),
+}))
+
+// Mock Terminal
+vi.mock("../../../integrations/terminal/Terminal", () => ({
+	Terminal: {
+		defaultShellIntegrationTimeout: 10000,
+		setShellIntegrationTimeout: vi.fn(),
+		setShellIntegrationDisabled: vi.fn(),
+		setCommandDelay: vi.fn(),
+		setTerminalZshClearEolMark: vi.fn(),
+		setTerminalZshOhMy: vi.fn(),
+		setTerminalZshP10k: vi.fn(),
+		setPowershellCounter: vi.fn(),
+		setTerminalZdotdir: vi.fn(),
+		setTerminalProfile: vi.fn(),
+	},
+}))
+
+// Mock McpHub and McpServerManager
+vi.mock("../../services/mcp/McpHub", () => ({
+	McpHub: vi.fn().mockImplementation(function () {
+		return {
+			registerClient: vi.fn(),
+			unregisterClient: vi.fn(),
+			getAllServers: vi.fn().mockReturnValue([]),
+		}
+	}),
+}))
+
+vi.mock("../../services/mcp/McpServerManager", () => ({
+	McpServerManager: {
+		getInstance: vi.fn().mockResolvedValue({
+			registerClient: vi.fn(),
+			unregisterClient: vi.fn(),
+			getAllServers: vi.fn().mockReturnValue([]),
+		}),
+		unregisterProvider: vi.fn(),
+	},
+}))
+
+// Mock SkillsManager
+vi.mock("../../services/skills/SkillsManager", () => ({
+	SkillsManager: vi.fn().mockImplementation(function () {
+		return {
+			initialize: vi.fn().mockResolvedValue(undefined),
+			dispose: vi.fn(),
+		}
+	}),
+}))
+
+// Mock MarketplaceManager
+vi.mock("../../services/marketplace", () => ({
+	MarketplaceManager: vi.fn().mockImplementation(function () {
+		return {
+			cleanup: vi.fn(),
+		}
+	}),
+}))
+
+// Mock ProviderSettingsManager
+vi.mock("../../config/ProviderSettingsManager", () => ({
+	ProviderSettingsManager: vi.fn().mockImplementation(function () {
+		return {
+			saveConfig: vi.fn().mockResolvedValue("test-id"),
+			listConfig: vi.fn().mockResolvedValue([]),
+			getProfile: vi.fn().mockResolvedValue({}),
+			activateProfile: vi.fn().mockImplementation(async (args: { name?: string; id?: string }) => ({
+				name: args.name ?? "default",
+				id: args.id ?? "test-id",
+				apiProvider: "anthropic",
+			})),
+			setModeConfig: vi.fn().mockResolvedValue(undefined),
+			getModeConfigId: vi.fn().mockResolvedValue(undefined),
+		}
+	}),
+}))
+
+// Mock CustomModesManager
+vi.mock("../../config/CustomModesManager", () => ({
+	CustomModesManager: vi.fn().mockImplementation(function () {
+		return {
+			updateCustomMode: vi.fn().mockResolvedValue(undefined),
+			getCustomModes: vi.fn().mockResolvedValue([]),
+			dispose: vi.fn(),
+		}
+	}),
+}))
+
+// Mock task persistence
+vi.mock("../../task-persistence/taskMessages", () => ({
+	readTaskMessages: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock("../../task-persistence", () => ({
+	readApiMessages: vi.fn().mockResolvedValue([]),
+	saveApiMessages: vi.fn().mockResolvedValue(undefined),
+	saveTaskMessages: vi.fn().mockResolvedValue(undefined),
+	TaskHistoryStore: vi.fn().mockImplementation(function () {
+		return {
+			initialize: vi.fn().mockResolvedValue(undefined),
+			getAll: vi.fn().mockReturnValue([]),
+			get: vi.fn().mockReturnValue(null),
+			set: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+			migrateFromGlobalState: vi.fn().mockResolvedValue(undefined),
+			dispose: vi.fn(),
+		}
+	}),
+	assertValidTransition: vi.fn(),
+}))
+
+// Mock RateLimitClock
+vi.mock("../../task/RateLimitClock", () => ({
+	createRateLimitClock: vi.fn().mockReturnValue({
+		isRateLimited: vi.fn().mockReturnValue(false),
+		resetTimer: vi.fn(),
+	}),
+}))
+
+beforeAll(() => {
+	vi.spyOn(console, "log").mockImplementation(() => {})
+	vi.spyOn(console, "warn").mockImplementation(() => {})
+	vi.spyOn(console, "error").mockImplementation(() => {})
+})
+
+afterAll(() => {
+	vi.restoreAllMocks()
+})
+
+/**
+ * ClineProvider - Parallel Mode Support Tests
+ *
+ * These tests verify that the view-local state isolation feature works correctly,
+ * allowing multiple ClineProvider instances (e.g., in parallel tabs) to maintain
+ * independent mode, API configuration, and other view-specific settings.
+ */
+describe("ClineProvider - Parallel Mode Support", () => {
+	let mockContext: vscode.ExtensionContext
+	let mockOutputChannel: vscode.OutputChannel
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		if (!TelemetryService.hasInstance()) {
+			TelemetryService.createInstance([])
+		}
+
+		const globalState: Record<string, any> = {
+			mode: "code",
+			currentApiConfigName: "default",
+			apiConfiguration: {},
+			customModePrompts: {},
+			modeApiConfigs: {},
+			listApiConfigMeta: [],
+			pinnedApiConfigs: {},
+		}
+
+		const secrets: Record<string, string | undefined> = {}
+
+		mockContext = {
+			extensionPath: "/test/path",
+			extensionUri: { fsPath: "/test/path" } as vscode.Uri,
+			globalState: {
+				get: vi.fn().mockImplementation((key: string) => {
+					return globalState[key]
+				}),
+				update: vi.fn().mockImplementation((key: string, value: any) => {
+					globalState[key] = value
+					return Promise.resolve()
+				}),
+				keys: vi.fn().mockImplementation(() => {
+					return Object.keys(globalState)
+				}),
+			} as any,
+			secrets: {
+				get: vi.fn().mockImplementation((key: string) => {
+					return secrets[key]
+				}),
+				store: vi.fn().mockImplementation((key: string, value: string) => {
+					secrets[key] = value
+					return Promise.resolve()
+				}),
+				delete: vi.fn().mockImplementation((key: string) => {
+					delete secrets[key]
+					return Promise.resolve()
+				}),
+			} as any,
+			workspaceState: {
+				get: vi.fn().mockReturnValue(undefined),
+				update: vi.fn().mockResolvedValue(undefined),
+				keys: vi.fn().mockReturnValue([]),
+			} as any,
+			subscriptions: [],
+			extension: {
+				packageJSON: { version: "1.0.0" },
+			},
+			globalStorageUri: {
+				fsPath: "/test/storage/path",
+			} as vscode.Uri,
+		} as unknown as vscode.ExtensionContext
+
+		mockOutputChannel = {
+			appendLine: vi.fn(),
+			clear: vi.fn(),
+			dispose: vi.fn(),
+		} as unknown as vscode.OutputChannel
+	})
+	describe("viewId uniqueness", () => {
+		it("should assign unique viewId to each instance", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			// Each instance should have a unique viewId
+			expect(provider1.viewId).toBeDefined()
+			expect(provider2.viewId).toBeDefined()
+			expect(provider1.viewId).not.toBe(provider2.viewId)
+
+			await provider1.dispose()
+			await provider2.dispose()
+		})
+
+		it("should have viewId in correct format: {renderContext}-{instanceCount}", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			expect(provider.viewId).toMatch(/^sidebar-\d+$/)
+
+			await provider.dispose()
+		})
+
+		it("should increment instance count for each new instance", async () => {
+			const provider1 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			// First editor instance should be "editor-0" (or next available)
+			// Second editor instance should have a different number
+			const num1 = parseInt(provider1.viewId.split("-")[1]!)
+			const num2 = parseInt(provider2.viewId.split("-")[1]!)
+
+			expect(num2).toBeGreaterThan(num1)
+
+			await provider1.dispose()
+			await provider2.dispose()
+		})
+	})
+
+	describe("local state isolation", () => {
+		it("should isolate mode state between instances", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			// Access viewLocalState via private property for testing
+			const state1 = await provider1.getState()
+			const state2 = await provider2.getState()
+
+			// Both should start with the same default mode from global state
+			expect(state1.mode).toBe("code")
+			expect(state2.mode).toBe("code")
+
+			await provider1.dispose()
+			await provider2.dispose()
+		})
+
+		it("should allow different modes in separate instances after saveViewState", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			// Access private method for testing
+			const saveViewState1 = (provider1 as any).saveViewState.bind(provider1)
+			const saveViewState2 = (provider2 as any).saveViewState.bind(provider2)
+
+			// Save different modes to each provider
+			await saveViewState1("mode", "architect")
+			await saveViewState2("mode", "debugger")
+
+			// Verify isolation - each provider should have its own mode
+			const state1 = await provider1.getState()
+			const state2 = await provider2.getState()
+
+			expect(state1.mode).toBe("architect")
+			expect(state2.mode).toBe("debugger")
+
+			await provider1.dispose()
+			await provider2.dispose()
+		})
+
+		it("should isolate currentApiConfigName between instances", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			const saveViewState1 = (provider1 as any).saveViewState.bind(provider1)
+			const saveViewState2 = (provider2 as any).saveViewState.bind(provider2)
+
+			await saveViewState1("currentApiConfigName", "profile-a")
+			await saveViewState2("currentApiConfigName", "profile-b")
+
+			const state1 = await provider1.getState()
+			const state2 = await provider2.getState()
+
+			expect(state1.currentApiConfigName).toBe("profile-a")
+			expect(state2.currentApiConfigName).toBe("profile-b")
+
+			await provider1.dispose()
+			await provider2.dispose()
+		})
+	})
+
+	describe("saveViewState", () => {
+		it("should update viewLocalState when saveViewState is called", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			const contextProxySpy = vi.spyOn(provider.contextProxy, "setValue")
+			await (provider as any).setViewStateId("stable-sidebar-view")
+
+			await (provider as any).saveViewState("mode", "architect")
+
+			// Verify viewLocalState was updated
+			expect((provider as any).viewLocalState.mode).toBe("architect")
+
+			// saveViewState uses the stable per-view id, not the construction-order viewId suffix.
+			expect(contextProxySpy).toHaveBeenCalledWith("__view_state_stable-sidebar-view_mode", "architect")
+			expect(contextProxySpy).not.toHaveBeenCalledWith(`__view_state_${provider.viewId}_mode`, expect.anything())
+
+			await provider.dispose()
+		})
+
+		it("should update viewLocalState for currentApiConfigName", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("currentApiConfigName", "my-profile")
+
+			expect((provider as any).viewLocalState.currentApiConfigName).toBe("my-profile")
+
+			await provider.dispose()
+		})
+
+		it("should update viewLocalState for apiConfiguration", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			const testApiConfig = {
+				apiProvider: "openrouter" as const,
+				openRouterModelId: "claude-3.5-sonnet",
+			}
+
+			await (provider as any).saveViewState("apiConfiguration", testApiConfig)
+
+			expect((provider as any).viewLocalState.apiConfiguration).toEqual(testApiConfig)
+
+			await provider.dispose()
+		})
+
+		it("should clear local override when saveViewState receives undefined", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("mode", "architect")
+			expect((provider as any).viewLocalState.mode).toBe("architect")
+
+			await (provider as any).saveViewState("mode", undefined)
+
+			expect(Object.prototype.hasOwnProperty.call((provider as any).viewLocalState, "mode")).toBe(false)
+
+			await provider.dispose()
+		})
+
+		it("should clear local override when saveViewState receives null", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("currentApiConfigName", "my-profile")
+			expect((provider as any).viewLocalState.currentApiConfigName).toBe("my-profile")
+
+			await (provider as any).saveViewState("currentApiConfigName", null)
+
+			expect(Object.prototype.hasOwnProperty.call((provider as any).viewLocalState, "currentApiConfigName")).toBe(
+				false,
+			)
+
+			await provider.dispose()
+		})
+	})
+
+	describe("loadViewState", () => {
+		it("should keep viewLocalState empty when no stable per-view values exist", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await vi.waitFor(() => {
+				expect((provider as any).viewLocalState).toEqual({})
+			})
+
+			const state = await provider.getState()
+			expect(state.mode).toBe("code")
+			expect(state.currentApiConfigName).toBe("default")
+
+			await provider.dispose()
+		})
+
+		it("should update viewLocalState when stable per-view values are loaded manually", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const stableViewId = "stable-sidebar-view"
+
+			await provider.contextProxy.setValue(`__view_state_${stableViewId}_mode` as any, "architect")
+			await provider.contextProxy.setValue(
+				`__view_state_${stableViewId}_currentApiConfigName` as any,
+				"new-profile",
+			)
+
+			await (provider as any).setViewStateId(stableViewId)
+
+			const state = await provider.getState()
+			expect(state.mode).toBe("architect")
+			expect(state.currentApiConfigName).toBe("new-profile")
+
+			await provider.dispose()
+		})
+
+		it("should restore mode, current API config name, and API configuration from stable per-view state", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+			const stableViewId = "stable-editor-tab-a"
+			const persistedApiConfiguration = {
+				apiProvider: "openrouter" as const,
+				openRouterModelId: "openrouter/anthropic/claude-sonnet-4",
+			}
+
+			await provider.contextProxy.setValue(`__view_state_${stableViewId}_mode` as any, "architect")
+			await provider.contextProxy.setValue(
+				`__view_state_${stableViewId}_currentApiConfigName` as any,
+				"profile-a",
+			)
+			await provider.contextProxy.setValue(
+				`__view_state_${stableViewId}_apiConfiguration` as any,
+				persistedApiConfiguration,
+			)
+			await provider.contextProxy.setValue("mode" as any, "debugger")
+			await provider.contextProxy.setValue("currentApiConfigName" as any, "profile-b")
+			await provider.contextProxy.setValue("apiConfiguration" as any, { apiProvider: "anthropic" })
+
+			await (provider as any).setViewStateId(stableViewId)
+			const state = await provider.getState()
+
+			expect(state.mode).toBe("architect")
+			expect(state.currentApiConfigName).toBe("profile-a")
+			expect(state.apiConfiguration).toMatchObject(persistedApiConfiguration)
+
+			await provider.dispose()
+		})
+
+		it("should log and keep existing viewLocalState when loadViewState fails", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const logSpy = vi.spyOn(provider as any, "log")
+
+			;(provider as any).viewLocalState = { mode: "architect" }
+			vi.spyOn(provider.contextProxy, "getValue").mockImplementation(() => {
+				throw new Error("load failed")
+			})
+
+			await (provider as any).loadViewState()
+
+			expect((provider as any).viewLocalState.mode).toBe("architect")
+			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Error loading state"))
+
+			await provider.dispose()
+		})
+	})
+
+	describe("getState merging", () => {
+		it("should merge viewLocalState on top of global state", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			// Initially, getState should return values from contextProxy (global state)
+			let state = await provider.getState()
+			expect(state.mode).toBe("code")
+
+			// After saveViewState, viewLocalState should take precedence
+			await (provider as any).saveViewState("mode", "architect")
+
+			state = await provider.getState()
+			expect(state.mode).toBe("architect")
+
+			await provider.dispose()
+		})
+
+		it("should preserve global state values not overridden by viewLocalState", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("mode", "architect")
+
+			const state = await provider.getState()
+
+			// mode should come from viewLocalState
+			expect(state.mode).toBe("architect")
+
+			// Other values should still come from global state / contextProxy
+			expect(state.language).toBeDefined()
+			expect(state.customModes).toBeDefined()
+
+			await provider.dispose()
+		})
+
+		it("should let viewLocalState apiConfiguration override provider settings", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("apiConfiguration", {
+				apiProvider: "openrouter",
+				openRouterApiKey: "local-key",
+			})
+
+			const state = await provider.getState()
+
+			expect(state.apiConfiguration.apiProvider).toBe("openrouter")
+			expect(state.apiConfiguration.openRouterApiKey).toBe("local-key")
+
+			await provider.dispose()
+		})
+
+		it("should update viewLocalState apiConfiguration when setValues receives flat provider settings", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("apiConfiguration", {
+				apiProvider: "openrouter",
+				openRouterModelId: "openrouter/old-model",
+			})
+
+			await provider.setValues({
+				apiProvider: "bedrock",
+				awsUseApiKey: true,
+				awsApiKey: "mock-key",
+				awsRegion: "us-east-1",
+				apiModelId: "anthropic.claude-opus-4-8-20261215-v1:0",
+				awsBedrockEndpoint: "http://127.0.0.1:4567",
+				awsBedrockEndpointEnabled: true,
+			})
+
+			const state = await provider.getState()
+
+			expect(state.apiConfiguration.apiProvider).toBe("bedrock")
+			expect(state.apiConfiguration.awsBedrockEndpoint).toBe("http://127.0.0.1:4567")
+			expect((provider as any).viewLocalState.apiConfiguration.apiProvider).toBe("bedrock")
+
+			await provider.dispose()
+		})
+	})
+
+	describe("_clearViewLocalState", () => {
+		it("should clear all view-local state values", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("mode", "architect")
+			await (provider as any).saveViewState("currentApiConfigName", "my-profile")
+			await (provider as any).saveViewState("apiConfiguration", { apiProvider: "openrouter" })
+
+			expect((provider as any).viewLocalState.mode).toBe("architect")
+			expect((provider as any).viewLocalState.currentApiConfigName).toBe("my-profile")
+			expect((provider as any).viewLocalState.apiConfiguration).toEqual({ apiProvider: "openrouter" })
+
+			// Call _clearViewLocalState
+			;(provider as any)._clearViewLocalState()
+
+			// All values should be cleared
+			expect((provider as any).viewLocalState).toEqual({})
+
+			await provider.dispose()
+		})
+
+		it("should cause getState to fall back to contextProxy values after clear", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).saveViewState("mode", "architect")
+
+			let state = await provider.getState()
+			expect(state.mode).toBe("architect")
+
+			// Clear viewLocalState
+			;(provider as any)._clearViewLocalState()
+
+			// getState should now fall back to contextProxy (global) state
+			state = await provider.getState()
+			expect(state.mode).toBe("code") // Default from mock context
+
+			await provider.dispose()
+		})
+
+		it("should be safe to call on empty viewLocalState", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			// Should not throw even if viewLocalState is already empty
+			expect((provider as any)._clearViewLocalState()).toBeUndefined()
+			expect((provider as any).viewLocalState).toEqual({})
+
+			await provider.dispose()
+		})
+	})
+})

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -616,6 +616,22 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			dispose: vi.fn(),
 		} as unknown as vscode.OutputChannel
 	})
+
+	const createMockWebviewView = (postMessage = vi.fn()) =>
+		({
+			webview: {
+				postMessage,
+				html: "",
+				options: {},
+				onDidReceiveMessage: vi.fn(),
+				asWebviewUri: vi.fn(),
+				cspSource: "vscode-webview://test-csp-source",
+			},
+			visible: true,
+			onDidChangeVisibility: vi.fn(() => ({ dispose: vi.fn() })),
+			onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+		}) as any
+
 	describe("viewId uniqueness", () => {
 		it("should assign unique viewId to each instance", async () => {
 			const provider1 = new ClineProvider(
@@ -1019,6 +1035,155 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			expect((provider as any).viewLocalState.apiConfiguration.apiProvider).toBe("bedrock")
 
 			await provider.dispose()
+		})
+	})
+
+	describe("handleModeSwitch integration", () => {
+		it("should update viewLocalState.mode when handleModeSwitch is called", async () => {
+			const postMessage = vi.fn()
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).resolveWebviewView(createMockWebviewView(postMessage))
+
+			const saveViewStateSpy = vi.spyOn(provider as any, "saveViewState")
+
+			await provider.handleModeSwitch("architect" as any)
+
+			expect((provider as any).viewLocalState.mode).toBe("architect")
+			expect(saveViewStateSpy).toHaveBeenCalledWith("mode", "architect")
+
+			await provider.dispose()
+		})
+
+		it("should post state and skip mode config lookup when API config locking is enabled", async () => {
+			const postMessage = vi.fn()
+			mockContext.workspaceState.get = vi.fn().mockImplementation((key: string, fallback?: unknown) => {
+				return key === "lockApiConfigAcrossModes" ? true : fallback
+			})
+
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const getModeConfigIdSpy = vi.spyOn(provider.providerSettingsManager, "getModeConfigId")
+
+			await (provider as any).resolveWebviewView(createMockWebviewView(postMessage))
+			postMessage.mockClear()
+
+			await provider.handleModeSwitch("architect" as any)
+
+			expect(getModeConfigIdSpy).not.toHaveBeenCalled()
+			expect(postMessage).toHaveBeenCalled()
+
+			await provider.dispose()
+		})
+
+		it("should activate configured mode profile when switching modes", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			vi.spyOn(provider.providerSettingsManager, "getModeConfigId").mockResolvedValueOnce("profile-id")
+			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValueOnce([
+				{ id: "profile-id", name: "mode-profile", apiProvider: "openrouter" },
+			] as any)
+			vi.spyOn(provider.providerSettingsManager, "getProfile").mockResolvedValueOnce({
+				apiProvider: "openrouter",
+			} as any)
+			const activateProviderProfileSpy = vi.spyOn(provider, "activateProviderProfile")
+
+			await provider.handleModeSwitch("architect" as any)
+
+			expect(activateProviderProfileSpy).toHaveBeenCalledWith({ name: "mode-profile" })
+
+			await provider.dispose()
+		})
+
+		it("should leave current configuration unchanged for empty mode profiles", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			vi.spyOn(provider.providerSettingsManager, "getModeConfigId").mockResolvedValueOnce("empty-profile-id")
+			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValueOnce([
+				{ id: "empty-profile-id", name: "empty-profile" },
+			] as any)
+			vi.spyOn(provider.providerSettingsManager, "getProfile").mockResolvedValueOnce({} as any)
+			const activateProviderProfileSpy = vi.spyOn(provider, "activateProviderProfile")
+
+			await provider.handleModeSwitch("architect" as any)
+
+			expect(activateProviderProfileSpy).not.toHaveBeenCalled()
+
+			await provider.dispose()
+		})
+
+		it("should emit ModeChanged event after handleModeSwitch", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const modeChangedSpy = vi.fn()
+
+			provider.on(RooCodeEventName.ModeChanged, modeChangedSpy)
+
+			await provider.handleModeSwitch("architect" as any)
+
+			expect(modeChangedSpy).toHaveBeenCalledWith("architect")
+
+			await provider.dispose()
+		})
+	})
+
+	describe("multi-instance isolation", () => {
+		it("should maintain independent state across three instances", async () => {
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+			const provider3 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			await (provider1 as any).saveViewState("mode", "code")
+			await (provider1 as any).saveViewState("currentApiConfigName", "profile-1")
+			await (provider2 as any).saveViewState("mode", "architect")
+			await (provider2 as any).saveViewState("currentApiConfigName", "profile-2")
+			await (provider3 as any).saveViewState("mode", "debugger")
+			await (provider3 as any).saveViewState("currentApiConfigName", "profile-3")
+
+			const state1 = await provider1.getState()
+			const state2 = await provider2.getState()
+			const state3 = await provider3.getState()
+
+			expect(state1.mode).toBe("code")
+			expect(state1.currentApiConfigName).toBe("profile-1")
+			expect(state2.mode).toBe("architect")
+			expect(state2.currentApiConfigName).toBe("profile-2")
+			expect(state3.mode).toBe("debugger")
+			expect(state3.currentApiConfigName).toBe("profile-3")
+
+			await provider1.dispose()
+			await provider2.dispose()
+			await provider3.dispose()
+		})
+
+		it("should handle mode switch in one instance without affecting others", async () => {
+			const postMessage1 = vi.fn()
+			const postMessage2 = vi.fn()
+			const provider1 = new ClineProvider(
+				mockContext,
+				mockOutputChannel,
+				"sidebar",
+				new ContextProxy(mockContext),
+			)
+			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			await (provider1 as any).resolveWebviewView(createMockWebviewView(postMessage1))
+			await (provider2 as any).resolveWebviewView(createMockWebviewView(postMessage2))
+			await (provider1 as any).saveViewState("mode", "code")
+			await (provider2 as any).saveViewState("mode", "debugger")
+
+			await provider1.handleModeSwitch("architect" as any)
+
+			const state1 = await provider1.getState()
+			const state2 = await provider2.getState()
+
+			expect(state1.mode).toBe("architect")
+			expect(state2.mode).toBe("debugger")
+			expect((provider2 as any).viewLocalState.mode).toBe("debugger")
+
+			await provider1.dispose()
+			await provider2.dispose()
 		})
 	})
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -290,6 +290,10 @@ vi.mock("../../config/ContextProxy", () => {
 			)
 		})
 		setProviderSettings = vi.fn().mockImplementation((settings: Record<string, any>) => this.setValues(settings))
+		resetAllState = vi.fn().mockImplementation(() => {
+			const keys = this.context?.globalState?.keys?.() ?? []
+			return Promise.all(keys.map((key: string) => this.setValue(key, undefined))).then(() => undefined)
+		})
 	}
 	return { ContextProxy: MockContextProxy }
 })
@@ -482,6 +486,7 @@ vi.mock("../../config/ProviderSettingsManager", () => ({
 			})),
 			setModeConfig: vi.fn().mockResolvedValue(undefined),
 			getModeConfigId: vi.fn().mockResolvedValue(undefined),
+			resetAllConfigs: vi.fn().mockResolvedValue(undefined),
 		}
 	}),
 }))
@@ -492,6 +497,7 @@ vi.mock("../../config/CustomModesManager", () => ({
 		return {
 			updateCustomMode: vi.fn().mockResolvedValue(undefined),
 			getCustomModes: vi.fn().mockResolvedValue([]),
+			resetCustomModes: vi.fn().mockResolvedValue(undefined),
 			dispose: vi.fn(),
 		}
 	}),
@@ -1033,6 +1039,106 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			expect(state.apiConfiguration.apiProvider).toBe("bedrock")
 			expect(state.apiConfiguration.awsBedrockEndpoint).toBe("http://127.0.0.1:4567")
 			expect((provider as any).viewLocalState.apiConfiguration.apiProvider).toBe("bedrock")
+
+			await provider.dispose()
+		})
+	})
+
+	describe("profile mutations", () => {
+		it("should synchronize viewLocalState when activateProviderProfile mutates ContextProxy", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			vi.spyOn(provider.providerSettingsManager, "activateProfile").mockResolvedValueOnce({
+				name: "new-profile",
+				id: "new-profile-id",
+				apiProvider: "openrouter",
+				openRouterModelId: "openrouter/new-model",
+			} as any)
+			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValueOnce([
+				{ id: "new-profile-id", name: "new-profile", apiProvider: "openrouter" },
+			] as any)
+			;(provider as any).viewLocalState = {
+				currentApiConfigName: "stale-profile",
+				apiConfiguration: { apiProvider: "anthropic" },
+			}
+
+			await provider.activateProviderProfile({ name: "new-profile" })
+			const state = await provider.getState()
+
+			expect(state.currentApiConfigName).toBe("new-profile")
+			expect(state.apiConfiguration).toMatchObject({
+				apiProvider: "openrouter",
+				openRouterModelId: "openrouter/new-model",
+			})
+
+			await provider.dispose()
+		})
+
+		it("should synchronize viewLocalState when upsertProviderProfile activates a saved profile", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValue([
+				{ id: "test-id", name: "saved-profile", apiProvider: "bedrock" },
+			] as any)
+			;(provider as any).viewLocalState = {
+				currentApiConfigName: "stale-profile",
+				apiConfiguration: { apiProvider: "anthropic" },
+			}
+
+			await provider.upsertProviderProfile("saved-profile", {
+				apiProvider: "bedrock",
+				awsRegion: "us-east-1",
+			} as any)
+			const state = await provider.getState()
+
+			expect(state.currentApiConfigName).toBe("saved-profile")
+			expect(state.apiConfiguration).toMatchObject({
+				apiProvider: "bedrock",
+				awsRegion: "us-east-1",
+			})
+
+			await provider.dispose()
+		})
+
+		it("should synchronize viewLocalState when deleteProviderProfile selects a replacement profile", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			await provider.contextProxy.setValue("currentApiConfigName" as any, "deleted-profile")
+			await provider.contextProxy.setValue("listApiConfigMeta" as any, [
+				{ id: "deleted-id", name: "deleted-profile", apiProvider: "anthropic" },
+				{ id: "replacement-id", name: "replacement-profile", apiProvider: "openrouter" },
+			])
+			;(provider as any).viewLocalState = {
+				currentApiConfigName: "deleted-profile",
+				apiConfiguration: { apiProvider: "anthropic" },
+			}
+
+			await provider.deleteProviderProfile({
+				id: "deleted-id",
+				name: "deleted-profile",
+				apiProvider: "anthropic",
+			} as any)
+			const state = await provider.getState()
+
+			expect(state.currentApiConfigName).toBe("replacement-profile")
+			expect(state.listApiConfigMeta).toEqual([
+				{ id: "replacement-id", name: "replacement-profile", apiProvider: "openrouter" },
+			])
+
+			await provider.dispose()
+		})
+
+		it("should clear viewLocalState when resetState resets ContextProxy", async () => {
+			vi.mocked(vscode.window.showInformationMessage).mockImplementationOnce(
+				async (_message: string, _options: unknown, confirm: unknown) => confirm as any,
+			)
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			;(provider as any).viewLocalState = {
+				mode: "architect",
+				currentApiConfigName: "stale-profile",
+				apiConfiguration: { apiProvider: "openrouter" },
+			}
+
+			await provider.resetState()
+
+			expect((provider as any).viewLocalState).toEqual({})
 
 			await provider.dispose()
 		})

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1220,6 +1220,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			expect(state.currentApiConfigName).toBe("default")
 			expect(state.apiConfiguration).toMatchObject(providerSettings)
 			expect(state.apiConfiguration.apiProvider).toBe("zai")
+			expect(state.apiConfiguration).not.toHaveProperty("openRouterModelId")
 			expect((provider as any).viewLocalState.apiConfiguration).toMatchObject(providerSettings)
 
 			await provider.dispose()

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -198,7 +198,7 @@ vi.mock("vscode", () => ({
 		showErrorMessage: vi.fn(),
 		activeTextEditor: undefined,
 		onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
-		createTextEditorDecorationType: vi.fn().mockReturnValue({}),
+		createTextEditorDecorationType: vi.fn().mockReturnValue({ dispose: vi.fn() }),
 		tabGroups: {
 			onDidChangeTabs: vi.fn().mockReturnValue({ dispose: vi.fn() }),
 		},
@@ -691,13 +691,14 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			)
 			const provider2 = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
 
+			await (provider2 as any).saveViewState("mode", "debugger")
 			await (provider1 as any).saveViewState("mode", "architect")
 
 			const state1 = await provider1.getState()
 			const state2 = await provider2.getState()
 
 			expect(state1.mode).toBe("architect")
-			expect(state2.mode).toBe("code")
+			expect(state2.mode).toBe("debugger")
 
 			await provider1.dispose()
 			await provider2.dispose()
@@ -1064,6 +1065,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			expect(state.apiConfiguration.apiProvider).toBe("bedrock")
 			expect(state.apiConfiguration.awsBedrockEndpoint).toBe("http://127.0.0.1:4567")
 			expect((provider as any).viewLocalState.apiConfiguration.apiProvider).toBe("bedrock")
+			expect((provider as any).viewLocalState.apiConfiguration).not.toHaveProperty("openRouterModelId")
 
 			await provider.dispose()
 		})
@@ -1092,6 +1094,72 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			})
 
 			await provider.dispose()
+		})
+
+		it("should sanitize raw viewStateId before using it as persisted viewStates key", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).setViewStateId("tab panel/with.dots and spaces")
+			await provider.setValue("mode" as any, "architect" as any)
+
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				tab_panel_with_dots_and_spaces: { mode: "architect" },
+			})
+			expect(provider.contextProxy.getValue("viewStates" as any)).not.toHaveProperty(
+				"tab panel/with.dots and spaces",
+			)
+
+			await provider.dispose()
+		})
+
+		it("should persist queued writes under the viewStateId active when the change was made", async () => {
+			let releaseFirstWrite!: () => void
+			const firstWriteStarted = new Promise<void>((resolve) => {
+				mockContext.globalState.update = vi
+					.fn()
+					.mockImplementationOnce((key: string, value: any) => {
+						mockContext.globalState.get = vi
+							.fn()
+							.mockImplementation((lookupKey: string) => (lookupKey === key ? value : undefined))
+						resolve()
+						return new Promise<void>((writeResolve) => {
+							releaseFirstWrite = writeResolve
+						})
+					})
+					.mockImplementation((key: string, value: any) => {
+						mockContext.globalState.get = vi
+							.fn()
+							.mockImplementation((lookupKey: string) => (lookupKey === key ? value : undefined))
+						return Promise.resolve()
+					})
+			})
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+
+			await (provider as any).setViewStateId("view-a")
+			const firstSave = (provider as any).saveViewState("mode", "architect")
+			await firstWriteStarted
+			await (provider as any).setViewStateId("view-b")
+			releaseFirstWrite()
+			await firstSave
+
+			expect(provider.contextProxy.getValue("viewStates" as any)).toMatchObject({
+				"view-a": { mode: "architect" },
+			})
+			expect(provider.contextProxy.getValue("viewStates" as any)).not.toHaveProperty("view-b")
+
+			await provider.dispose()
+		})
+
+		it("should clean up persisted viewStates entry when a tab provider is disposed", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
+
+			await (provider as any).setViewStateId("tab-to-dispose")
+			await (provider as any).saveViewState("mode", "architect")
+			expect(provider.contextProxy.getValue("viewStates" as any)).toHaveProperty("tab-to-dispose")
+
+			await provider.dispose()
+
+			expect(provider.contextProxy.getValue("viewStates" as any)).not.toHaveProperty("tab-to-dispose")
 		})
 	})
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1206,16 +1206,16 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await provider.dispose()
 		})
 
-		it("should clean up persisted viewStates entry when a tab provider is disposed", async () => {
+		it("should preserve persisted viewStates entry when an editor provider is disposed during teardown", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "editor", new ContextProxy(mockContext))
 
-			await (provider as any).setViewStateId("tab-to-dispose")
+			await (provider as any).setViewStateId("tab-to-preserve")
 			await (provider as any).saveViewState("mode", "architect")
-			expect(provider.contextProxy.getValue("viewStates" as any)).toHaveProperty("tab-to-dispose")
+			expect(provider.contextProxy.getValue("viewStates" as any)).toHaveProperty("tab-to-preserve")
 
 			await provider.dispose()
 
-			expect(provider.contextProxy.getValue("viewStates" as any)).not.toHaveProperty("tab-to-dispose")
+			expect(provider.contextProxy.getValue("viewStates" as any)).toHaveProperty("tab-to-preserve")
 		})
 	})
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -1060,6 +1060,44 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await provider.dispose()
 		})
 
+		it("should merge getValues from ContextProxy with view-local values taking precedence", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const providerAccess = provider as unknown as {
+				saveViewState: (key: keyof ExtensionState, value: unknown) => Promise<void>
+			}
+			const contextProxyAccess = provider.contextProxy as unknown as {
+				setValues: (values: Partial<ExtensionState>) => Promise<void>
+			}
+			await contextProxyAccess.setValues({
+				mode: "debugger",
+				currentApiConfigName: "shared-profile",
+				apiConfiguration: {
+					apiProvider: "anthropic",
+					apiKey: "shared-key",
+				},
+				customModePrompts: { code: { roleDefinition: "shared" } },
+			})
+
+			await providerAccess.saveViewState("mode", "architect")
+			await providerAccess.saveViewState("currentApiConfigName", "view-profile")
+			await providerAccess.saveViewState("apiConfiguration", {
+				apiProvider: "openrouter",
+				openRouterApiKey: "view-key",
+			})
+
+			const values = provider.getValues()
+
+			expect(values.mode).toBe("architect")
+			expect(values.currentApiConfigName).toBe("view-profile")
+			expect(values.apiConfiguration).toEqual({
+				apiProvider: "openrouter",
+				openRouterApiKey: "view-key",
+			})
+			expect(values.customModePrompts).toEqual({ code: { roleDefinition: "shared" } })
+
+			await provider.dispose()
+		})
+
 		it("should update viewLocalState apiConfiguration when setValues receives flat provider settings", async () => {
 			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
 

--- a/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.parallelMode.spec.ts
@@ -844,6 +844,24 @@ describe("ClineProvider - Parallel Mode Support", () => {
 
 			await provider.dispose()
 		})
+		it("should not update viewLocalState when durable view-state persistence fails", async () => {
+			const provider = new ClineProvider(mockContext, mockOutputChannel, "sidebar", new ContextProxy(mockContext))
+			const providerAccess = provider as unknown as {
+				setViewStateId: (viewStateId: string) => Promise<void>
+				saveViewState: (key: keyof ExtensionState, value: unknown) => Promise<void>
+				viewLocalState: Partial<ExtensionState>
+			}
+			vi.spyOn(provider.contextProxy, "setValue").mockRejectedValueOnce(new Error("persist failed"))
+
+			await providerAccess.setViewStateId("stable-sidebar-view")
+
+			await expect(providerAccess.saveViewState("mode", "architect")).rejects.toThrow("persist failed")
+			expect(providerAccess.viewLocalState).not.toHaveProperty("mode")
+			expect(provider.contextProxy.getValue("viewStates")).toBeUndefined()
+
+			await provider.dispose()
+		})
+
 		it("should merge concurrent persisted updates from separate provider instances without lost viewStates", async () => {
 			const provider1 = new ClineProvider(
 				mockContext,
@@ -1175,6 +1193,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValueOnce([
 				{ id: "new-profile-id", name: "new-profile", apiProvider: "openrouter" },
 			] as any)
+			const saveViewStateSpy = vi.spyOn(provider as any, "saveViewState")
 			;(provider as any).viewLocalState = {
 				currentApiConfigName: "stale-profile",
 				apiConfiguration: { apiProvider: "anthropic" },
@@ -1183,6 +1202,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			await provider.activateProviderProfile({ name: "new-profile" })
 			const state = await provider.getState()
 
+			expect(saveViewStateSpy).not.toHaveBeenCalled()
 			expect(state.currentApiConfigName).toBe("new-profile")
 			expect(state.apiConfiguration).toMatchObject({
 				apiProvider: "openrouter",
@@ -1197,6 +1217,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			vi.spyOn(provider.providerSettingsManager, "listConfig").mockResolvedValue([
 				{ id: "test-id", name: "saved-profile", apiProvider: "bedrock" },
 			] as any)
+			const saveViewStateSpy = vi.spyOn(provider as any, "saveViewState")
 			;(provider as any).viewLocalState = {
 				currentApiConfigName: "stale-profile",
 				apiConfiguration: { apiProvider: "anthropic" },
@@ -1208,6 +1229,7 @@ describe("ClineProvider - Parallel Mode Support", () => {
 			} as any)
 			const state = await provider.getState()
 
+			expect(saveViewStateSpy).not.toHaveBeenCalled()
 			expect(state.currentApiConfigName).toBe("saved-profile")
 			expect(state.apiConfiguration).toMatchObject({
 				apiProvider: "bedrock",

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -578,7 +578,7 @@ describe("ClineProvider", () => {
 	})
 
 	test("does not reload full model details when the LM Studio model is already loaded", async () => {
-		vi.mocked(hasLoadedFullDetails).mockReturnValue(true)
+		vi.mocked(hasLoadedFullDetails).mockReturnValueOnce(true)
 
 		await provider.performPreparationTasks({
 			apiConfiguration: {

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -1814,8 +1814,13 @@ describe("ClineProvider", () => {
 			// Switch to architect mode
 			await provider.handleModeSwitch("architect")
 
-			// Verify mode was updated
-			expect(mockContext.globalState.update).toHaveBeenCalledWith("mode", "architect")
+			// Verify mode was updated in durable per-view state
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					[provider.viewId]: expect.objectContaining({ mode: "architect" }),
+				}),
+			)
 
 			// Verify saved config was loaded
 			expect(provider.providerSettingsManager.getModeConfigId).toHaveBeenCalledWith("architect")
@@ -1846,8 +1851,13 @@ describe("ClineProvider", () => {
 			// Switch to architect mode
 			await provider.handleModeSwitch("architect")
 
-			// Verify mode was updated
-			expect(mockContext.globalState.update).toHaveBeenCalledWith("mode", "architect")
+			// Verify mode was updated in durable per-view state
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					[provider.viewId]: expect.objectContaining({ mode: "architect" }),
+				}),
+			)
 
 			// Verify current config was saved as default for new mode
 			expect(provider.providerSettingsManager.setModeConfig).toHaveBeenCalledWith("architect", "current-id")

--- a/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.sticky-mode.spec.ts
@@ -350,8 +350,13 @@ describe("ClineProvider - Sticky Mode", () => {
 			// Switch mode
 			await provider.handleModeSwitch("architect")
 
-			// Verify mode was updated in global state
-			expect(mockContext.globalState.update).toHaveBeenCalledWith("mode", "architect")
+			// Verify mode was updated in durable per-view state
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					[provider.viewId]: expect.objectContaining({ mode: "architect" }),
+				}),
+			)
 
 			// Verify task history was updated with new mode
 			expect(updateTaskHistorySpy).toHaveBeenCalledWith(
@@ -682,8 +687,13 @@ describe("ClineProvider - Sticky Mode", () => {
 			// Switch mode - should not throw
 			await expect(provider.handleModeSwitch("architect")).resolves.not.toThrow()
 
-			// Verify mode was still updated in global state
-			expect(mockContext.globalState.update).toHaveBeenCalledWith("mode", "architect")
+			// Verify mode was still updated in durable per-view state
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					[provider.viewId]: expect.objectContaining({ mode: "architect" }),
+				}),
+			)
 		})
 
 		it("should handle null/undefined mode gracefully", async () => {
@@ -859,12 +869,16 @@ describe("ClineProvider - Sticky Mode", () => {
 
 			await Promise.all(switches)
 
-			// Find the last mode update call
-			const modeCalls = vi.mocked(mockContext.globalState.update).mock.calls.filter((call) => call[0] === "mode")
-			const lastModeCall = modeCalls[modeCalls.length - 1]
+			// Find the last durable view state update call
+			const viewStateCalls = vi
+				.mocked(mockContext.globalState.update)
+				.mock.calls.filter((call) => call[0] === "viewStates")
+			const lastViewStateCall = viewStateCalls[viewStateCalls.length - 1]
 
 			// Verify the last mode switch wins
-			expect(lastModeCall).toEqual(["mode", "code"])
+			expect(lastViewStateCall?.[1]).toMatchObject({
+				[provider.viewId]: { mode: "code" },
+			})
 
 			// Verify task history was updated with final mode
 			const lastCall = updateTaskHistorySpy.mock.calls[updateTaskHistorySpy.mock.calls.length - 1]
@@ -955,7 +969,12 @@ describe("ClineProvider - Sticky Mode", () => {
 			await provider.handleModeSwitch("invalid-mode" as any)
 
 			// The mode WILL be updated to invalid-mode (this is the actual behavior)
-			expect(mockContext.globalState.update).toHaveBeenCalledWith("mode", "invalid-mode")
+			expect(mockContext.globalState.update).toHaveBeenCalledWith(
+				"viewStates",
+				expect.objectContaining({
+					[provider.viewId]: expect.objectContaining({ mode: "invalid-mode" }),
+				}),
+			)
 		})
 
 		it("should handle errors during mode switch gracefully", async () => {

--- a/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { webviewMessageHandler } from "../webviewMessageHandler"
+import type { WebviewMessage } from "@roo-code/types"
+
 import type { ClineProvider } from "../ClineProvider"
 
 // Mock vscode (minimal)
@@ -37,9 +39,15 @@ vi.mock("vscode", () => ({
 // Mock modelCache getModels/flushModels used by the handler
 const getModelsMock = vi.fn()
 const flushModelsMock = vi.fn()
+const kimiCodeGetAccessTokenMock = vi.fn()
 vi.mock("../../../api/providers/fetchers/modelCache", () => ({
 	getModels: (...args: any[]) => getModelsMock(...args),
 	flushModels: (...args: any[]) => flushModelsMock(...args),
+}))
+vi.mock("../../../integrations/kimi-code/oauth", () => ({
+	kimiCodeOAuthManager: {
+		getAccessToken: (...args: unknown[]) => kimiCodeGetAccessTokenMock(...args),
+	},
 }))
 
 describe("webviewMessageHandler - requestRouterModels provider filter", () => {
@@ -293,6 +301,31 @@ describe("webviewMessageHandler - requestRouterModels provider filter", () => {
 			provider: "litellm",
 			apiKey: "stored-api-key",
 			baseUrl: "http://stored:4000",
+		})
+	})
+
+	it("continues posting routerModels when Kimi Code OAuth lookup fails", async () => {
+		mockProvider.getState.mockResolvedValue({
+			apiConfiguration: {
+				kimiCodeAuthMethod: "oauth",
+			},
+		})
+		kimiCodeGetAccessTokenMock.mockRejectedValueOnce(new Error("refresh failed"))
+
+		await webviewMessageHandler(mockProvider, {
+			type: "requestRouterModels",
+			values: { provider: "kimi-code" },
+		} satisfies WebviewMessage)
+
+		expect(kimiCodeGetAccessTokenMock).toHaveBeenCalledOnce()
+		expect(mockProvider.log).toHaveBeenCalledWith(
+			"[requestRouterModels] kimi-code credential lookup failed: refresh failed",
+		)
+		expect(getModelsMock).not.toHaveBeenCalledWith(expect.objectContaining({ provider: "kimi-code" }))
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "routerModels",
+			routerModels: {},
+			values: { provider: "kimi-code" },
 		})
 	})
 

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -234,6 +234,7 @@ describe("webviewMessageHandler - webviewDidLaunch", () => {
 		await webviewMessageHandler(mockClineProvider, { type: "webviewDidLaunch", viewStateId: "view-1" })
 		await new Promise((resolve) => setImmediate(resolve))
 
+		expect((mockClineProvider as any).setViewStateId).toHaveBeenCalledWith("view-1")
 		expect((mockClineProvider as any).providerSettingsManager.hasConfig).toHaveBeenCalledWith("view-local-profile")
 		expect((mockClineProvider as any).providerSettingsManager.hasConfig).not.toHaveBeenCalledWith("shared-profile")
 	})

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -11,6 +11,17 @@ vi.mock("../../../api/providers/fetchers/lmstudio", () => ({
 	getLMStudioModels: vi.fn(),
 }))
 
+vi.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			updateTelemetryState: vi.fn(),
+			captureCustomModeCreated: vi.fn(),
+			captureModeSettingChanged: vi.fn(),
+		},
+		hasInstance: vi.fn(() => false),
+	},
+}))
+
 vi.mock("../../../integrations/openai-codex/oauth", () => ({
 	openAiCodexOAuthManager: {
 		getAccessToken: vi.fn(),
@@ -82,6 +93,7 @@ const mockClineProvider = {
 	postMessageToWebview: vi.fn(),
 	customModesManager: {
 		getCustomModes: vi.fn(),
+		updateCustomMode: vi.fn(),
 		deleteCustomMode: vi.fn(),
 	},
 	context: {
@@ -102,6 +114,7 @@ const mockClineProvider = {
 	getTaskWithId: vi.fn(),
 	createTaskWithHistoryItem: vi.fn(),
 	getSkillsManager: vi.fn(),
+	handleModeSwitch: vi.fn(),
 	cwd: "/mock/workspace",
 } as unknown as ClineProvider
 
@@ -177,6 +190,7 @@ import { getWorkspacePath } from "../../../utils/path"
 import { ensureSettingsDirectoryExists } from "../../../utils/globalContext"
 import { generateErrorDiagnostics } from "../diagnosticsHandler"
 import type { ModeConfig } from "@roo-code/types"
+import { defaultModeSlug } from "../../../shared/modes"
 
 vi.mock("../../../utils/fs")
 vi.mock("../../../utils/path")
@@ -192,6 +206,38 @@ vi.mock("../../mentions/resolveImageMentions", () => ({
 import { resolveImageMentions } from "../../mentions/resolveImageMentions"
 import { Terminal } from "../../../integrations/terminal/Terminal"
 import { TerminalRegistry } from "../../../integrations/terminal/TerminalRegistry"
+
+describe("webviewMessageHandler - webviewDidLaunch", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(mockClineProvider.getState).mockResolvedValue({
+			apiConfiguration: { apiProvider: "anthropic" },
+			currentApiConfigName: "view-local-profile",
+		} as any)
+		;(mockClineProvider as any).setViewStateId = vi.fn().mockResolvedValue(undefined)
+		;(mockClineProvider as any).workspaceTracker = { initializeFilePaths: vi.fn() }
+		;(mockClineProvider as any).providerSettingsManager = {
+			listConfig: vi.fn().mockResolvedValue([{ name: "shared-profile", apiProvider: "anthropic" }]),
+			hasConfig: vi.fn().mockResolvedValue(false),
+		}
+		;(mockClineProvider as any).activateProviderProfile = vi.fn().mockResolvedValue(undefined)
+		;(mockClineProvider as any).getMcpHub = vi.fn().mockReturnValue(undefined)
+		;(mockClineProvider as any).getStateToPostToWebview = vi
+			.fn()
+			.mockResolvedValue({ telemetrySetting: "disabled" })
+		vi.mocked(mockClineProvider.customModesManager.getCustomModes).mockResolvedValue([])
+		vi.mocked(mockClineProvider.contextProxy.getValue).mockReturnValue("shared-profile")
+		vi.mocked(mockClineProvider.contextProxy.setValue).mockResolvedValue(undefined)
+	})
+
+	it("validates the view-local currentApiConfigName on launch", async () => {
+		await webviewMessageHandler(mockClineProvider, { type: "webviewDidLaunch", viewStateId: "view-1" })
+		await new Promise((resolve) => setImmediate(resolve))
+
+		expect((mockClineProvider as any).providerSettingsManager.hasConfig).toHaveBeenCalledWith("view-local-profile")
+		expect((mockClineProvider as any).providerSettingsManager.hasConfig).not.toHaveBeenCalledWith("shared-profile")
+	})
+})
 
 describe("webviewMessageHandler - requestLmStudioModels", () => {
 	beforeEach(() => {

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -215,7 +215,7 @@ describe("webviewMessageHandler - webviewDidLaunch", () => {
 			currentApiConfigName: "view-local-profile",
 		} as any)
 		;(mockClineProvider as any).setViewStateId = vi.fn().mockResolvedValue(undefined)
-		;(mockClineProvider as any).workspaceTracker = { initializeFilePaths: vi.fn() }
+		;(mockClineProvider as any).workspaceTracker = { initializeFilePaths: vi.fn().mockResolvedValue(undefined) }
 		;(mockClineProvider as any).providerSettingsManager = {
 			listConfig: vi.fn().mockResolvedValue([{ name: "shared-profile", apiProvider: "anthropic" }]),
 			hasConfig: vi.fn().mockResolvedValue(false),

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -558,7 +558,7 @@ export const webviewMessageHandler = async (
 	}
 
 	switch (message.type) {
-		case "webviewDidLaunch":
+		case "webviewDidLaunch": {
 			await provider.setViewStateId(message.viewStateId)
 
 			// Load custom modes first
@@ -645,6 +645,7 @@ export const webviewMessageHandler = async (
 
 			provider.isViewLaunched = true
 			break
+		}
 		case "newTask":
 			// Initializing new instance of Cline will make sure that any
 			// agentically running promises in old instance don't affect our new
@@ -1205,18 +1206,24 @@ export const webviewMessageHandler = async (
 			})
 
 			if (!providerFilter || providerFilter === "kimi-code") {
-				const { kimiCodeOAuthManager } = await import("../../integrations/kimi-code/oauth")
-				const kimiCodeAuthMethod =
-					message?.values?.kimiCodeAuthMethod ?? apiConfiguration.kimiCodeAuthMethod ?? "oauth"
-				const kimiCodeApiKey =
-					kimiCodeAuthMethod === "api-key"
-						? (message?.values?.kimiCodeApiKey ?? apiConfiguration.kimiCodeApiKey)
-						: await kimiCodeOAuthManager.getAccessToken()
-				if (kimiCodeApiKey) {
-					candidates.push({
-						key: "kimi-code",
-						options: { provider: "kimi-code", apiKey: kimiCodeApiKey },
-					})
+				try {
+					const { kimiCodeOAuthManager } = await import("../../integrations/kimi-code/oauth")
+					const kimiCodeAuthMethod =
+						message?.values?.kimiCodeAuthMethod ?? apiConfiguration.kimiCodeAuthMethod ?? "oauth"
+					const kimiCodeApiKey =
+						kimiCodeAuthMethod === "api-key"
+							? (message?.values?.kimiCodeApiKey ?? apiConfiguration.kimiCodeApiKey)
+							: await kimiCodeOAuthManager.getAccessToken()
+					if (kimiCodeApiKey) {
+						candidates.push({
+							key: "kimi-code",
+							options: { provider: "kimi-code", apiKey: kimiCodeApiKey },
+						})
+					}
+				} catch (error) {
+					provider.log(
+						`[requestRouterModels] kimi-code credential lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+					)
 				}
 			}
 
@@ -1368,11 +1375,12 @@ export const webviewMessageHandler = async (
 			}
 
 			break
-		case "requestVsCodeLmModels":
+		case "requestVsCodeLmModels": {
 			const vsCodeLmModels = await getVsCodeLmModels()
 			// TODO: Cache like we do for OpenRouter, etc?
 			await provider.postMessageToWebview({ type: "vsCodeLmModels", vsCodeLmModels })
 			break
+		}
 		case "openImage":
 			await openImage(message.text!, { values: message.values })
 			break

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -559,6 +559,8 @@ export const webviewMessageHandler = async (
 
 	switch (message.type) {
 		case "webviewDidLaunch":
+			await provider.setViewStateId(message.viewStateId)
+
 			// Load custom modes first
 			const customModes = await provider.customModesManager.getCustomModes()
 			await updateGlobalState("customModes", customModes)
@@ -607,7 +609,8 @@ export const webviewMessageHandler = async (
 						}
 					}
 
-					const currentConfigName = getGlobalState("currentApiConfigName")
+					const currentState = await provider.getState()
+					const currentConfigName = currentState.currentApiConfigName
 
 					if (currentConfigName) {
 						if (!(await provider.providerSettingsManager.hasConfig(currentConfigName))) {

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1061,12 +1061,17 @@
 	},
 	"core/webview/ClineProvider.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 12
+			"count": 16
 		}
 	},
 	"core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
 			"count": 34
+		}
+	},
+	"core/webview/__tests__/ClineProvider.parallelMode.spec.ts": {
+		"@typescript-eslint/no-explicit-any": {
+			"count": 141
 		}
 	},
 	"core/webview/__tests__/ClineProvider.spec.ts": {
@@ -1156,7 +1161,7 @@
 	},
 	"core/webview/__tests__/webviewMessageHandler.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 35
+			"count": 45
 		}
 	},
 	"core/webview/messageEnhancer.ts": {
@@ -1177,6 +1182,11 @@
 	"extension/__tests__/api-delete-queued-message.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
 			"count": 1
+		}
+	},
+	"extension/__tests__/api-set-configuration.spec.ts": {
+		"@typescript-eslint/no-explicit-any": {
+			"count": 2
 		}
 	},
 	"extension/__tests__/api-send-message.spec.ts": {

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1071,7 +1071,7 @@
 	},
 	"core/webview/__tests__/ClineProvider.parallelMode.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 141
+			"count": 143
 		}
 	},
 	"core/webview/__tests__/ClineProvider.spec.ts": {

--- a/src/extension/__tests__/api-set-configuration.spec.ts
+++ b/src/extension/__tests__/api-set-configuration.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { API } from "../api"
+
+vi.mock("@roo-code/ipc", () => ({
+	IpcServer: class {},
+}))
+
+vi.mock("../../integrations/terminal/Terminal", () => ({
+	Terminal: {
+		getTerminalProfile: vi.fn(),
+		setTerminalProfile: vi.fn(),
+	},
+}))
+
+vi.mock("../../integrations/terminal/TerminalRegistry", () => ({
+	TerminalRegistry: {
+		closeIdleTerminals: vi.fn(),
+	},
+}))
+
+describe("API.setConfiguration", () => {
+	it("routes configuration through ClineProvider.setValues so view-local state stays in sync", async () => {
+		const provider = {
+			context: {},
+			on: vi.fn(),
+			setValues: vi.fn().mockResolvedValue(undefined),
+			contextProxy: {
+				setValues: vi.fn().mockResolvedValue(undefined),
+			},
+			providerSettingsManager: {
+				saveConfig: vi.fn().mockResolvedValue("default-id"),
+			},
+			postStateToWebview: vi.fn().mockResolvedValue(undefined),
+		} as any
+		const api = new API({ appendLine: vi.fn() } as any, provider)
+		const configuration = {
+			apiProvider: "bedrock" as const,
+			currentApiConfigName: "default",
+			awsRegion: "us-east-1",
+			apiModelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+		}
+
+		await api.setConfiguration(configuration)
+
+		expect(provider.setValues).toHaveBeenCalledWith(configuration)
+		expect(provider.contextProxy.setValues).not.toHaveBeenCalled()
+		expect(provider.providerSettingsManager.saveConfig).toHaveBeenCalledWith("default", configuration)
+		expect(provider.postStateToWebview).toHaveBeenCalled()
+	})
+})

--- a/src/extension/__tests__/api-task-control.spec.ts
+++ b/src/extension/__tests__/api-task-control.spec.ts
@@ -170,7 +170,7 @@ describe("API task controls", () => {
 			expect(task.approveAsk).toHaveBeenCalledOnce()
 		})
 
-		it("removes completed and aborted tasks from the registry", async () => {
+		it("removes completed, aborted, and unfocused tasks from the registry", async () => {
 			const completedTask = createTask("completed-task")
 			sidebarProvider.emit(RooCodeEventName.TaskCreated, completedTask)
 			completedTask.emit(RooCodeEventName.TaskCompleted, completedTask.taskId, {}, {})
@@ -182,6 +182,12 @@ describe("API task controls", () => {
 			abortedTask.emit(RooCodeEventName.TaskAborted)
 
 			await expect(api.approveTaskAsk(abortedTask.taskId)).resolves.toBe(false)
+
+			const unfocusedTask = createTask("unfocused-task")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, unfocusedTask)
+			unfocusedTask.emit(RooCodeEventName.TaskUnfocused)
+
+			await expect(api.approveTaskAsk(unfocusedTask.taskId)).resolves.toBe(false)
 		})
 	})
 
@@ -218,8 +224,9 @@ describe("API task controls", () => {
 			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Use architect")
 		})
 
-		it("responds without switching modes when the requested mode is invalid", async () => {
+		it("responds without switching modes and logs when the requested mode is invalid", async () => {
 			const task = createTask("task-invalid-mode")
+			api = new API(outputChannel, asClineProvider(sidebarProvider), undefined, true)
 			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
 
 			await expect(
@@ -229,6 +236,9 @@ describe("API task controls", () => {
 			expect(sidebarProvider.getState).toHaveBeenCalledOnce()
 			expect(sidebarProvider.handleModeSwitch).not.toHaveBeenCalled()
 			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Use invalid")
+			expect(outputChannel.appendLine).toHaveBeenCalledWith(
+				'[API#selectTaskFollowupSuggestion] ignoring unknown mode "not-a-mode" for task task-invalid-mode',
+			)
 		})
 
 		it("treats custom modes from the task provider state as valid", async () => {

--- a/src/extension/__tests__/api-task-control.spec.ts
+++ b/src/extension/__tests__/api-task-control.spec.ts
@@ -1,0 +1,253 @@
+import { EventEmitter } from "events"
+
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest"
+import * as vscode from "vscode"
+
+import { RooCodeEventName, type ModeConfig, type RooCodeSettings } from "@roo-code/types"
+
+import { API } from "../api"
+import { ClineProvider } from "../../core/webview/ClineProvider"
+
+const { openClineInNewTabMock } = vi.hoisted(() => ({
+	openClineInNewTabMock: vi.fn(),
+}))
+
+vi.mock("vscode", () => ({
+	commands: {
+		executeCommand: vi.fn().mockResolvedValue(undefined),
+	},
+}))
+
+vi.mock("@roo-code/ipc", () => ({
+	IpcServer: class {},
+}))
+
+vi.mock("../../activate/registerCommands", () => ({
+	openClineInNewTab: openClineInNewTabMock,
+}))
+
+vi.mock("../../integrations/terminal/Terminal", () => ({
+	Terminal: {
+		getTerminalProfile: vi.fn(),
+		setTerminalProfile: vi.fn(),
+	},
+}))
+
+vi.mock("../../integrations/terminal/TerminalRegistry", () => ({
+	TerminalRegistry: {
+		closeIdleTerminals: vi.fn(),
+	},
+}))
+
+type CreatedTask = {
+	taskId: string
+}
+
+type ProviderDouble = EventEmitter & {
+	context: vscode.ExtensionContext
+	evictCurrentTask: Mock<() => Promise<void>>
+	postStateToWebview: Mock<() => Promise<void>>
+	postMessageToWebview: Mock<(message: unknown) => Promise<void>>
+	createTask: Mock<(...args: unknown[]) => Promise<CreatedTask>>
+	getCurrentTaskStack: Mock<() => string[]>
+	getCurrentTask: Mock<() => undefined>
+	getState: Mock<() => Promise<{ customModes?: ModeConfig[] }>>
+	handleModeSwitch: Mock<(mode: string) => Promise<void>>
+	viewLaunched: boolean
+}
+
+type TaskDouble = EventEmitter & {
+	taskId: string
+	parentTaskId?: string
+	approveAsk: Mock<() => void>
+	handleWebviewAskResponse: Mock<(response: "messageResponse", text?: string, images?: string[]) => void>
+}
+
+const configuration: RooCodeSettings = {}
+
+function asClineProvider(provider: ProviderDouble): ClineProvider {
+	// ClineProvider has private members, so a structural test double requires an unknown bridge.
+	return provider as unknown as ClineProvider
+}
+
+function createProvider(taskId = "task-1"): ProviderDouble {
+	const provider = new EventEmitter() as ProviderDouble
+	provider.context = {} as vscode.ExtensionContext
+	provider.evictCurrentTask = vi.fn().mockResolvedValue(undefined)
+	provider.postStateToWebview = vi.fn().mockResolvedValue(undefined)
+	provider.postMessageToWebview = vi.fn().mockResolvedValue(undefined)
+	provider.createTask = vi.fn().mockResolvedValue({ taskId })
+	provider.getCurrentTaskStack = vi.fn().mockReturnValue([])
+	provider.getCurrentTask = vi.fn().mockReturnValue(undefined)
+	provider.getState = vi.fn().mockResolvedValue({ customModes: [] })
+	provider.handleModeSwitch = vi.fn().mockResolvedValue(undefined)
+	provider.viewLaunched = true
+	return provider
+}
+
+function createTask(taskId: string): TaskDouble {
+	const task = new EventEmitter() as TaskDouble
+	task.taskId = taskId
+	task.approveAsk = vi.fn()
+	task.handleWebviewAskResponse = vi.fn()
+	return task
+}
+
+describe("API task controls", () => {
+	let outputChannel: vscode.OutputChannel
+	let sidebarProvider: ProviderDouble
+	let api: API
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		outputChannel = { appendLine: vi.fn() } as unknown as vscode.OutputChannel
+		sidebarProvider = createProvider("sidebar-task")
+		api = new API(outputChannel, asClineProvider(sidebarProvider))
+	})
+
+	describe("startNewTask", () => {
+		it("reverts and closes existing editors before opening a new tab unless preserveOpenTabs is true", async () => {
+			const newTabProvider = createProvider("new-tab-task")
+			openClineInNewTabMock.mockResolvedValue(newTabProvider)
+
+			const taskId = await api.startNewTask({ configuration, text: "new task", newTab: true })
+
+			expect(taskId).toBe("new-tab-task")
+			expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(1, "workbench.action.files.revert")
+			expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(2, "workbench.action.closeAllEditors")
+			expect(openClineInNewTabMock).toHaveBeenCalledWith({
+				context: sidebarProvider.context,
+				outputChannel,
+			})
+			expect(newTabProvider.evictCurrentTask).toHaveBeenCalledOnce()
+			expect(newTabProvider.createTask).toHaveBeenCalledWith(
+				"new task",
+				undefined,
+				undefined,
+				{ consecutiveMistakeLimit: Number.MAX_SAFE_INTEGER },
+				configuration,
+			)
+		})
+
+		it("opens a new tab without revert or close commands when preserveOpenTabs is true", async () => {
+			const newTabProvider = createProvider("preserved-tab-task")
+			openClineInNewTabMock.mockResolvedValue(newTabProvider)
+
+			const taskId = await api.startNewTask({
+				configuration,
+				text: "keep editors",
+				newTab: true,
+				preserveOpenTabs: true,
+			})
+
+			expect(taskId).toBe("preserved-tab-task")
+			expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+			expect(openClineInNewTabMock).toHaveBeenCalledWith({
+				context: sidebarProvider.context,
+				outputChannel,
+			})
+			expect(newTabProvider.createTask).toHaveBeenCalledWith(
+				"keep editors",
+				undefined,
+				undefined,
+				{ consecutiveMistakeLimit: Number.MAX_SAFE_INTEGER },
+				configuration,
+			)
+		})
+	})
+
+	describe("task ask registry", () => {
+		it("returns false when approving an unknown task", async () => {
+			await expect(api.approveTaskAsk("missing-task")).resolves.toBe(false)
+		})
+
+		it("registers tasks on TaskCreated and approves a task by id", async () => {
+			const task = createTask("task-to-approve")
+
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
+
+			await expect(api.approveTaskAsk(task.taskId)).resolves.toBe(true)
+			expect(task.approveAsk).toHaveBeenCalledOnce()
+		})
+
+		it("removes completed and aborted tasks from the registry", async () => {
+			const completedTask = createTask("completed-task")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, completedTask)
+			completedTask.emit(RooCodeEventName.TaskCompleted, completedTask.taskId, {}, {})
+
+			await expect(api.approveTaskAsk(completedTask.taskId)).resolves.toBe(false)
+
+			const abortedTask = createTask("aborted-task")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, abortedTask)
+			abortedTask.emit(RooCodeEventName.TaskAborted)
+
+			await expect(api.approveTaskAsk(abortedTask.taskId)).resolves.toBe(false)
+		})
+	})
+
+	describe("selectTaskFollowupSuggestion", () => {
+		it("returns false when the task is unknown", async () => {
+			await expect(
+				api.selectTaskFollowupSuggestion({ taskId: "missing-task", answer: "Use this" }),
+			).resolves.toBe(false)
+		})
+
+		it("responds to the task without switching modes when no mode is provided", async () => {
+			const task = createTask("task-without-mode")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
+
+			await expect(api.selectTaskFollowupSuggestion({ taskId: task.taskId, answer: "Continue" })).resolves.toBe(
+				true,
+			)
+
+			expect(sidebarProvider.getState).not.toHaveBeenCalled()
+			expect(sidebarProvider.handleModeSwitch).not.toHaveBeenCalled()
+			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Continue")
+		})
+
+		it("switches to a valid built-in mode before responding", async () => {
+			const task = createTask("task-built-in-mode")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
+
+			await expect(
+				api.selectTaskFollowupSuggestion({ taskId: task.taskId, answer: "Use architect", mode: "architect" }),
+			).resolves.toBe(true)
+
+			expect(sidebarProvider.getState).toHaveBeenCalledOnce()
+			expect(sidebarProvider.handleModeSwitch).toHaveBeenCalledWith("architect")
+			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Use architect")
+		})
+
+		it("responds without switching modes when the requested mode is invalid", async () => {
+			const task = createTask("task-invalid-mode")
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
+
+			await expect(
+				api.selectTaskFollowupSuggestion({ taskId: task.taskId, answer: "Use invalid", mode: "not-a-mode" }),
+			).resolves.toBe(true)
+
+			expect(sidebarProvider.getState).toHaveBeenCalledOnce()
+			expect(sidebarProvider.handleModeSwitch).not.toHaveBeenCalled()
+			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Use invalid")
+		})
+
+		it("treats custom modes from the task provider state as valid", async () => {
+			const task = createTask("task-custom-mode")
+			const customMode: ModeConfig = {
+				slug: "custom-review",
+				name: "Custom Review",
+				roleDefinition: "Review the implementation",
+				groups: ["read"],
+			}
+			sidebarProvider.getState.mockResolvedValue({ customModes: [customMode] })
+			sidebarProvider.emit(RooCodeEventName.TaskCreated, task)
+
+			await expect(
+				api.selectTaskFollowupSuggestion({ taskId: task.taskId, answer: "Review it", mode: customMode.slug }),
+			).resolves.toBe(true)
+
+			expect(sidebarProvider.handleModeSwitch).toHaveBeenCalledWith(customMode.slug)
+			expect(task.handleWebviewAskResponse).toHaveBeenCalledWith("messageResponse", "Review it")
+		})
+	})
+})

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -503,7 +503,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	}
 
 	public async setConfiguration(values: RooCodeSettings) {
-		await this.sidebarProvider.contextProxy.setValues(values)
+		await this.sidebarProvider.setValues(values)
 		await this.sidebarProvider.providerSettingsManager.saveConfig(values.currentApiConfigName || "default", values)
 		await this.sidebarProvider.postStateToWebview()
 	}

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -358,6 +358,8 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 			if (isValidMode) {
 				await entry.provider.handleModeSwitch(mode)
+			} else {
+				this.log(`[API#selectTaskFollowupSuggestion] ignoring unknown mode "${mode}" for task ${taskId}`)
 			}
 		}
 
@@ -416,6 +418,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 			task.on(RooCodeEventName.TaskUnfocused, () => {
 				this.emit(RooCodeEventName.TaskUnfocused, task.taskId)
+				this.tasksById.delete(task.taskId)
 			})
 
 			task.on(RooCodeEventName.TaskActive, () => {

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -24,6 +24,7 @@ import {
 import { IpcServer } from "@roo-code/ipc"
 
 import { Package } from "../shared/package"
+import { getAllModes } from "../shared/modes"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { Terminal } from "../integrations/terminal/Terminal"
 import { TerminalRegistry } from "../integrations/terminal/TerminalRegistry"
@@ -31,12 +32,22 @@ import { openClineInNewTab } from "../activate/registerCommands"
 import { getCommands } from "../services/command/commands"
 import { getModels } from "../api/providers/fetchers/modelCache"
 
+type TaskAskController = {
+	approveAsk(): void
+	handleWebviewAskResponse(response: "messageResponse", text?: string, images?: string[]): void
+}
+
+type RegisteredTask = {
+	task: TaskAskController
+	provider: ClineProvider
+}
+
 export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	private readonly outputChannel: vscode.OutputChannel
 	private readonly sidebarProvider: ClineProvider
 	private readonly context: vscode.ExtensionContext
 	private readonly ipc?: IpcServer
-	private readonly tasksById = new Map<string, { approveAsk(): void }>()
+	private readonly tasksById = new Map<string, RegisteredTask>()
 	private readonly log: (...args: unknown[]) => void
 	private logfile?: string
 
@@ -174,17 +185,21 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		text,
 		images,
 		newTab,
+		preserveOpenTabs,
 	}: {
 		configuration: RooCodeSettings
 		text?: string
 		images?: string[]
 		newTab?: boolean
+		preserveOpenTabs?: boolean
 	}) {
 		let provider: ClineProvider
 
 		if (newTab) {
-			await vscode.commands.executeCommand("workbench.action.files.revert")
-			await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+			if (!preserveOpenTabs) {
+				await vscode.commands.executeCommand("workbench.action.files.revert")
+				await vscode.commands.executeCommand("workbench.action.closeAllEditors")
+			}
 
 			provider = await openClineInNewTab({ context: this.context, outputChannel: this.outputChannel })
 			this.registerListeners(provider)
@@ -312,13 +327,41 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	}
 
 	public async approveTaskAsk(taskId: string): Promise<boolean> {
-		const task = this.tasksById.get(taskId)
+		const entry = this.tasksById.get(taskId)
 
-		if (!task) {
+		if (!entry) {
 			return false
 		}
 
-		task.approveAsk()
+		entry.task.approveAsk()
+		return true
+	}
+
+	public async selectTaskFollowupSuggestion({
+		taskId,
+		answer,
+		mode,
+	}: {
+		taskId: string
+		answer: string
+		mode?: string
+	}): Promise<boolean> {
+		const entry = this.tasksById.get(taskId)
+
+		if (!entry) {
+			return false
+		}
+
+		if (mode) {
+			const { customModes } = await entry.provider.getState()
+			const isValidMode = getAllModes(customModes).some((modeConfig) => modeConfig.slug === mode)
+
+			if (isValidMode) {
+				await entry.provider.handleModeSwitch(mode)
+			}
+		}
+
+		entry.task.handleWebviewAskResponse("messageResponse", answer)
 		return true
 	}
 
@@ -342,7 +385,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	private registerListeners(provider: ClineProvider) {
 		provider.on(RooCodeEventName.TaskCreated, (task) => {
-			this.tasksById.set(task.taskId, task)
+			this.tasksById.set(task.taskId, { task: task as unknown as TaskAskController, provider })
 
 			// Task Lifecycle
 

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -8,6 +8,7 @@ import pWaitFor from "p-wait-for"
 
 import {
 	type RooCodeAPI,
+	type GlobalState,
 	type RooCodeSettings,
 	type RooCodeEvents,
 	type ProviderSettings,
@@ -35,6 +36,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	private readonly sidebarProvider: ClineProvider
 	private readonly context: vscode.ExtensionContext
 	private readonly ipc?: IpcServer
+	private readonly tasksById = new Map<string, { approveAsk(): void }>()
 	private readonly log: (...args: unknown[]) => void
 	private logfile?: string
 
@@ -309,6 +311,17 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		this.sidebarProvider.getCurrentTask()?.approveAsk()
 	}
 
+	public async approveTaskAsk(taskId: string): Promise<boolean> {
+		const task = this.tasksById.get(taskId)
+
+		if (!task) {
+			return false
+		}
+
+		task.approveAsk()
+		return true
+	}
+
 	public isReady() {
 		return this.sidebarProvider.viewLaunched
 	}
@@ -329,6 +342,8 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	private registerListeners(provider: ClineProvider) {
 		provider.on(RooCodeEventName.TaskCreated, (task) => {
+			this.tasksById.set(task.taskId, task)
+
 			// Task Lifecycle
 
 			task.on(RooCodeEventName.TaskStarted, async () => {
@@ -340,6 +355,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 				this.emit(RooCodeEventName.TaskCompleted, task.taskId, tokenUsage, toolUsage, {
 					isSubtask: !!task.parentTaskId,
 				})
+				this.tasksById.delete(task.taskId)
 
 				await this.fileLog(
 					`[${new Date().toISOString()}] taskCompleted -> ${task.taskId} | ${JSON.stringify(tokenUsage, null, 2)} | ${JSON.stringify(toolUsage, null, 2)}\n`,
@@ -348,6 +364,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 			task.on(RooCodeEventName.TaskAborted, () => {
 				this.emit(RooCodeEventName.TaskAborted, task.taskId)
+				this.tasksById.delete(task.taskId)
 			})
 
 			task.on(RooCodeEventName.TaskFocused, () => {
@@ -506,6 +523,10 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		await this.sidebarProvider.setValues(values)
 		await this.sidebarProvider.providerSettingsManager.saveConfig(values.currentApiConfigName || "default", values)
 		await this.sidebarProvider.postStateToWebview()
+	}
+
+	public getGlobalState<K extends keyof GlobalState>(key: K): GlobalState[K] {
+		return this.context.globalState.get<GlobalState[K]>(key)
 	}
 
 	public setTerminalProfile(name: string | undefined): void {

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -190,9 +190,6 @@ const App = () => {
 		}
 	}, [telemetrySetting, telemetryKey, machineId, didHydrateState])
 
-	// Tell the extension that we are ready to receive messages.
-	useEffect(() => vscode.postMessage({ type: "webviewDidLaunch" }), [])
-
 	// Initialize source map support for better error reporting
 	useEffect(() => {
 		// Initialize source maps for better error reporting in production

--- a/webview-ui/src/__tests__/App.spec.tsx
+++ b/webview-ui/src/__tests__/App.spec.tsx
@@ -8,6 +8,7 @@ import AppWithProviders from "../App"
 vi.mock("@src/utils/vscode", () => ({
 	vscode: {
 		postMessage: vi.fn(),
+		getViewStateId: vi.fn(() => "test-view-state-id"),
 	},
 }))
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -489,7 +489,10 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 	}, [handleMessage])
 
 	useEffect(() => {
-		vscode.postMessage({ type: "webviewDidLaunch" })
+		vscode.postMessage({
+			type: "webviewDidLaunch",
+			viewStateId: typeof vscode.getViewStateId === "function" ? vscode.getViewStateId() : undefined,
+		})
 	}, [])
 
 	// Apply the configurable chat font size as a CSS variable. When unset, the

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
@@ -11,6 +11,14 @@ import {
 } from "@roo-code/types"
 
 import { ExtensionStateContextProvider, useExtensionState, mergeExtensionState } from "../ExtensionStateContext"
+import { vscode } from "@src/utils/vscode"
+
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+		getViewStateId: vi.fn(() => "view-a"),
+	},
+}))
 
 const TestComponent = () => {
 	const { allowedCommands, setAllowedCommands, soundEnabled, showRooIgnoredFiles, setShowRooIgnoredFiles } =
@@ -71,7 +79,80 @@ const ApiConfigTestComponent = () => {
 	)
 }
 
+const ViewLocalStateTestComponent = () => {
+	const { mode, setMode, currentApiConfigName, setCurrentApiConfigName } = useExtensionState()
+
+	return (
+		<div>
+			<div data-testid="view-local-mode">{mode}</div>
+			<div data-testid="view-local-api-config">{currentApiConfigName}</div>
+			<button data-testid="set-local-mode" onClick={() => setMode("ask" as any)}>
+				Set Local Mode
+			</button>
+			<button data-testid="set-local-api-config" onClick={() => setCurrentApiConfigName("local-profile")}>
+				Set Local API Config
+			</button>
+		</div>
+	)
+}
+
 describe("ExtensionStateContext", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("posts webviewDidLaunch with the stable viewStateId from vscode API", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<TestComponent />
+			</ExtensionStateContextProvider>,
+		)
+
+		expect(vscode.getViewStateId).toHaveBeenCalled()
+		expect(vscode.postMessage).toHaveBeenCalledWith({ type: "webviewDidLaunch", viewStateId: "view-a" })
+	})
+
+	it("reseeds view-local mode and API profile from a new state payload after local edits", () => {
+		render(
+			<ExtensionStateContextProvider>
+				<ViewLocalStateTestComponent />
+			</ExtensionStateContextProvider>,
+		)
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "state",
+						state: { mode: "code", currentApiConfigName: "profile-a", apiConfiguration: {} },
+					},
+				}),
+			)
+		})
+		expect(screen.getByTestId("view-local-mode")).toHaveTextContent("code")
+		expect(screen.getByTestId("view-local-api-config")).toHaveTextContent("profile-a")
+
+		act(() => {
+			screen.getByTestId("set-local-mode").click()
+			screen.getByTestId("set-local-api-config").click()
+		})
+		expect(screen.getByTestId("view-local-mode")).toHaveTextContent("ask")
+		expect(screen.getByTestId("view-local-api-config")).toHaveTextContent("local-profile")
+
+		act(() => {
+			window.dispatchEvent(
+				new MessageEvent("message", {
+					data: {
+						type: "state",
+						state: { mode: "architect", currentApiConfigName: "profile-b", apiConfiguration: {} },
+					},
+				}),
+			)
+		})
+		expect(screen.getByTestId("view-local-mode")).toHaveTextContent("architect")
+		expect(screen.getByTestId("view-local-api-config")).toHaveTextContent("profile-b")
+	})
+
 	it("initializes with empty allowedCommands array", () => {
 		render(
 			<ExtensionStateContextProvider>

--- a/webview-ui/src/utils/__tests__/vscode.spec.ts
+++ b/webview-ui/src/utils/__tests__/vscode.spec.ts
@@ -1,0 +1,87 @@
+import { VSCodeAPIWrapper } from "../vscode"
+
+const originalCrypto = globalThis.crypto
+const originalLocalStorage = globalThis.localStorage
+
+const createMockStorage = (initialState: Record<string, string> = {}) => {
+	const state = { ...initialState }
+	return {
+		getItem: vi.fn((key: string) => state[key] ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			state[key] = value
+		}),
+		removeItem: vi.fn((key: string) => {
+			delete state[key]
+		}),
+		clear: vi.fn(() => {
+			for (const key of Object.keys(state)) {
+				delete state[key]
+			}
+		}),
+	} as unknown as Storage
+}
+
+describe("VSCodeAPIWrapper", () => {
+	afterEach(() => {
+		vi.restoreAllMocks()
+		Object.defineProperty(globalThis, "crypto", {
+			configurable: true,
+			value: originalCrypto,
+		})
+		Object.defineProperty(globalThis, "localStorage", {
+			configurable: true,
+			value: originalLocalStorage,
+		})
+	})
+
+	it("reuses the persisted webview viewStateId when browser storage is available", () => {
+		Object.defineProperty(globalThis, "localStorage", {
+			configurable: true,
+			value: createMockStorage({ vscodeState: JSON.stringify({ viewStateId: "persisted-view" }) }),
+		})
+		const wrapper = new VSCodeAPIWrapper()
+
+		expect(wrapper.getViewStateId()).toBe("persisted-view")
+	})
+
+	it("creates and persists a new viewStateId when storage has been cleared", () => {
+		Object.defineProperty(globalThis, "crypto", {
+			configurable: true,
+			value: { randomUUID: vi.fn(() => "generated-view") },
+		})
+		const storage = createMockStorage()
+		Object.defineProperty(globalThis, "localStorage", {
+			configurable: true,
+			value: storage,
+		})
+		const wrapper = new VSCodeAPIWrapper()
+
+		expect(wrapper.getViewStateId()).toBe("generated-view")
+		expect(JSON.parse(storage.getItem("vscodeState")!)).toMatchObject({ viewStateId: "generated-view" })
+	})
+
+	it("falls back to in-memory state when browser storage access is restricted", () => {
+		Object.defineProperty(globalThis, "crypto", {
+			configurable: true,
+			value: { randomUUID: vi.fn(() => "memory-view") },
+		})
+		const storage = {
+			getItem: vi.fn(() => {
+				throw new Error("storage denied")
+			}),
+			setItem: vi.fn(() => {
+				throw new Error("storage denied")
+			}),
+		} as unknown as Storage
+		Object.defineProperty(globalThis, "localStorage", {
+			configurable: true,
+			value: storage,
+		})
+		const wrapper = new VSCodeAPIWrapper()
+
+		expect(wrapper.getViewStateId()).toBe("memory-view")
+		expect(wrapper.getViewStateId()).toBe("memory-view")
+		expect(storage.getItem).toHaveBeenCalled()
+		expect(storage.setItem).toHaveBeenCalled()
+	})
+})

--- a/webview-ui/src/utils/__tests__/vscode.spec.ts
+++ b/webview-ui/src/utils/__tests__/vscode.spec.ts
@@ -61,9 +61,10 @@ describe("VSCodeAPIWrapper", () => {
 	})
 
 	it("falls back to in-memory state when browser storage access is restricted", () => {
+		const randomUUID = vi.fn().mockReturnValueOnce("memory-view").mockReturnValueOnce("new-memory-view")
 		Object.defineProperty(globalThis, "crypto", {
 			configurable: true,
-			value: { randomUUID: vi.fn(() => "memory-view") },
+			value: { randomUUID },
 		})
 		const storage = {
 			getItem: vi.fn(() => {
@@ -81,6 +82,7 @@ describe("VSCodeAPIWrapper", () => {
 
 		expect(wrapper.getViewStateId()).toBe("memory-view")
 		expect(wrapper.getViewStateId()).toBe("memory-view")
+		expect(randomUUID).toHaveBeenCalledTimes(1)
 		expect(storage.getItem).toHaveBeenCalled()
 		expect(storage.setItem).toHaveBeenCalled()
 	})

--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -11,8 +11,9 @@ import { WebviewMessage } from "@roo/WebviewMessage"
  * dev server by using native web browser features that mock the functionality
  * enabled by acquireVsCodeApi.
  */
-class VSCodeAPIWrapper {
+export class VSCodeAPIWrapper {
 	private readonly vsCodeApi: WebviewApi<unknown> | undefined
+	private fallbackState: unknown | undefined
 
 	constructor() {
 		// Check if the acquireVsCodeApi function exists in the current development
@@ -74,12 +75,18 @@ class VSCodeAPIWrapper {
 	public getState(): unknown | undefined {
 		if (this.vsCodeApi) {
 			return this.vsCodeApi.getState()
-		} else if (typeof localStorage?.getItem === "function") {
-			const state = localStorage.getItem("vscodeState")
-			return state ? JSON.parse(state) : undefined
-		} else {
-			return undefined
 		}
+
+		try {
+			if (typeof localStorage?.getItem === "function") {
+				const state = localStorage.getItem("vscodeState")
+				return state ? JSON.parse(state) : this.fallbackState
+			}
+		} catch {
+			return this.fallbackState
+		}
+
+		return this.fallbackState
 	}
 
 	/**
@@ -96,12 +103,20 @@ class VSCodeAPIWrapper {
 	public setState<T extends unknown | undefined>(newState: T): T {
 		if (this.vsCodeApi) {
 			return this.vsCodeApi.setState(newState)
-		} else {
+		}
+
+		this.fallbackState = newState
+
+		try {
 			if (typeof localStorage?.setItem === "function") {
 				localStorage.setItem("vscodeState", JSON.stringify(newState))
 			}
-			return newState
+		} catch {
+			// Storage can be unavailable in restricted webview/browser contexts.
+			// The in-memory fallback above keeps a stable viewStateId for this session.
 		}
+
+		return newState
 	}
 }
 

--- a/webview-ui/src/utils/vscode.ts
+++ b/webview-ui/src/utils/vscode.ts
@@ -22,6 +22,31 @@ class VSCodeAPIWrapper {
 		}
 	}
 
+	private createViewStateId(): string {
+		if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+			return crypto.randomUUID()
+		}
+
+		return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+	}
+
+	public getViewStateId(): string {
+		const currentState = this.getState()
+		const stateObject =
+			currentState && typeof currentState === "object" && !Array.isArray(currentState)
+				? (currentState as Record<string, unknown>)
+				: {}
+		const existingViewStateId = stateObject.viewStateId
+
+		if (typeof existingViewStateId === "string" && existingViewStateId.length > 0) {
+			return existingViewStateId
+		}
+
+		const viewStateId = this.createViewStateId()
+		this.setState({ ...stateObject, viewStateId })
+		return viewStateId
+	}
+
 	/**
 	 * Post a message (i.e. send arbitrary data) to the owner of the webview.
 	 *
@@ -49,9 +74,11 @@ class VSCodeAPIWrapper {
 	public getState(): unknown | undefined {
 		if (this.vsCodeApi) {
 			return this.vsCodeApi.getState()
-		} else {
+		} else if (typeof localStorage?.getItem === "function") {
 			const state = localStorage.getItem("vscodeState")
 			return state ? JSON.parse(state) : undefined
+		} else {
+			return undefined
 		}
 	}
 
@@ -70,7 +97,9 @@ class VSCodeAPIWrapper {
 		if (this.vsCodeApi) {
 			return this.vsCodeApi.setState(newState)
 		} else {
-			localStorage.setItem("vscodeState", JSON.stringify(newState))
+			if (typeof localStorage?.setItem === "function") {
+				localStorage.setItem("vscodeState", JSON.stringify(newState))
+			}
 			return newState
 		}
 	}


### PR DESCRIPTION
## Summary

E2E tests, API task control tests, and review feedback fixes. This is **Branch 3 of 3** split from PR #977 for easier review.

## Changes

- `test(webview): mock workspace tracker init` (+1 / -1)
- `test(vscode-e2e): cross-panel isolation` (+191 / -2)
- `test(vscode-e2e): follow-up mode isolation` (+308 / -8)
- `test(api): task controls + view-local values` (+291)
- `fix(webview): address review feedback` (+79 / -30)

**~806 lines changed (incremental)**

## Related

- Split from #977
- Depends on PR #1138 (Branch 1) and PR #1139 (Branch 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent state for each sidebar or editor view, including selected modes and API profiles.
  * View-specific settings are restored across sessions without persisting secret configuration values.
  * Added API controls for approving task requests, submitting follow-up suggestions, switching modes, and preserving open tabs when starting tasks.

* **Bug Fixes**
  * Improved reliability when loading model information, including graceful handling of credential lookup failures.
  * Fixed task and mode state association across concurrent views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->