### PR TITLE
refactor(webview): migrate provider identifiers in UI hooks

### DIFF
--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -19,12 +19,15 @@ import {
 	friendliDefaultModelId,
 	friendliModels,
 	deepSeekDefaultModelId,
+	deepSeekModels,
 	openRouterDefaultModelId,
 	vscodeLlmModels,
 	vscodeLlmDefaultModelId,
 	moonshotDefaultModelId,
 	moonshotModels,
 	kimiCodeDefaultModelInfo,
+	lMStudioDefaultModelInfo,
+	opencodeGoDefaultModelInfo,
 	providerIdentifiers,
 	retiredProviderIdentifiers,
 } from "@roo-code/types"
@@ -59,6 +62,8 @@ const createWrapper = () => {
 
 describe("useSelectedModel", () => {
 	beforeEach(() => {
+		mockUseLmStudioModels.mockClear()
+		mockUseOllamaModels.mockClear()
 		mockUseLmStudioModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
 		mockUseOllamaModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
 	})
@@ -113,6 +118,53 @@ describe("useSelectedModel", () => {
 		)
 
 		expect(result.current.id).toBe("configured-model")
+		if (provider === providerIdentifiers.lmstudio) {
+			expect(mockUseLmStudioModels).toHaveBeenCalledWith("configured-model")
+		} else {
+			expect(mockUseOllamaModels).toHaveBeenCalledWith("configured-model")
+		}
+	})
+
+	it.each([
+		[providerIdentifiers.lmstudio, "lmStudioModelId", lMStudioDefaultModelInfo],
+		[providerIdentifiers.ollama, "ollamaModelId", undefined],
+	] as const)("applies local model metadata for %s", (provider, modelIdKey, defaultInfo) => {
+		const modelId = "configured-model"
+		const modelInfo: ModelInfo = {
+			maxTokens: 12_000,
+			contextWindow: 100_000,
+			supportsImages: false,
+			supportsPromptCache: false,
+		}
+		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		if (provider === providerIdentifiers.lmstudio) {
+			mockUseLmStudioModels.mockReturnValue({
+				data: { [modelId]: modelInfo },
+				isLoading: false,
+				isError: false,
+			} as any)
+		} else {
+			mockUseOllamaModels.mockReturnValue({
+				data: { [modelId]: modelInfo },
+				isLoading: false,
+				isError: false,
+			} as any)
+		}
+
+		const apiConfiguration = {
+			apiProvider: provider,
+			[modelIdKey]: modelId,
+			...(provider === providerIdentifiers.ollama ? { ollamaNumCtx: 32_000 } : {}),
+		} as ProviderSettings
+		const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper: createWrapper() })
+
+		expect(result.current.id).toBe(modelId)
+		expect(result.current.info).toEqual(
+			provider === providerIdentifiers.lmstudio
+				? { ...defaultInfo, ...modelInfo }
+				: { ...modelInfo, contextWindow: 32_000 },
+		)
 	})
 
 	it("falls back to the OpenRouter default for a retired provider", () => {
@@ -124,6 +176,7 @@ describe("useSelectedModel", () => {
 		})
 
 		expect(result.current.id).toBe(openRouterDefaultModelId)
+		expect(result.current.info).toBeUndefined()
 	})
 
 	it("uses OpenCode Go default model information when the router catalog is empty", () => {
@@ -138,14 +191,14 @@ describe("useSelectedModel", () => {
 			wrapper: createWrapper(),
 		})
 
-		expect(result.current.info).toBeDefined()
+		expect(result.current.info).toEqual(opencodeGoDefaultModelInfo)
 	})
 
 	it.each([providerIdentifiers.deepseek, providerIdentifiers.moonshot])(
 		"prefers router data over static data for %s",
 		(provider) => {
 			const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
-			const modelId = provider === providerIdentifiers.deepseek ? deepSeekDefaultModelId : moonshotDefaultModelId
+			const modelId = provider === providerIdentifiers.deepseek ? "deepseek-v4-pro" : moonshotDefaultModelId
 			mockUseRouterModels.mockReturnValue({
 				data: { [provider]: { [modelId]: modelInfo } },
 				isLoading: false,
@@ -157,6 +210,7 @@ describe("useSelectedModel", () => {
 				wrapper: createWrapper(),
 			})
 
+			expect(result.current.id).toBe(modelId)
 			expect(result.current.info).toEqual(modelInfo)
 		},
 	)
@@ -177,7 +231,11 @@ describe("useSelectedModel", () => {
 			})
 
 			expect(result.current.id).toBe(modelId)
-			expect(result.current.info).toBeDefined()
+			if (provider === providerIdentifiers.deepseek) {
+				expect(result.current.info).toEqual(deepSeekModels[deepSeekDefaultModelId])
+			} else {
+				expect(result.current.info).toEqual(moonshotModels[modelId as keyof typeof moonshotModels])
+			}
 		},
 	)
 
@@ -1255,7 +1313,7 @@ describe("useSelectedModel", () => {
 			}
 
 			mockUseRouterModels.mockReturnValue({
-				data: { "kimi-code": { "kimi-for-coding": modelInfo } },
+				data: { [providerIdentifiers.kimiCode]: { "kimi-for-coding": modelInfo } },
 				isLoading: false,
 				isError: false,
 			} as any)

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -18,6 +18,7 @@ import {
 	minimaxModels,
 	friendliDefaultModelId,
 	friendliModels,
+	deepSeekDefaultModelId,
 	openRouterDefaultModelId,
 	vscodeLlmModels,
 	vscodeLlmDefaultModelId,
@@ -25,17 +26,24 @@ import {
 	moonshotModels,
 	kimiCodeDefaultModelInfo,
 	providerIdentifiers,
+	retiredProviderIdentifiers,
 } from "@roo-code/types"
 
 import { useSelectedModel } from "../useSelectedModel"
 import { useRouterModels } from "../useRouterModels"
 import { useOpenRouterModelProviders } from "../useOpenRouterModelProviders"
+import { useLmStudioModels } from "../useLmStudioModels"
+import { useOllamaModels } from "../useOllamaModels"
 
 vi.mock("../useRouterModels")
 vi.mock("../useOpenRouterModelProviders")
+vi.mock("../useLmStudioModels")
+vi.mock("../useOllamaModels")
 
 const mockUseRouterModels = useRouterModels as Mock<typeof useRouterModels>
 const mockUseOpenRouterModelProviders = useOpenRouterModelProviders as Mock<typeof useOpenRouterModelProviders>
+const mockUseLmStudioModels = useLmStudioModels as Mock<typeof useLmStudioModels>
+const mockUseOllamaModels = useOllamaModels as Mock<typeof useOllamaModels>
 
 const createWrapper = () => {
 	const queryClient = new QueryClient({
@@ -50,6 +58,146 @@ const createWrapper = () => {
 }
 
 describe("useSelectedModel", () => {
+	beforeEach(() => {
+		mockUseLmStudioModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseOllamaModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+	})
+
+	const dynamicProviderCases = [
+		[providerIdentifiers.requesty, "requestyModelId"],
+		[providerIdentifiers.unbound, "unboundModelId"],
+		[providerIdentifiers.vercelAiGateway, "vercelAiGatewayModelId"],
+		[providerIdentifiers.opencodeGo, "opencodeGoModelId"],
+		[providerIdentifiers.zooGateway, "zooGatewayModelId"],
+	] as const
+
+	it.each(dynamicProviderCases)("uses router data for %s", (provider, modelIdKey) => {
+		const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
+		mockUseRouterModels.mockReturnValue({
+			data: { [provider]: { model: modelInfo } },
+			isLoading: false,
+			isError: false,
+		} as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+		const apiConfiguration = {
+			apiProvider: provider,
+			[modelIdKey]: "model",
+		} as ProviderSettings
+		const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper: createWrapper() })
+
+		expect(result.current.id).toBe("model")
+		expect(result.current.info).toEqual(modelInfo)
+	})
+
+	it.each([
+		[providerIdentifiers.lmstudio, "lmStudioModelId"],
+		[providerIdentifiers.ollama, "ollamaModelId"],
+	] as const)("passes the configured model ID to the %s model hook", (provider, modelIdKey) => {
+		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseLmStudioModels.mockReturnValue({
+			data: { "configured-model": {} },
+			isLoading: false,
+			isError: false,
+		} as any)
+		mockUseOllamaModels.mockReturnValue({
+			data: { "configured-model": {} },
+			isLoading: false,
+			isError: false,
+		} as any)
+
+		const { result } = renderHook(
+			() => useSelectedModel({ apiProvider: provider, [modelIdKey]: "configured-model" }),
+			{ wrapper: createWrapper() },
+		)
+
+		expect(result.current.id).toBe("configured-model")
+	})
+
+	it("falls back to the OpenRouter default for a retired provider", () => {
+		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+		const { result } = renderHook(() => useSelectedModel({ apiProvider: retiredProviderIdentifiers.cerebras }), {
+			wrapper: createWrapper(),
+		})
+
+		expect(result.current.id).toBe(openRouterDefaultModelId)
+	})
+
+	it("uses OpenCode Go default model information when the router catalog is empty", () => {
+		mockUseRouterModels.mockReturnValue({
+			data: { [providerIdentifiers.opencodeGo]: {} },
+			isLoading: false,
+			isError: false,
+		} as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+		const { result } = renderHook(() => useSelectedModel({ apiProvider: providerIdentifiers.opencodeGo }), {
+			wrapper: createWrapper(),
+		})
+
+		expect(result.current.info).toBeDefined()
+	})
+
+	it.each([providerIdentifiers.deepseek, providerIdentifiers.moonshot])(
+		"prefers router data over static data for %s",
+		(provider) => {
+			const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
+			const modelId = provider === providerIdentifiers.deepseek ? deepSeekDefaultModelId : moonshotDefaultModelId
+			mockUseRouterModels.mockReturnValue({
+				data: { [provider]: { [modelId]: modelInfo } },
+				isLoading: false,
+				isError: false,
+			} as any)
+			mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+			const { result } = renderHook(() => useSelectedModel({ apiProvider: provider, apiModelId: modelId }), {
+				wrapper: createWrapper(),
+			})
+
+			expect(result.current.info).toEqual(modelInfo)
+		},
+	)
+
+	it.each([providerIdentifiers.deepseek, providerIdentifiers.moonshot])(
+		"falls back to static data when the %s router catalog is null",
+		(provider) => {
+			const modelId = provider === providerIdentifiers.deepseek ? deepSeekDefaultModelId : moonshotDefaultModelId
+			mockUseRouterModels.mockReturnValue({
+				data: { [provider]: null },
+				isLoading: false,
+				isError: false,
+			} as any)
+			mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+			const { result } = renderHook(() => useSelectedModel({ apiProvider: provider, apiModelId: modelId }), {
+				wrapper: createWrapper(),
+			})
+
+			expect(result.current.id).toBe(modelId)
+			expect(result.current.info).toBeDefined()
+		},
+	)
+
+	it("uses router data for Poe", () => {
+		const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
+		mockUseRouterModels.mockReturnValue({
+			data: { [providerIdentifiers.poe]: { model: modelInfo } },
+			isLoading: false,
+			isError: false,
+		} as any)
+		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+
+		const { result } = renderHook(
+			() => useSelectedModel({ apiProvider: providerIdentifiers.poe, apiModelId: "model" }),
+			{ wrapper: createWrapper() },
+		)
+
+		expect(result.current.info).toEqual(modelInfo)
+	})
+
 	describe("OpenRouter provider merging", () => {
 		it("should merge base model info with specific provider info when both exist", () => {
 			const baseModelInfo: ModelInfo = {
@@ -1081,6 +1229,25 @@ describe("useSelectedModel", () => {
 	})
 
 	describe("Kimi Code provider", () => {
+		it("should use the Kimi Code default while router models are loading and no model is configured", () => {
+			mockUseRouterModels.mockReturnValue({
+				data: undefined,
+				isLoading: true,
+				isError: false,
+			} as any)
+
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: providerIdentifiers.kimiCode,
+			}
+
+			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper: createWrapper() })
+
+			expect(result.current.provider).toBe(providerIdentifiers.kimiCode)
+			expect(result.current.id).toBe("kimi-for-coding")
+			expect(result.current.info).toEqual(kimiCodeDefaultModelInfo)
+			expect(result.current.isLoading).toBe(true)
+		})
+
 		it("should resolve the configured model from router models", () => {
 			const modelInfo: ModelInfo = {
 				...kimiCodeDefaultModelInfo,

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -8,6 +8,8 @@ import type { Mock } from "vitest"
 import {
 	ProviderSettings,
 	ModelInfo,
+	type ModelRecord,
+	type RouterModels,
 	anthropicModels,
 	BEDROCK_1M_CONTEXT_MODEL_IDS,
 	litellmDefaultModelInfo,
@@ -48,6 +50,32 @@ const mockUseOpenRouterModelProviders = useOpenRouterModelProviders as Mock<type
 const mockUseLmStudioModels = useLmStudioModels as Mock<typeof useLmStudioModels>
 const mockUseOllamaModels = useOllamaModels as Mock<typeof useOllamaModels>
 
+type TestRouterModels = Partial<Record<keyof RouterModels, ModelRecord | null>>
+type QueryResultOptions = { isLoading?: boolean; isError?: boolean }
+
+const createQueryResult = <TData>(data: TData, options: QueryResultOptions = {}) => ({
+	data,
+	isLoading: options.isLoading ?? false,
+	isError: options.isError ?? false,
+})
+
+// React Query exposes a discriminated union with additional runtime fields; these tests only need the stable query state fields.
+const createRouterModelsResult = (
+	data: TestRouterModels | undefined,
+	options?: QueryResultOptions,
+): ReturnType<typeof useRouterModels> => createQueryResult(data, options) as ReturnType<typeof useRouterModels>
+
+const createOpenRouterModelProvidersResult = (
+	data: Record<string, ModelInfo> | undefined,
+	options?: QueryResultOptions,
+): ReturnType<typeof useOpenRouterModelProviders> =>
+	createQueryResult(data, options) as ReturnType<typeof useOpenRouterModelProviders>
+
+const createLocalModelsResult = (
+	data: ModelRecord | undefined,
+	options?: QueryResultOptions,
+): ReturnType<typeof useLmStudioModels> => createQueryResult(data, options) as ReturnType<typeof useLmStudioModels>
+
 const createWrapper = () => {
 	const queryClient = new QueryClient({
 		defaultOptions: {
@@ -64,8 +92,8 @@ describe("useSelectedModel", () => {
 	beforeEach(() => {
 		mockUseLmStudioModels.mockClear()
 		mockUseOllamaModels.mockClear()
-		mockUseLmStudioModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
-		mockUseOllamaModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseLmStudioModels.mockReturnValue(createLocalModelsResult({}))
+		mockUseOllamaModels.mockReturnValue(createLocalModelsResult({}))
 	})
 
 	const dynamicProviderCases = [
@@ -75,15 +103,12 @@ describe("useSelectedModel", () => {
 		[providerIdentifiers.opencodeGo, "opencodeGoModelId"],
 		[providerIdentifiers.zooGateway, "zooGatewayModelId"],
 	] as const
+	const configuredModelInfo: ModelInfo = { contextWindow: 1, supportsPromptCache: false }
 
 	it.each(dynamicProviderCases)("uses router data for %s", (provider, modelIdKey) => {
 		const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
-		mockUseRouterModels.mockReturnValue({
-			data: { [provider]: { model: modelInfo } },
-			isLoading: false,
-			isError: false,
-		} as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseRouterModels.mockReturnValue(createRouterModelsResult({ [provider]: { model: modelInfo } }))
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 		const apiConfiguration = {
 			apiProvider: provider,
@@ -99,18 +124,10 @@ describe("useSelectedModel", () => {
 		[providerIdentifiers.lmstudio, "lmStudioModelId"],
 		[providerIdentifiers.ollama, "ollamaModelId"],
 	] as const)("passes the configured model ID to the %s model hook", (provider, modelIdKey) => {
-		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
-		mockUseLmStudioModels.mockReturnValue({
-			data: { "configured-model": {} },
-			isLoading: false,
-			isError: false,
-		} as any)
-		mockUseOllamaModels.mockReturnValue({
-			data: { "configured-model": {} },
-			isLoading: false,
-			isError: false,
-		} as any)
+		mockUseRouterModels.mockReturnValue(createRouterModelsResult({}))
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
+		mockUseLmStudioModels.mockReturnValue(createLocalModelsResult({ "configured-model": configuredModelInfo }))
+		mockUseOllamaModels.mockReturnValue(createLocalModelsResult({ "configured-model": configuredModelInfo }))
 
 		const { result } = renderHook(
 			() => useSelectedModel({ apiProvider: provider, [modelIdKey]: "configured-model" }),
@@ -136,20 +153,12 @@ describe("useSelectedModel", () => {
 			supportsImages: false,
 			supportsPromptCache: false,
 		}
-		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseRouterModels.mockReturnValue(createRouterModelsResult({}))
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 		if (provider === providerIdentifiers.lmstudio) {
-			mockUseLmStudioModels.mockReturnValue({
-				data: { [modelId]: modelInfo },
-				isLoading: false,
-				isError: false,
-			} as any)
+			mockUseLmStudioModels.mockReturnValue(createLocalModelsResult({ [modelId]: modelInfo }))
 		} else {
-			mockUseOllamaModels.mockReturnValue({
-				data: { [modelId]: modelInfo },
-				isLoading: false,
-				isError: false,
-			} as any)
+			mockUseOllamaModels.mockReturnValue(createLocalModelsResult({ [modelId]: modelInfo }))
 		}
 
 		const apiConfiguration = {
@@ -168,8 +177,8 @@ describe("useSelectedModel", () => {
 	})
 
 	it("falls back to the OpenRouter default for a retired provider", () => {
-		mockUseRouterModels.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseRouterModels.mockReturnValue(createRouterModelsResult({}))
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 		const { result } = renderHook(() => useSelectedModel({ apiProvider: retiredProviderIdentifiers.cerebras }), {
 			wrapper: createWrapper(),
@@ -180,12 +189,8 @@ describe("useSelectedModel", () => {
 	})
 
 	it("uses OpenCode Go default model information when the router catalog is empty", () => {
-		mockUseRouterModels.mockReturnValue({
-			data: { [providerIdentifiers.opencodeGo]: {} },
-			isLoading: false,
-			isError: false,
-		} as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseRouterModels.mockReturnValue(createRouterModelsResult({ [providerIdentifiers.opencodeGo]: {} }))
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 		const { result } = renderHook(() => useSelectedModel({ apiProvider: providerIdentifiers.opencodeGo }), {
 			wrapper: createWrapper(),
@@ -199,12 +204,8 @@ describe("useSelectedModel", () => {
 		(provider) => {
 			const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
 			const modelId = provider === providerIdentifiers.deepseek ? "deepseek-v4-pro" : moonshotDefaultModelId
-			mockUseRouterModels.mockReturnValue({
-				data: { [provider]: { [modelId]: modelInfo } },
-				isLoading: false,
-				isError: false,
-			} as any)
-			mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+			mockUseRouterModels.mockReturnValue(createRouterModelsResult({ [provider]: { [modelId]: modelInfo } }))
+			mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 			const { result } = renderHook(() => useSelectedModel({ apiProvider: provider, apiModelId: modelId }), {
 				wrapper: createWrapper(),
@@ -219,12 +220,8 @@ describe("useSelectedModel", () => {
 		"falls back to static data when the %s router catalog is null",
 		(provider) => {
 			const modelId = provider === providerIdentifiers.deepseek ? deepSeekDefaultModelId : moonshotDefaultModelId
-			mockUseRouterModels.mockReturnValue({
-				data: { [provider]: null },
-				isLoading: false,
-				isError: false,
-			} as any)
-			mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+			mockUseRouterModels.mockReturnValue(createRouterModelsResult({ [provider]: null }))
+			mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 			const { result } = renderHook(() => useSelectedModel({ apiProvider: provider, apiModelId: modelId }), {
 				wrapper: createWrapper(),
@@ -241,12 +238,10 @@ describe("useSelectedModel", () => {
 
 	it("uses router data for Poe", () => {
 		const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }
-		mockUseRouterModels.mockReturnValue({
-			data: { [providerIdentifiers.poe]: { model: modelInfo } },
-			isLoading: false,
-			isError: false,
-		} as any)
-		mockUseOpenRouterModelProviders.mockReturnValue({ data: {}, isLoading: false, isError: false } as any)
+		mockUseRouterModels.mockReturnValue(
+			createRouterModelsResult({ [providerIdentifiers.poe]: { model: modelInfo } }),
+		)
+		mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
 
 		const { result } = renderHook(
 			() => useSelectedModel({ apiProvider: providerIdentifiers.poe, apiModelId: "model" }),
@@ -1288,11 +1283,7 @@ describe("useSelectedModel", () => {
 
 	describe("Kimi Code provider", () => {
 		it("should use the Kimi Code default while router models are loading and no model is configured", () => {
-			mockUseRouterModels.mockReturnValue({
-				data: undefined,
-				isLoading: true,
-				isError: false,
-			} as any)
+			mockUseRouterModels.mockReturnValue(createRouterModelsResult(undefined, { isLoading: true }))
 
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: providerIdentifiers.kimiCode,
@@ -1312,11 +1303,9 @@ describe("useSelectedModel", () => {
 				description: "Configured Kimi Code model",
 			}
 
-			mockUseRouterModels.mockReturnValue({
-				data: { [providerIdentifiers.kimiCode]: { "kimi-for-coding": modelInfo } },
-				isLoading: false,
-				isError: false,
-			} as any)
+			mockUseRouterModels.mockReturnValue(
+				createRouterModelsResult({ [providerIdentifiers.kimiCode]: { "kimi-for-coding": modelInfo } }),
+			)
 
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: providerIdentifiers.kimiCode,

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -57,12 +57,14 @@ function getValidatedModelId(
 }
 
 export const useSelectedModel = (apiConfiguration?: ProviderSettings) => {
-	const provider = apiConfiguration?.apiProvider || "openrouter"
+	const provider = apiConfiguration?.apiProvider || providerIdentifiers.openrouter
 	const activeProvider: ProviderName | undefined = isRetiredProvider(provider) ? undefined : provider
 	const dynamicProvider = activeProvider && isDynamicProvider(activeProvider) ? activeProvider : undefined
-	const openRouterModelId = activeProvider === "openrouter" ? apiConfiguration?.openRouterModelId : undefined
-	const lmStudioModelId = activeProvider === "lmstudio" ? apiConfiguration?.lmStudioModelId : undefined
-	const ollamaModelId = activeProvider === "ollama" ? apiConfiguration?.ollamaModelId : undefined
+	const openRouterModelId =
+		activeProvider === providerIdentifiers.openrouter ? apiConfiguration?.openRouterModelId : undefined
+	const lmStudioModelId =
+		activeProvider === providerIdentifiers.lmstudio ? apiConfiguration?.lmStudioModelId : undefined
+	const ollamaModelId = activeProvider === providerIdentifiers.ollama ? apiConfiguration?.ollamaModelId : undefined
 
 	// Only fetch router models for dynamic providers
 	const shouldFetchRouterModels = !!dynamicProvider
@@ -77,7 +79,7 @@ export const useSelectedModel = (apiConfiguration?: ProviderSettings) => {
 
 	// Compute readiness only for the data actually needed for the selected provider
 	const needRouterModels = shouldFetchRouterModels
-	const needOpenRouterProviders = activeProvider === "openrouter"
+	const needOpenRouterProviders = activeProvider === providerIdentifiers.openrouter
 	const needLmStudio = typeof lmStudioModelId !== "undefined"
 	const needOllama = typeof ollamaModelId !== "undefined"
 
@@ -105,12 +107,12 @@ export const useSelectedModel = (apiConfiguration?: ProviderSettings) => {
 					lmStudioModels: (lmStudioModels.data || undefined) as ModelRecord | undefined,
 					ollamaModels: (ollamaModels.data || undefined) as ModelRecord | undefined,
 				})
-			: activeProvider === "kimi-code" && apiConfiguration
+			: activeProvider === providerIdentifiers.kimiCode && apiConfiguration
 				? {
-						id: apiConfiguration.apiModelId || getProviderDefaultModelId("kimi-code"),
+						id: apiConfiguration.apiModelId || getProviderDefaultModelId(providerIdentifiers.kimiCode),
 						info: kimiCodeDefaultModelInfo,
 					}
-				: { id: getProviderDefaultModelId(activeProvider ?? "openrouter"), info: undefined }
+				: { id: getProviderDefaultModelId(activeProvider ?? providerIdentifiers.openrouter), info: undefined }
 
 	return {
 		provider,
@@ -150,8 +152,12 @@ function getSelectedModel({
 	const defaultModelId = getProviderDefaultModelId(provider)
 	switch (provider) {
 		case providerIdentifiers.openrouter: {
-			const id = getValidatedModelId(apiConfiguration.openRouterModelId, routerModels.openrouter, defaultModelId)
-			let info = routerModels.openrouter?.[id]
+			const id = getValidatedModelId(
+				apiConfiguration.openRouterModelId,
+				routerModels[providerIdentifiers.openrouter],
+				defaultModelId,
+			)
+			let info = routerModels[providerIdentifiers.openrouter]?.[id]
 			const specificProvider = apiConfiguration.openRouterSpecificProvider
 
 			if (specificProvider && openRouterModelProviders[specificProvider]) {
@@ -166,13 +172,21 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case providerIdentifiers.requesty: {
-			const id = getValidatedModelId(apiConfiguration.requestyModelId, routerModels.requesty, defaultModelId)
-			const routerInfo = routerModels.requesty?.[id]
+			const id = getValidatedModelId(
+				apiConfiguration.requestyModelId,
+				routerModels[providerIdentifiers.requesty],
+				defaultModelId,
+			)
+			const routerInfo = routerModels[providerIdentifiers.requesty]?.[id]
 			return { id, info: routerInfo }
 		}
 		case providerIdentifiers.unbound: {
-			const id = getValidatedModelId(apiConfiguration.unboundModelId, routerModels.unbound, defaultModelId)
-			const routerInfo = routerModels.unbound?.[id]
+			const id = getValidatedModelId(
+				apiConfiguration.unboundModelId,
+				routerModels[providerIdentifiers.unbound],
+				defaultModelId,
+			)
+			const routerInfo = routerModels[providerIdentifiers.unbound]?.[id]
 			return { id, info: routerInfo }
 		}
 		case providerIdentifiers.litellm: {
@@ -181,11 +195,17 @@ function getSelectedModel({
 			// default model, so we never substitute a hardcoded default here -- when
 			// nothing is configured we return an empty ID so the picker shows "no
 			// selection" rather than a phantom model that does not exist on the server.
-			const hasModels = routerModels.litellm && Object.keys(routerModels.litellm).length > 0
+			const hasModels =
+				routerModels[providerIdentifiers.litellm] &&
+				Object.keys(routerModels[providerIdentifiers.litellm]).length > 0
 			const id = hasModels
-				? getValidatedModelId(apiConfiguration.litellmModelId, routerModels.litellm, defaultModelId)
+				? getValidatedModelId(
+						apiConfiguration.litellmModelId,
+						routerModels[providerIdentifiers.litellm],
+						defaultModelId,
+					)
 				: (apiConfiguration.litellmModelId ?? "")
-			const routerInfo = routerModels.litellm?.[id]
+			const routerInfo = routerModels[providerIdentifiers.litellm]?.[id]
 			return { id, info: routerInfo ?? litellmDefaultModelInfo }
 		}
 		case providerIdentifiers.xai: {
@@ -251,26 +271,26 @@ function getSelectedModel({
 			return { id, info }
 		}
 		case providerIdentifiers.deepseek: {
-			const availableModels = routerModels.deepseek
-				? { ...deepSeekModels, ...routerModels.deepseek }
+			const availableModels = routerModels[providerIdentifiers.deepseek]
+				? { ...deepSeekModels, ...routerModels[providerIdentifiers.deepseek] }
 				: deepSeekModels
 			const id = getValidatedModelId(apiConfiguration.apiModelId, availableModels, defaultModelId)
-			const routerInfo = routerModels.deepseek?.[id]
+			const routerInfo = routerModels[providerIdentifiers.deepseek]?.[id]
 			const staticInfo = deepSeekModels[id as keyof typeof deepSeekModels]
 			return { id, info: routerInfo ?? staticInfo }
 		}
 		case providerIdentifiers.moonshot: {
-			const availableModels = routerModels.moonshot
-				? { ...moonshotModels, ...routerModels.moonshot }
+			const availableModels = routerModels[providerIdentifiers.moonshot]
+				? { ...moonshotModels, ...routerModels[providerIdentifiers.moonshot] }
 				: moonshotModels
 			const id = getValidatedModelId(apiConfiguration.apiModelId, availableModels, defaultModelId)
-			const routerInfo = routerModels.moonshot?.[id]
+			const routerInfo = routerModels[providerIdentifiers.moonshot]?.[id]
 			const staticInfo = moonshotModels[id as keyof typeof moonshotModels]
 			return { id, info: routerInfo ?? staticInfo }
 		}
 		case providerIdentifiers.kimiCode: {
 			const configuredId = apiConfiguration.apiModelId
-			const availableModels = routerModels["kimi-code"]
+			const availableModels = routerModels[providerIdentifiers.kimiCode]
 			const id = configuredId || defaultModelId
 			return { id, info: availableModels?.[id] ?? kimiCodeDefaultModelInfo }
 		}
@@ -369,7 +389,7 @@ function getSelectedModel({
 		}
 		case providerIdentifiers.poe: {
 			const id = apiConfiguration.apiModelId ?? defaultModelId
-			const info = routerModels.poe?.[id]
+			const info = routerModels[providerIdentifiers.poe]?.[id]
 			return { id, info }
 		}
 		case providerIdentifiers.qwenCode: {
@@ -385,37 +405,41 @@ function getSelectedModel({
 		case providerIdentifiers.vercelAiGateway: {
 			const id = getValidatedModelId(
 				apiConfiguration.vercelAiGatewayModelId,
-				routerModels["vercel-ai-gateway"],
+				routerModels[providerIdentifiers.vercelAiGateway],
 				defaultModelId,
 			)
-			const info = routerModels["vercel-ai-gateway"]?.[id]
+			const info = routerModels[providerIdentifiers.vercelAiGateway]?.[id]
 			return { id, info }
 		}
 		case providerIdentifiers.opencodeGo: {
 			const id = getValidatedModelId(
 				apiConfiguration.opencodeGoModelId,
-				routerModels["opencode-go"],
+				routerModels[providerIdentifiers.opencodeGo],
 				defaultModelId,
 			)
 			// Fall back to the provider's default ModelInfo so capability-driven UI
 			// keeps working when the /models list is empty or unavailable.
-			const info = routerModels["opencode-go"]?.[id] ?? opencodeGoDefaultModelInfo
+			const info = routerModels[providerIdentifiers.opencodeGo]?.[id] ?? opencodeGoDefaultModelInfo
 			return { id, info }
 		}
 		case providerIdentifiers.kenari: {
-			const id = getValidatedModelId(apiConfiguration.kenariModelId, routerModels["kenari"], defaultModelId)
+			const id = getValidatedModelId(
+				apiConfiguration.kenariModelId,
+				routerModels[providerIdentifiers.kenari],
+				defaultModelId,
+			)
 			// Fall back to the provider's default ModelInfo so capability-driven UI
 			// keeps working when the /models list is empty or unavailable.
-			const info = routerModels["kenari"]?.[id] ?? kenariDefaultModelInfo
+			const info = routerModels[providerIdentifiers.kenari]?.[id] ?? kenariDefaultModelInfo
 			return { id, info }
 		}
 		case providerIdentifiers.zooGateway: {
 			const id = getValidatedModelId(
 				apiConfiguration.zooGatewayModelId,
-				routerModels["zoo-gateway"],
+				routerModels[providerIdentifiers.zooGateway],
 				defaultModelId,
 			)
-			const info = routerModels["zoo-gateway"]?.[id]
+			const info = routerModels[providerIdentifiers.zooGateway]?.[id]
 			return { id, info }
 		}
 		case providerIdentifiers.anthropic:

--- a/webview-ui/src/components/ui/hooks/useZooGatewayRouterModelsSync.ts
+++ b/webview-ui/src/components/ui/hooks/useZooGatewayRouterModelsSync.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 
-import type { ExtensionMessage, RouterModels } from "@roo-code/types"
+import { type ExtensionMessage, type RouterModels, providerIdentifiers } from "@roo-code/types"
 
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 
@@ -22,14 +22,14 @@ export function useZooGatewayRouterModelsSync() {
 		}
 
 		try {
-			const partial = await fetchRouterModels("zoo-gateway")
-			const zooModels = partial["zoo-gateway"]
+			const partial = await fetchRouterModels(providerIdentifiers.zooGateway)
+			const zooModels = partial[providerIdentifiers.zooGateway]
 			if (!zooModels || Object.keys(zooModels).length === 0) {
 				return
 			}
 
 			queryClient.setQueryData<RouterModels>(["routerModels", "all"], (current) =>
-				current ? { ...current, "zoo-gateway": zooModels } : partial,
+				current ? { ...current, [providerIdentifiers.zooGateway]: zooModels } : partial,
 			)
 		} catch {
 			// Ignore: bulk router fetch may still be in flight.


### PR DESCRIPTION
## Summary

Extracts the `webview-ui/src/components/ui/hooks` portion of #1141 into a focused pull request:

- canonicalizes provider checks and router-model keys in `useSelectedModel`
- canonicalizes Zoo Gateway router-model synchronization
- adds focused `useSelectedModel` coverage for dynamic, retired, local, and router-backed providers

These changes have been removed from #1141.

Related to #944.

## Validation

- repository pre-commit lint passed
- repository pre-push type checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection across supported providers, including DeepSeek, LM Studio, Ollama, OpenCode Go, Requesty, Unbound, Vercel AI Gateway, Zoo Gateway, and others.
  * Preserved configured model choices and improved fallback behavior when provider or router data is unavailable.
  * Corrected Kimi Code model resolution and default-model behavior while router information is loading.
  * Improved handling of local model metadata and retired provider configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->