### PR TITLE
refactor(webview): use provider identifiers in ApiOptions

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -8,6 +8,7 @@ import {
 	type ProviderName,
 	type ProviderSettings,
 	isRetiredProvider,
+	providerIdentifiers,
 	DEFAULT_CONSECUTIVE_MISTAKE_LIMIT,
 } from "@roo-code/types"
 
@@ -207,7 +208,7 @@ const ApiOptions = ({
 	// stops typing.
 	useDebounce(
 		() => {
-			if (selectedProvider === "openai") {
+			if (selectedProvider === providerIdentifiers.openai) {
 				// Use our custom headers state to build the headers object.
 				const headerObject = convertHeadersToObject(customHeaders)
 
@@ -220,7 +221,7 @@ const ApiOptions = ({
 						openAiHeaders: headerObject,
 					},
 				})
-			} else if (selectedProvider === "ollama") {
+			} else if (selectedProvider === providerIdentifiers.ollama) {
 				vscode.postMessage({
 					type: "requestOllamaModels",
 					values: {
@@ -228,11 +229,11 @@ const ApiOptions = ({
 						apiKey: apiConfiguration?.ollamaApiKey,
 					},
 				})
-			} else if (selectedProvider === "lmstudio") {
+			} else if (selectedProvider === providerIdentifiers.lmstudio) {
 				requestLmStudioModels(apiConfiguration?.lmStudioBaseUrl)
-			} else if (selectedProvider === "vscode-lm") {
+			} else if (selectedProvider === providerIdentifiers.vscodeLm) {
 				vscode.postMessage({ type: "requestVsCodeLmModels" })
-			} else if (selectedProvider === "litellm") {
+			} else if (selectedProvider === providerIdentifiers.litellm) {
 				vscode.postMessage({
 					type: "requestRouterModels",
 					values: {
@@ -240,7 +241,7 @@ const ApiOptions = ({
 						litellmBaseUrl: apiConfiguration?.litellmBaseUrl,
 					},
 				})
-			} else if (selectedProvider === "poe") {
+			} else if (selectedProvider === providerIdentifiers.poe) {
 				vscode.postMessage({ type: "requestRouterModels" })
 			}
 		},
@@ -270,7 +271,7 @@ const ApiOptions = ({
 		// Zoo Gateway renders its own auth-state error inline (sign-in card in
 		// ZooGateway.tsx) so it can react to zooCodeIsAuthenticated changes
 		// without re-running this effect or threading auth state through validation.
-		if (apiConfiguration.apiProvider === "zoo-gateway") {
+		if (apiConfiguration.apiProvider === providerIdentifiers.zooGateway) {
 			setErrorMessage(undefined)
 			return
 		}
@@ -322,7 +323,7 @@ const ApiOptions = ({
 				}
 
 				// Bedrock has a special “custom-arn” pseudo-model that isn't part of MODELS_BY_PROVIDER.
-				if (provider === "bedrock" && modelId === "custom-arn") {
+				if (provider === providerIdentifiers.bedrock && modelId === "custom-arn") {
 					return
 				}
 
@@ -441,7 +442,7 @@ const ApiOptions = ({
 				</div>
 			) : (
 				<>
-					{selectedProvider === "openrouter" && (
+					{selectedProvider === providerIdentifiers.openrouter && (
 						<OpenRouter
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -454,7 +455,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "requesty" && (
+					{selectedProvider === providerIdentifiers.requesty && (
 						<Requesty
 							uriScheme={uriScheme}
 							apiConfiguration={apiConfiguration}
@@ -467,7 +468,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "unbound" && (
+					{selectedProvider === providerIdentifiers.unbound && (
 						<Unbound
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -479,7 +480,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "anthropic" && (
+					{selectedProvider === providerIdentifiers.anthropic && (
 						<Anthropic
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -487,7 +488,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "openai-codex" && (
+					{selectedProvider === providerIdentifiers.openaiCodex && (
 						<OpenAICodex
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -496,7 +497,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "openai-native" && (
+					{selectedProvider === providerIdentifiers.openaiNative && (
 						<OpenAI
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -505,7 +506,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "mistral" && (
+					{selectedProvider === providerIdentifiers.mistral && (
 						<Mistral
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -513,7 +514,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "baseten" && (
+					{selectedProvider === providerIdentifiers.baseten && (
 						<Baseten
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -521,7 +522,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "bedrock" && (
+					{selectedProvider === providerIdentifiers.bedrock && (
 						<Bedrock
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -530,21 +531,21 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "vertex" && (
+					{selectedProvider === providerIdentifiers.vertex && (
 						<Vertex
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "gemini" && (
+					{selectedProvider === providerIdentifiers.gemini && (
 						<Gemini
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "openai" && (
+					{selectedProvider === providerIdentifiers.openai && (
 						<OpenAICompatible
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -554,21 +555,21 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "lmstudio" && (
+					{selectedProvider === providerIdentifiers.lmstudio && (
 						<LMStudio
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "deepseek" && (
+					{selectedProvider === providerIdentifiers.deepseek && (
 						<DeepSeek
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "qwen-code" && (
+					{selectedProvider === providerIdentifiers.qwenCode && (
 						<QwenCode
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -576,7 +577,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "moonshot" && (
+					{selectedProvider === providerIdentifiers.moonshot && (
 						<Moonshot
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -584,7 +585,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "kimi-code" && (
+					{selectedProvider === providerIdentifiers.kimiCode && (
 						<KimiCode
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -593,36 +594,36 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "minimax" && (
+					{selectedProvider === providerIdentifiers.minimax && (
 						<MiniMax
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "mimo" && (
+					{selectedProvider === providerIdentifiers.mimo && (
 						<Mimo apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
 					)}
 
-					{selectedProvider === "vscode-lm" && (
+					{selectedProvider === providerIdentifiers.vscodeLm && (
 						<VSCodeLM
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "ollama" && (
+					{selectedProvider === providerIdentifiers.ollama && (
 						<Ollama
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "xai" && (
+					{selectedProvider === providerIdentifiers.xai && (
 						<XAI apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
 					)}
 
-					{selectedProvider === "litellm" && (
+					{selectedProvider === providerIdentifiers.litellm && (
 						<LiteLLM
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -632,18 +633,18 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "sambanova" && (
+					{selectedProvider === providerIdentifiers.sambanova && (
 						<SambaNova
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "zai" && (
+					{selectedProvider === providerIdentifiers.zai && (
 						<ZAi apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
 					)}
 
-					{selectedProvider === "vercel-ai-gateway" && (
+					{selectedProvider === providerIdentifiers.vercelAiGateway && (
 						<VercelAiGateway
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -654,7 +655,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "opencode-go" && (
+					{selectedProvider === providerIdentifiers.opencodeGo && (
 						<OpenCodeGo
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -665,7 +666,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "kenari" && (
+					{selectedProvider === providerIdentifiers.kenari && (
 						<Kenari
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -676,7 +677,7 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "zoo-gateway" && (
+					{selectedProvider === providerIdentifiers.zooGateway && (
 						<ZooGateway
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -687,21 +688,21 @@ const ApiOptions = ({
 						/>
 					)}
 
-					{selectedProvider === "fireworks" && (
+					{selectedProvider === providerIdentifiers.fireworks && (
 						<Fireworks
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "friendli" && (
+					{selectedProvider === providerIdentifiers.friendli && (
 						<Friendli
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "poe" && (
+					{selectedProvider === providerIdentifiers.poe && (
 						<Poe
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
@@ -737,7 +738,7 @@ const ApiOptions = ({
 								}
 							/>
 
-							{selectedProvider === "bedrock" && selectedModelId === "custom-arn" && (
+							{selectedProvider === providerIdentifiers.bedrock && selectedModelId === "custom-arn" && (
 								<BedrockCustomArn
 									apiConfiguration={apiConfiguration}
 									setApiConfigurationField={setApiConfigurationField}
@@ -796,7 +797,7 @@ const ApiOptions = ({
 									}
 									onChange={(value) => setApiConfigurationField("consecutiveMistakeLimit", value)}
 								/>
-								{selectedProvider === "poe" && (
+								{selectedProvider === providerIdentifiers.poe && (
 									<VSCodeTextField
 										value={apiConfiguration?.poeBaseUrl || ""}
 										onInput={handleInputChange("poeBaseUrl")}
@@ -807,7 +808,7 @@ const ApiOptions = ({
 										</label>
 									</VSCodeTextField>
 								)}
-								{selectedProvider === "openrouter" &&
+								{selectedProvider === providerIdentifiers.openrouter &&
 									openRouterModelProviders &&
 									Object.keys(openRouterModelProviders).length > 0 && (
 										<div>

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -398,7 +398,7 @@ const ApiOptions = ({
 		}))
 
 		if (fromWelcomeView) {
-			const openRouterIndex = options.findIndex((opt) => opt.value === "openrouter")
+			const openRouterIndex = options.findIndex((opt) => opt.value === providerIdentifiers.openrouter)
 			if (openRouterIndex > 0) {
 				const [openRouterOption] = options.splice(openRouterIndex, 1)
 				options.unshift(openRouterOption)

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.interactions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.interactions.spec.tsx
@@ -1,0 +1,388 @@
+import { act, fireEvent, render, screen, within } from "@/utils/test-utils"
+import { bedrockDefaultModelId, providerIdentifiers, type ProviderSettings } from "@roo-code/types"
+import type { ChangeEventHandler, InputHTMLAttributes, ReactNode } from "react"
+
+import { requestLmStudioModels } from "@src/components/ui/hooks/useLmStudioModels"
+import type { useOpenRouterModelProviders } from "@src/components/ui/hooks/useOpenRouterModelProviders"
+import { vscode } from "@src/utils/vscode"
+
+import ApiOptions, { type ApiOptionsProps } from "../ApiOptions"
+
+type OpenRouterModelProvidersQueryResult = Pick<ReturnType<typeof useOpenRouterModelProviders>, "data">
+
+const { useOpenRouterModelProvidersMock } = vi.hoisted(() => ({
+	useOpenRouterModelProvidersMock: vi.fn<() => OpenRouterModelProvidersQueryResult>(() => ({ data: undefined })),
+}))
+
+type ChildrenProps = { children?: ReactNode }
+
+type VSCodeTextFieldMockProps = ChildrenProps &
+	Pick<InputHTMLAttributes<HTMLInputElement>, "value" | "placeholder"> & {
+		onInput?: ChangeEventHandler<HTMLInputElement>
+	}
+
+type SearchableSelectMockProps = {
+	value?: string
+	onValueChange: (value: string) => void
+	options: Array<{ value: string; label: string }>
+	"data-testid"?: string
+}
+
+vi.mock("@src/context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		organizationAllowList: { allowAll: true, providers: {} },
+		openAiCodexIsAuthenticated: false,
+		kimiCodeIsAuthenticated: false,
+		kimiCodeOAuthState: undefined,
+	}),
+}))
+
+vi.mock("@src/components/ui/hooks/useRouterModels", () => ({
+	useRouterModels: () => ({ data: {}, refetch: vi.fn() }),
+}))
+
+vi.mock("@src/components/ui/hooks/useZooGatewayRouterModelsSync", () => ({
+	useZooGatewayRouterModelsSync: vi.fn(),
+}))
+
+vi.mock("@src/components/ui/hooks/useOpenRouterModelProviders", () => ({
+	useOpenRouterModelProviders: useOpenRouterModelProvidersMock,
+	OPENROUTER_DEFAULT_PROVIDER_NAME: "Auto",
+}))
+
+vi.mock("@src/components/ui/hooks/useSelectedModel", () => ({
+	useSelectedModel: (configuration: ProviderSettings) => ({
+		provider: configuration.apiProvider,
+		id: configuration.apiModelId,
+		info: {},
+	}),
+}))
+
+vi.mock("@src/components/ui/hooks/useLmStudioModels", () => ({
+	requestLmStudioModels: vi.fn(),
+}))
+
+vi.mock("../providers", () => {
+	const Provider = () => null
+	return {
+		Anthropic: Provider,
+		Baseten: Provider,
+		Bedrock: Provider,
+		DeepSeek: Provider,
+		Gemini: Provider,
+		LMStudio: Provider,
+		LiteLLM: Provider,
+		Mistral: Provider,
+		Moonshot: Provider,
+		KimiCode: Provider,
+		Ollama: Provider,
+		OpenAI: Provider,
+		OpenAICompatible: Provider,
+		OpenAICodex: Provider,
+		OpenRouter: Provider,
+		Poe: Provider,
+		QwenCode: Provider,
+		Requesty: Provider,
+		SambaNova: Provider,
+		Unbound: Provider,
+		Vertex: Provider,
+		VSCodeLM: Provider,
+		XAI: Provider,
+		ZAi: Provider,
+		Fireworks: Provider,
+		Friendli: Provider,
+		VercelAiGateway: Provider,
+		OpenCodeGo: Provider,
+		Kenari: Provider,
+		ZooGateway: Provider,
+		MiniMax: Provider,
+		Mimo: Provider,
+	}
+})
+
+vi.mock("../providers/BedrockCustomArn", () => ({
+	BedrockCustomArn: () => <div data-testid="bedrock-custom-arn" />,
+}))
+vi.mock("../ModelPicker", () => ({ ModelPicker: () => null }))
+vi.mock("../ApiErrorMessage", () => ({ ApiErrorMessage: () => null }))
+vi.mock("../ThinkingBudget", () => ({ ThinkingBudget: () => null }))
+vi.mock("../Verbosity", () => ({ Verbosity: () => null }))
+vi.mock("../TodoListSettingsControl", () => ({ TodoListSettingsControl: () => null }))
+vi.mock("../TemperatureControl", () => ({ TemperatureControl: () => null }))
+vi.mock("../RateLimitSecondsControl", () => ({ RateLimitSecondsControl: () => null }))
+vi.mock("../ConsecutiveMistakeLimitControl", () => ({
+	ConsecutiveMistakeLimitControl: ({ value, onChange }: { value: number; onChange: (value: number) => void }) => (
+		<div data-testid="consecutive-mistake-limit-control">
+			<input type="range" value={value} onChange={(event) => onChange(Number(event.target.value))} />
+		</div>
+	),
+}))
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+	VSCodeTextField: ({ children, value, onInput, placeholder }: VSCodeTextFieldMockProps) => (
+		<label>
+			{children}
+			<input value={value} placeholder={placeholder} onChange={onInput} />
+		</label>
+	),
+	VSCodeLink: ({ children }: ChildrenProps) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui", () => ({
+	SearchableSelect: ({ value, onValueChange, options, "data-testid": testId }: SearchableSelectMockProps) => (
+		<div data-testid={testId}>
+			<select value={value} onChange={(event) => onValueChange(event.target.value)}>
+				{options.map((option) => (
+					<option key={option.value} value={option.value}>
+						{option.label}
+					</option>
+				))}
+			</select>
+		</div>
+	),
+	Collapsible: ({ children }: ChildrenProps) => <div>{children}</div>,
+	CollapsibleTrigger: ({ children }: ChildrenProps) => <div>{children}</div>,
+	CollapsibleContent: ({ children }: ChildrenProps) => <div>{children}</div>,
+	Select: ({ children }: ChildrenProps) => <div>{children}</div>,
+	SelectTrigger: ({ children }: ChildrenProps) => <div>{children}</div>,
+	SelectValue: () => null,
+	SelectContent: ({ children }: ChildrenProps) => <div>{children}</div>,
+	SelectItem: ({ children }: ChildrenProps) => <div>{children}</div>,
+}))
+
+const renderApiOptions = (props: Partial<ApiOptionsProps> = {}) =>
+	render(
+		<ApiOptions
+			errorMessage={undefined}
+			setErrorMessage={() => undefined}
+			uriScheme={undefined}
+			apiConfiguration={{}}
+			setApiConfigurationField={() => undefined}
+			{...props}
+		/>,
+	)
+
+describe("ApiOptions interactions", () => {
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	describe("debounced provider model refresh", () => {
+		it.each([
+			{
+				provider: providerIdentifiers.openai,
+				configuration: {
+					openAiBaseUrl: "https://openai.example/v1",
+					openAiApiKey: "openai-key",
+					openAiHeaders: { "X-Custom": "header-value" },
+				},
+				expectedMessage: {
+					type: "requestOpenAiModels",
+					values: {
+						baseUrl: "https://openai.example/v1",
+						apiKey: "openai-key",
+						customHeaders: {},
+						openAiHeaders: { "X-Custom": "header-value" },
+					},
+				},
+			},
+			{
+				provider: providerIdentifiers.ollama,
+				configuration: { ollamaBaseUrl: "http://ollama:11434", ollamaApiKey: "ollama-key" },
+				expectedMessage: {
+					type: "requestOllamaModels",
+					values: { baseUrl: "http://ollama:11434", apiKey: "ollama-key" },
+				},
+			},
+			{
+				provider: providerIdentifiers.vscodeLm,
+				configuration: {},
+				expectedMessage: { type: "requestVsCodeLmModels" },
+			},
+			{
+				provider: providerIdentifiers.litellm,
+				configuration: { litellmBaseUrl: "http://litellm:4000", litellmApiKey: "litellm-key" },
+				expectedMessage: {
+					type: "requestRouterModels",
+					values: { litellmApiKey: "litellm-key", litellmBaseUrl: "http://litellm:4000" },
+				},
+			},
+			{
+				provider: providerIdentifiers.poe,
+				configuration: { poeApiKey: "poe-key", poeBaseUrl: "https://api.poe.example/v1" },
+				expectedMessage: { type: "requestRouterModels" },
+			},
+		])("requests models for $provider", ({ provider, configuration, expectedMessage }) => {
+			vi.useFakeTimers()
+			const postMessage = vi.spyOn(vscode, "postMessage").mockImplementation(() => undefined)
+
+			renderApiOptions({ apiConfiguration: { apiProvider: provider, ...configuration } })
+			act(() => vi.advanceTimersByTime(249))
+			expect(postMessage).not.toHaveBeenCalledWith(expectedMessage)
+
+			act(() => vi.advanceTimersByTime(1))
+			expect(postMessage).toHaveBeenCalledTimes(1)
+			expect(postMessage).toHaveBeenCalledWith(expectedMessage)
+		})
+
+		it("requests LM Studio models using its configured base URL", () => {
+			vi.useFakeTimers()
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: providerIdentifiers.lmstudio,
+					lmStudioBaseUrl: "http://lmstudio:1234",
+				},
+			})
+
+			act(() => vi.advanceTimersByTime(249))
+			expect(requestLmStudioModels).not.toHaveBeenCalledWith("http://lmstudio:1234")
+
+			act(() => vi.advanceTimersByTime(1))
+			expect(requestLmStudioModels).toHaveBeenCalledTimes(1)
+			expect(requestLmStudioModels).toHaveBeenCalledWith("http://lmstudio:1234")
+		})
+
+		it("does not request dynamic models for a static provider", () => {
+			vi.useFakeTimers()
+			const postMessage = vi.spyOn(vscode, "postMessage").mockImplementation(() => undefined)
+
+			renderApiOptions({ apiConfiguration: { apiProvider: providerIdentifiers.anthropic } })
+			act(() => vi.advanceTimersByTime(250))
+
+			expect(postMessage).not.toHaveBeenCalled()
+		})
+	})
+
+	it.each([
+		providerIdentifiers.requesty,
+		providerIdentifiers.unbound,
+		providerIdentifiers.anthropic,
+		providerIdentifiers.openaiCodex,
+		providerIdentifiers.openaiNative,
+		providerIdentifiers.mistral,
+		providerIdentifiers.baseten,
+		providerIdentifiers.bedrock,
+		providerIdentifiers.gemini,
+		providerIdentifiers.lmstudio,
+		providerIdentifiers.deepseek,
+		providerIdentifiers.qwenCode,
+		providerIdentifiers.moonshot,
+		providerIdentifiers.kimiCode,
+		providerIdentifiers.minimax,
+		providerIdentifiers.mimo,
+		providerIdentifiers.ollama,
+		providerIdentifiers.litellm,
+		providerIdentifiers.sambanova,
+		providerIdentifiers.zai,
+		providerIdentifiers.xai,
+		providerIdentifiers.fireworks,
+		providerIdentifiers.friendli,
+		providerIdentifiers.vercelAiGateway,
+		providerIdentifiers.opencodeGo,
+	])("renders the canonical %s provider branch", (apiProvider) => {
+		const { unmount } = renderApiOptions({ apiConfiguration: { apiProvider } })
+		unmount()
+	})
+
+	it("clears parent validation errors for Zoo Gateway", () => {
+		const setErrorMessage = vi.fn()
+		renderApiOptions({ apiConfiguration: { apiProvider: providerIdentifiers.zooGateway }, setErrorMessage })
+
+		expect(setErrorMessage).toHaveBeenCalledWith(undefined)
+	})
+
+	it("renders OpenRouter provider routing when provider metadata is available", () => {
+		useOpenRouterModelProvidersMock.mockReturnValue({
+			data: { preferred: { label: "Preferred", contextWindow: 1, supportsPromptCache: false } },
+		})
+
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: providerIdentifiers.openrouter,
+				openRouterModelId: "anthropic/claude-sonnet-4.5",
+			},
+		})
+
+		expect(screen.getByText("settings:providers.openRouter.providerRouting.title")).toBeInTheDocument()
+	})
+
+	it("preserves the Bedrock custom ARN pseudo-model when switching to Bedrock", () => {
+		const setApiConfigurationField = vi.fn()
+		renderApiOptions({
+			apiConfiguration: { apiProvider: providerIdentifiers.anthropic, apiModelId: "custom-arn" },
+			setApiConfigurationField,
+		})
+
+		const providerSelect = screen.getByTestId("provider-select").querySelector("select") as HTMLSelectElement
+		fireEvent.change(providerSelect, { target: { value: providerIdentifiers.bedrock } })
+
+		expect(setApiConfigurationField).toHaveBeenCalledWith("apiProvider", providerIdentifiers.bedrock)
+		expect(setApiConfigurationField.mock.calls.filter(([field]) => field === "apiModelId")).toEqual([])
+	})
+
+	it("resets an invalid ordinary model to the Bedrock default when switching providers", () => {
+		const setApiConfigurationField = vi.fn()
+		renderApiOptions({
+			apiConfiguration: { apiProvider: providerIdentifiers.anthropic, apiModelId: "not-a-bedrock-model" },
+			setApiConfigurationField,
+		})
+
+		const providerSelect = screen.getByTestId("provider-select").querySelector("select") as HTMLSelectElement
+		fireEvent.change(providerSelect, { target: { value: providerIdentifiers.bedrock } })
+
+		expect(setApiConfigurationField).toHaveBeenCalledWith("apiProvider", providerIdentifiers.bedrock)
+		expect(setApiConfigurationField).toHaveBeenCalledWith("apiModelId", bedrockDefaultModelId, false)
+	})
+
+	it("renders the custom ARN settings only for Bedrock's custom ARN pseudo-model", () => {
+		const { rerender } = render(
+			<ApiOptions
+				errorMessage={undefined}
+				setErrorMessage={() => undefined}
+				uriScheme={undefined}
+				apiConfiguration={{ apiProvider: providerIdentifiers.bedrock, apiModelId: "custom-arn" }}
+				setApiConfigurationField={() => undefined}
+			/>,
+		)
+
+		expect(screen.getByTestId("bedrock-custom-arn")).toBeInTheDocument()
+
+		rerender(
+			<ApiOptions
+				errorMessage={undefined}
+				setErrorMessage={() => undefined}
+				uriScheme={undefined}
+				apiConfiguration={{ apiProvider: providerIdentifiers.bedrock, apiModelId: bedrockDefaultModelId }}
+				setApiConfigurationField={() => undefined}
+			/>,
+		)
+
+		expect(screen.queryByTestId("bedrock-custom-arn")).not.toBeInTheDocument()
+	})
+
+	it("updates the consecutive mistake limit from advanced settings", () => {
+		const setApiConfigurationField = vi.fn()
+		renderApiOptions({ apiConfiguration: {}, setApiConfigurationField })
+
+		fireEvent.change(within(screen.getByTestId("consecutive-mistake-limit-control")).getByRole("slider"), {
+			target: { value: "7" },
+		})
+
+		expect(setApiConfigurationField).toHaveBeenCalledWith("consecutiveMistakeLimit", 7)
+	})
+
+	it("renders and updates the Poe base URL in advanced settings", () => {
+		const setApiConfigurationField = vi.fn()
+		renderApiOptions({
+			apiConfiguration: { apiProvider: providerIdentifiers.poe, poeBaseUrl: "https://api.poe.example/v1" },
+			setApiConfigurationField,
+		})
+
+		const poeBaseUrl = screen.getByPlaceholderText("https://api.poe.com/v1")
+		expect(poeBaseUrl).toHaveValue("https://api.poe.example/v1")
+
+		fireEvent.change(poeBaseUrl, { target: { value: "https://new.poe.example/v1" } })
+		expect(setApiConfigurationField).toHaveBeenCalledWith("poeBaseUrl", "https://new.poe.example/v1")
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.interactions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.interactions.spec.tsx
@@ -10,10 +10,6 @@ import ApiOptions, { type ApiOptionsProps } from "../ApiOptions"
 
 type OpenRouterModelProvidersQueryResult = Pick<ReturnType<typeof useOpenRouterModelProviders>, "data">
 
-const { useOpenRouterModelProvidersMock } = vi.hoisted(() => ({
-	useOpenRouterModelProvidersMock: vi.fn<() => OpenRouterModelProvidersQueryResult>(() => ({ data: undefined })),
-}))
-
 type ChildrenProps = { children?: ReactNode }
 
 type VSCodeTextFieldMockProps = ChildrenProps &
@@ -27,6 +23,24 @@ type SearchableSelectMockProps = {
 	options: Array<{ value: string; label: string }>
 	"data-testid"?: string
 }
+
+type SelectMockProps = ChildrenProps & {
+	value?: string
+	onValueChange?: (value: string) => void
+}
+
+type UseSelectedModelReturn = { provider?: string; id?: string; info: Record<string, never> }
+
+const { useOpenRouterModelProvidersMock, useSelectedModelMock } = vi.hoisted(() => ({
+	useOpenRouterModelProvidersMock: vi.fn<() => OpenRouterModelProvidersQueryResult>(() => ({ data: undefined })),
+	useSelectedModelMock: vi.fn(
+		(configuration: ProviderSettings): UseSelectedModelReturn => ({
+			provider: configuration.apiProvider,
+			id: configuration.apiModelId,
+			info: {},
+		}),
+	),
+}))
 
 vi.mock("@src/context/ExtensionStateContext", () => ({
 	useExtensionState: () => ({
@@ -51,11 +65,7 @@ vi.mock("@src/components/ui/hooks/useOpenRouterModelProviders", () => ({
 }))
 
 vi.mock("@src/components/ui/hooks/useSelectedModel", () => ({
-	useSelectedModel: (configuration: ProviderSettings) => ({
-		provider: configuration.apiProvider,
-		id: configuration.apiModelId,
-		info: {},
-	}),
+	useSelectedModel: useSelectedModelMock,
 }))
 
 vi.mock("@src/components/ui/hooks/useLmStudioModels", () => ({
@@ -63,40 +73,40 @@ vi.mock("@src/components/ui/hooks/useLmStudioModels", () => ({
 }))
 
 vi.mock("../providers", () => {
-	const Provider = () => null
+	const provider = (testId: string) => () => <div data-testid={testId} />
 	return {
-		Anthropic: Provider,
-		Baseten: Provider,
-		Bedrock: Provider,
-		DeepSeek: Provider,
-		Gemini: Provider,
-		LMStudio: Provider,
-		LiteLLM: Provider,
-		Mistral: Provider,
-		Moonshot: Provider,
-		KimiCode: Provider,
-		Ollama: Provider,
-		OpenAI: Provider,
-		OpenAICompatible: Provider,
-		OpenAICodex: Provider,
-		OpenRouter: Provider,
-		Poe: Provider,
-		QwenCode: Provider,
-		Requesty: Provider,
-		SambaNova: Provider,
-		Unbound: Provider,
-		Vertex: Provider,
-		VSCodeLM: Provider,
-		XAI: Provider,
-		ZAi: Provider,
-		Fireworks: Provider,
-		Friendli: Provider,
-		VercelAiGateway: Provider,
-		OpenCodeGo: Provider,
-		Kenari: Provider,
-		ZooGateway: Provider,
-		MiniMax: Provider,
-		Mimo: Provider,
+		Anthropic: provider("provider-anthropic"),
+		Baseten: provider("provider-baseten"),
+		Bedrock: provider("provider-bedrock"),
+		DeepSeek: provider("provider-deepseek"),
+		Gemini: provider("provider-gemini"),
+		LMStudio: provider("provider-lmstudio"),
+		LiteLLM: provider("provider-litellm"),
+		Mistral: provider("provider-mistral"),
+		Moonshot: provider("provider-moonshot"),
+		KimiCode: provider("provider-kimi-code"),
+		Ollama: provider("provider-ollama"),
+		OpenAI: provider("provider-openai-native"),
+		OpenAICompatible: provider("provider-openai"),
+		OpenAICodex: provider("provider-openai-codex"),
+		OpenRouter: provider("provider-openrouter"),
+		Poe: provider("provider-poe"),
+		QwenCode: provider("provider-qwen-code"),
+		Requesty: provider("provider-requesty"),
+		SambaNova: provider("provider-sambanova"),
+		Unbound: provider("provider-unbound"),
+		Vertex: provider("provider-vertex"),
+		VSCodeLM: provider("provider-vscode-lm"),
+		XAI: provider("provider-xai"),
+		ZAi: provider("provider-zai"),
+		Fireworks: provider("provider-fireworks"),
+		Friendli: provider("provider-friendli"),
+		VercelAiGateway: provider("provider-vercel-ai-gateway"),
+		OpenCodeGo: provider("provider-opencode-go"),
+		Kenari: provider("provider-kenari"),
+		ZooGateway: provider("provider-zoo-gateway"),
+		MiniMax: provider("provider-minimax"),
+		Mimo: provider("provider-mimo"),
 	}
 })
 
@@ -104,7 +114,9 @@ vi.mock("../providers/BedrockCustomArn", () => ({
 	BedrockCustomArn: () => <div data-testid="bedrock-custom-arn" />,
 }))
 vi.mock("../ModelPicker", () => ({ ModelPicker: () => null }))
-vi.mock("../ApiErrorMessage", () => ({ ApiErrorMessage: () => null }))
+vi.mock("../ApiErrorMessage", () => ({
+	ApiErrorMessage: ({ errorMessage }: { errorMessage: string }) => <div>{String(errorMessage)}</div>,
+}))
 vi.mock("../ThinkingBudget", () => ({ ThinkingBudget: () => null }))
 vi.mock("../Verbosity", () => ({ Verbosity: () => null }))
 vi.mock("../TodoListSettingsControl", () => ({ TodoListSettingsControl: () => null }))
@@ -143,11 +155,17 @@ vi.mock("@/components/ui", () => ({
 	Collapsible: ({ children }: ChildrenProps) => <div>{children}</div>,
 	CollapsibleTrigger: ({ children }: ChildrenProps) => <div>{children}</div>,
 	CollapsibleContent: ({ children }: ChildrenProps) => <div>{children}</div>,
-	Select: ({ children }: ChildrenProps) => <div>{children}</div>,
-	SelectTrigger: ({ children }: ChildrenProps) => <div>{children}</div>,
+	Select: ({ value, onValueChange, children }: SelectMockProps) => (
+		<select data-testid="routing-select" value={value} onChange={(event) => onValueChange?.(event.target.value)}>
+			{children}
+		</select>
+	),
+	SelectTrigger: ({ children }: ChildrenProps) => <>{children}</>,
 	SelectValue: () => null,
-	SelectContent: ({ children }: ChildrenProps) => <div>{children}</div>,
-	SelectItem: ({ children }: ChildrenProps) => <div>{children}</div>,
+	SelectContent: ({ children }: ChildrenProps) => <>{children}</>,
+	SelectItem: ({ value, children }: { value?: string; children?: ReactNode }) => (
+		<option value={value}>{children}</option>
+	),
 }))
 
 const renderApiOptions = (props: Partial<ApiOptionsProps> = {}) =>
@@ -163,6 +181,15 @@ const renderApiOptions = (props: Partial<ApiOptionsProps> = {}) =>
 	)
 
 describe("ApiOptions interactions", () => {
+	beforeEach(() => {
+		useSelectedModelMock.mockImplementation((configuration: ProviderSettings) => ({
+			provider: configuration.apiProvider,
+			id: configuration.apiModelId,
+			info: {},
+		}))
+		useOpenRouterModelProvidersMock.mockImplementation(() => ({ data: undefined }))
+	})
+
 	afterEach(() => {
 		vi.useRealTimers()
 		vi.restoreAllMocks()
@@ -226,6 +253,46 @@ describe("ApiOptions interactions", () => {
 			expect(postMessage).toHaveBeenCalledWith(expectedMessage)
 		})
 
+		it("applies the header transform when requesting OpenAI models", () => {
+			vi.useFakeTimers()
+			const postMessage = vi.spyOn(vscode, "postMessage").mockImplementation(() => undefined)
+
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: providerIdentifiers.openai,
+					openAiBaseUrl: "https://openai.example/v1",
+					openAiApiKey: "openai-key",
+					openAiHeaders: { "": "ignored", "X-Keep": " kept" },
+				},
+			})
+			act(() => vi.advanceTimersByTime(250))
+
+			expect(postMessage).toHaveBeenCalledWith({
+				type: "requestOpenAiModels",
+				values: {
+					baseUrl: "https://openai.example/v1",
+					apiKey: "openai-key",
+					customHeaders: {},
+					openAiHeaders: { "X-Keep": "kept" },
+				},
+			})
+		})
+
+		it("syncs processed custom headers into the configuration", () => {
+			vi.useFakeTimers()
+			const setApiConfigurationField = vi.fn()
+
+			// The empty header key is dropped by convertHeadersToObject, so the
+			// processed object differs from the stored one and the sync fires.
+			renderApiOptions({
+				apiConfiguration: { apiProvider: providerIdentifiers.openai, openAiHeaders: { "": "ignored" } },
+				setApiConfigurationField,
+			})
+			act(() => vi.advanceTimersByTime(300))
+
+			expect(setApiConfigurationField).toHaveBeenCalledWith("openAiHeaders", {}, false)
+		})
+
 		it("requests LM Studio models using its configured base URL", () => {
 			vi.useFakeTimers()
 			renderApiOptions({
@@ -255,6 +322,7 @@ describe("ApiOptions interactions", () => {
 	})
 
 	it.each([
+		providerIdentifiers.openrouter,
 		providerIdentifiers.requesty,
 		providerIdentifiers.unbound,
 		providerIdentifiers.anthropic,
@@ -263,7 +331,9 @@ describe("ApiOptions interactions", () => {
 		providerIdentifiers.mistral,
 		providerIdentifiers.baseten,
 		providerIdentifiers.bedrock,
+		providerIdentifiers.vertex,
 		providerIdentifiers.gemini,
+		providerIdentifiers.openai,
 		providerIdentifiers.lmstudio,
 		providerIdentifiers.deepseek,
 		providerIdentifiers.qwenCode,
@@ -271,18 +341,23 @@ describe("ApiOptions interactions", () => {
 		providerIdentifiers.kimiCode,
 		providerIdentifiers.minimax,
 		providerIdentifiers.mimo,
+		providerIdentifiers.vscodeLm,
 		providerIdentifiers.ollama,
+		providerIdentifiers.xai,
 		providerIdentifiers.litellm,
 		providerIdentifiers.sambanova,
 		providerIdentifiers.zai,
-		providerIdentifiers.xai,
-		providerIdentifiers.fireworks,
-		providerIdentifiers.friendli,
 		providerIdentifiers.vercelAiGateway,
 		providerIdentifiers.opencodeGo,
-	])("renders the canonical %s provider branch", (apiProvider) => {
-		const { unmount } = renderApiOptions({ apiConfiguration: { apiProvider } })
-		unmount()
+		providerIdentifiers.kenari,
+		providerIdentifiers.zooGateway,
+		providerIdentifiers.fireworks,
+		providerIdentifiers.friendli,
+		providerIdentifiers.poe,
+	])("renders the %s provider branch when selected", (apiProvider) => {
+		renderApiOptions({ apiConfiguration: { apiProvider } })
+
+		expect(screen.getByTestId(`provider-${apiProvider}`)).toBeInTheDocument()
 	})
 
 	it("clears parent validation errors for Zoo Gateway", () => {
@@ -290,6 +365,23 @@ describe("ApiOptions interactions", () => {
 		renderApiOptions({ apiConfiguration: { apiProvider: providerIdentifiers.zooGateway }, setErrorMessage })
 
 		expect(setErrorMessage).toHaveBeenCalledWith(undefined)
+	})
+
+	it("reports a validation error for a non-gateway provider with missing credentials", () => {
+		const setErrorMessage = vi.fn()
+		renderApiOptions({ apiConfiguration: { apiProvider: providerIdentifiers.anthropic }, setErrorMessage })
+
+		expect(setErrorMessage).toHaveBeenCalled()
+		expect(setErrorMessage.mock.calls[0][0]).toBeTruthy()
+	})
+
+	it("renders the current validation error message", () => {
+		renderApiOptions({
+			apiConfiguration: { apiProvider: providerIdentifiers.anthropic },
+			errorMessage: "settings:validation.apiKey",
+		})
+
+		expect(screen.getByText("settings:validation.apiKey")).toBeInTheDocument()
 	})
 
 	it("renders OpenRouter provider routing when provider metadata is available", () => {
@@ -305,6 +397,37 @@ describe("ApiOptions interactions", () => {
 		})
 
 		expect(screen.getByText("settings:providers.openRouter.providerRouting.title")).toBeInTheDocument()
+	})
+
+	it("updates the OpenRouter specific provider from the routing control", () => {
+		useOpenRouterModelProvidersMock.mockReturnValue({
+			data: { preferred: { label: "Preferred", contextWindow: 1, supportsPromptCache: false } },
+		})
+		const setApiConfigurationField = vi.fn()
+
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: providerIdentifiers.openrouter,
+				openRouterModelId: "anthropic/claude-sonnet-4.5",
+			},
+			setApiConfigurationField,
+		})
+
+		fireEvent.change(screen.getByTestId("routing-select"), { target: { value: "preferred" } })
+		expect(setApiConfigurationField).toHaveBeenCalledWith("openRouterSpecificProvider", "preferred")
+	})
+
+	it("hides OpenRouter provider routing when no provider metadata is available", () => {
+		useOpenRouterModelProvidersMock.mockReturnValue({ data: {} })
+
+		renderApiOptions({
+			apiConfiguration: {
+				apiProvider: providerIdentifiers.openrouter,
+				openRouterModelId: "anthropic/claude-sonnet-4.5",
+			},
+		})
+
+		expect(screen.queryByTestId("routing-select")).not.toBeInTheDocument()
 	})
 
 	it("preserves the Bedrock custom ARN pseudo-model when switching to Bedrock", () => {
@@ -359,6 +482,18 @@ describe("ApiOptions interactions", () => {
 		)
 
 		expect(screen.queryByTestId("bedrock-custom-arn")).not.toBeInTheDocument()
+	})
+
+	it("syncs the selected model into the config when the model id differs", () => {
+		useSelectedModelMock.mockReturnValue({ provider: providerIdentifiers.anthropic, id: "claude-sonnet", info: {} })
+		const setApiConfigurationField = vi.fn()
+
+		renderApiOptions({
+			apiConfiguration: { apiProvider: providerIdentifiers.anthropic, apiModelId: "old-model" },
+			setApiConfigurationField,
+		})
+
+		expect(setApiConfigurationField).toHaveBeenCalledWith("apiModelId", "claude-sonnet", false)
 	})
 
 	it("updates the consecutive mistake limit from advanced settings", () => {


### PR DESCRIPTION
## Summary

- extract the `ApiOptions` provider identifier migration from #1141
- replace raw provider string comparisons with centralized `providerIdentifiers`
- add focused interaction coverage for dynamic model refresh, validation, provider routing, Bedrock custom ARN behavior, and advanced settings

## Test plan

- `cd webview-ui && npx vitest run src/components/settings/__tests__/ApiOptions.interactions.spec.tsx` (39 tests)
- `cd webview-ui && pnpm exec eslint --prune-suppressions --max-warnings=0 src/components/settings/ApiOptions.tsx src/components/settings/__tests__/ApiOptions.interactions.spec.tsx`
- repository pre-commit lint and type checks

Extracted from #1141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider-specific settings behavior, including model refreshes, URL handling, validation clearing, routing, and custom model configuration.
  * Standardized provider handling for more consistent model selection and advanced settings updates.
  * Preserved custom Bedrock model settings and reset invalid model selections appropriately.

* **Tests**
  * Added comprehensive coverage for dynamic provider interactions, model switching, validation, custom endpoints, provider-specific settings, and advanced configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->