### PR TITLE
feat(settings): add global hooks panel

### DIFF
--- a/packages/types/src/__tests__/hooks.test.ts
+++ b/packages/types/src/__tests__/hooks.test.ts
@@ -17,6 +17,7 @@ import {
 	type HookDefinition,
 } from "../hooks.js"
 import { clineMessageSchema, clineSaySchema } from "../message.js"
+import { GLOBAL_SETTINGS_KEYS, globalSettingsSchema } from "../global-settings.js"
 
 const encoder = new TextEncoder()
 
@@ -28,6 +29,14 @@ const sessionHook: HookDefinition = {
 	executable: "/usr/bin/env",
 	argv: ["node", "setup.js"],
 }
+
+describe("hook global settings", () => {
+	it("is optional, known, and accepts an explicit empty array", () => {
+		expect(globalSettingsSchema.parse({}).hookDefinitions).toBeUndefined()
+		expect(globalSettingsSchema.parse({ hookDefinitions: [] }).hookDefinitions).toEqual([])
+		expect(GLOBAL_SETTINGS_KEYS).toContain("hookDefinitions")
+	})
+})
 
 const preToolHook: HookDefinition = {
 	id: "pre-read",

--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { codebaseIndexConfigSchema, codebaseIndexModelsSchema } from "./codebase-index.js"
 import { experimentsSchema } from "./experiment.js"
 import { historyItemSchema } from "./history.js"
+import { hookDefinitionsSchema } from "./hooks.js"
 import { customModePromptsSchema, customSupportPromptsSchema, modeConfigSchema } from "./mode.js"
 import {
 	type ProviderSettings,
@@ -273,6 +274,7 @@ export const globalSettingsSchema = z.object({
 	 * Tools in this list will be excluded from prompt generation and rejected at execution time.
 	 */
 	disabledTools: z.array(toolNamesSchema).optional(),
+	hookDefinitions: hookDefinitionsSchema.optional(),
 })
 
 export type GlobalSettings = z.infer<typeof globalSettingsSchema>

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -322,6 +322,7 @@ export type ExtensionState = Pick<
 	| "requestDelaySeconds"
 	| "showWorktreesInHomeScreen"
 	| "disabledTools"
+	| "hookDefinitions"
 > & {
 	lockApiConfigAcrossModes?: boolean
 	version: string

--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -36,6 +36,7 @@ const globalSettingsExportSchema = globalSettingsSchema.omit({
 	taskHistory: true,
 	listApiConfigMeta: true,
 	currentApiConfigName: true,
+	hookDefinitions: true,
 })
 
 export class ContextProxy {

--- a/src/core/config/__tests__/ContextProxy.spec.ts
+++ b/src/core/config/__tests__/ContextProxy.spec.ts
@@ -150,6 +150,27 @@ describe("ContextProxy", () => {
 		})
 	})
 
+	describe("hook definitions", () => {
+		it("initializes, stores, and excludes hook definitions from export", async () => {
+			const definitions = [
+				{
+					id: "session-hook",
+					name: "Session hook",
+					enabled: false,
+					phase: "sessionStart" as const,
+					executable: "node",
+					argv: ["script.js"],
+				},
+			]
+
+			expect(mockGlobalState.get).toHaveBeenCalledWith("hookDefinitions")
+			await proxy.setValue("hookDefinitions", definitions)
+			expect(proxy.getValue("hookDefinitions")).toEqual(definitions)
+			expect(mockGlobalState.update).toHaveBeenCalledWith("hookDefinitions", definitions)
+			expect(await proxy.export()).not.toHaveProperty("hookDefinitions")
+		})
+	})
+
 	describe("updateGlobalState", () => {
 		it("should update state directly in original context", async () => {
 			await proxy.updateGlobalState("apiProvider", "deepseek")

--- a/src/core/config/__tests__/importExport.spec.ts
+++ b/src/core/config/__tests__/importExport.spec.ts
@@ -219,6 +219,42 @@ describe("importExport", () => {
 			])
 		})
 
+		it("does not install hook definitions from imported settings", async () => {
+			;(vscode.window.showOpenDialog as Mock).mockResolvedValue([{ fsPath: "/mock/path/settings.json" }])
+			;(fs.readFile as Mock).mockResolvedValue(
+				JSON.stringify({
+					providerProfiles: {
+						currentApiConfigName: "test",
+						apiConfigs: { test: { apiProvider: "openai", id: "test-id" } },
+					},
+					globalSettings: {
+						mode: "code",
+						hookDefinitions: [
+							{
+								id: "imported",
+								name: "Imported",
+								enabled: true,
+								phase: "sessionStart",
+								executable: "node",
+								argv: [],
+							},
+						],
+					},
+				}),
+			)
+			mockProviderSettingsManager.export.mockResolvedValue({ currentApiConfigName: "test", apiConfigs: {} })
+			mockProviderSettingsManager.listConfig.mockResolvedValue([])
+
+			const result = await importSettings({
+				providerSettingsManager: mockProviderSettingsManager,
+				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
+			})
+
+			expect(mockContextProxy.setValues).toHaveBeenCalledWith({ mode: "code" })
+			expect(result).toMatchObject({ success: true, warnings: [expect.stringContaining("cannot be imported")] })
+		})
+
 		it("should return success: false when file content is invalid", async () => {
 			;(vscode.window.showOpenDialog as Mock).mockResolvedValue([{ fsPath: "/mock/path/settings.json" }])
 

--- a/src/core/config/importExport.ts
+++ b/src/core/config/importExport.ts
@@ -97,6 +97,10 @@ function sanitizeGlobalSettings(rawGlobalSettings: unknown): {
 
 	for (const [key, rawValue] of Object.entries(rawGlobalSettings)) {
 		const path = `globalSettings.${key}`
+		if (key === "hookDefinitions") {
+			warnings.push(`Setting "${path}" was skipped: Hook definitions cannot be imported.`)
+			continue
+		}
 		const schema = globalSettingsShape[key as keyof GlobalSettings]
 
 		if (!schema) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -46,6 +46,7 @@ import {
 	DEFAULT_AUTO_CLOSE_ZOO_OPENED_FILES,
 	DEFAULT_AUTO_CLOSE_ZOO_OPENED_FILES_AFTER_USER_EDITED,
 	DEFAULT_AUTO_CLOSE_ZOO_OPENED_NEW_FILES,
+	DEFAULT_HOOK_DEFINITIONS,
 	ORGANIZATION_ALLOW_ALL,
 	DEFAULT_MODES,
 	DEFAULT_CHECKPOINT_TIMEOUT_SECONDS,
@@ -2389,6 +2390,7 @@ export class ClineProvider
 			autoCloseZooOpenedFiles,
 			autoCloseZooOpenedFilesAfterUserEdited,
 			autoCloseZooOpenedNewFiles,
+			hookDefinitions,
 		} = await this.getState()
 
 		let cloudOrganizations: CloudOrganizationMembership[] = []
@@ -2573,6 +2575,7 @@ export class ClineProvider
 			autoCloseZooOpenedFilesAfterUserEdited:
 				autoCloseZooOpenedFilesAfterUserEdited ?? DEFAULT_AUTO_CLOSE_ZOO_OPENED_FILES_AFTER_USER_EDITED,
 			autoCloseZooOpenedNewFiles: autoCloseZooOpenedNewFiles ?? DEFAULT_AUTO_CLOSE_ZOO_OPENED_NEW_FILES,
+			hookDefinitions: hookDefinitions ?? [...DEFAULT_HOOK_DEFINITIONS],
 			openAiCodexIsAuthenticated: await (async () => {
 				try {
 					const { openAiCodexOAuthManager } = await import("../../integrations/openai-codex/oauth")
@@ -2795,6 +2798,7 @@ export class ClineProvider
 			autoCloseZooOpenedFiles: stateValues.autoCloseZooOpenedFiles,
 			autoCloseZooOpenedFilesAfterUserEdited: stateValues.autoCloseZooOpenedFilesAfterUserEdited,
 			autoCloseZooOpenedNewFiles: stateValues.autoCloseZooOpenedNewFiles,
+			hookDefinitions: stateValues.hookDefinitions ?? [...DEFAULT_HOOK_DEFINITIONS],
 		}
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -1352,6 +1352,26 @@ describe("ClineProvider", () => {
 		expect((await provider.getState()).showRooIgnoredFiles).toBe(false)
 	})
 
+	test("returns persisted hook definitions and the shared empty default in both state stages", async () => {
+		expect((await provider.getState()).hookDefinitions).toEqual([])
+		expect((await provider.getStateToPostToWebview()).hookDefinitions).toEqual([])
+
+		const definitions = [
+			{
+				id: "session-hook",
+				name: "Session hook",
+				enabled: false,
+				phase: "sessionStart" as const,
+				executable: "node",
+				argv: ["script.js"],
+			},
+		]
+		await provider.contextProxy.setValue("hookDefinitions", definitions)
+
+		expect((await provider.getState()).hookDefinitions).toEqual(definitions)
+		expect((await provider.getStateToPostToWebview()).hookDefinitions).toEqual(definitions)
+	})
+
 	test("handles updatePrompt message correctly", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as any).mock.calls[0][0]

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -55,7 +55,7 @@ vi.mock("../rulesMessageHandler", () => ({
 	handleOpenRulesDirectory: vi.fn(),
 }))
 
-import type { ModelRecord } from "@roo-code/types"
+import type { ModelRecord, WebviewMessage } from "@roo-code/types"
 
 import { webviewMessageHandler } from "../webviewMessageHandler"
 import type { ClineProvider } from "../ClineProvider"
@@ -1216,12 +1216,15 @@ describe("webviewMessageHandler - hookDefinitions", () => {
 	})
 
 	it("rejects malformed phases and command values", async () => {
-		await webviewMessageHandler(mockClineProvider, {
+		// This test deliberately crosses the typed webview boundary with a malformed runtime payload.
+		const message = {
 			type: "updateSettings",
 			updatedSettings: {
-				hookDefinitions: [{ ...validHook, phase: "postToolUse", executable: " node " }] as any,
+				hookDefinitions: [{ ...validHook, phase: "postToolUse", executable: " node " }],
 			},
-		})
+		} as unknown as WebviewMessage
+
+		await webviewMessageHandler(mockClineProvider, message)
 
 		expect(mockClineProvider.contextProxy.setValue).not.toHaveBeenCalled()
 		expect(vscode.window.showErrorMessage).toHaveBeenCalled()

--- a/src/core/webview/__tests__/webviewMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.spec.ts
@@ -1173,6 +1173,71 @@ describe("webviewMessageHandler - destructiveCommandGuardEnabled", () => {
 	})
 })
 
+describe("webviewMessageHandler - hookDefinitions", () => {
+	const validHook = {
+		id: "session-hook",
+		name: "Session hook",
+		enabled: false,
+		phase: "sessionStart" as const,
+		executable: "node",
+		argv: ["script.js", " argument with spaces "],
+	}
+
+	beforeEach(() => vi.clearAllMocks())
+
+	it("persists the complete hook array without normalizing command fields", async () => {
+		await webviewMessageHandler(mockClineProvider, {
+			type: "updateSettings",
+			updatedSettings: { hookDefinitions: [validHook] },
+		})
+
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("hookDefinitions", [validHook])
+		expect(mockClineProvider.postStateToWebview).toHaveBeenCalledOnce()
+	})
+
+	it("persists an explicit empty array to clear hooks", async () => {
+		await webviewMessageHandler(mockClineProvider, {
+			type: "updateSettings",
+			updatedSettings: { hookDefinitions: [] },
+		})
+
+		expect(mockClineProvider.contextProxy.setValue).toHaveBeenCalledWith("hookDefinitions", [])
+	})
+
+	it("rejects duplicate definitions atomically before persisting other settings", async () => {
+		await webviewMessageHandler(mockClineProvider, {
+			type: "updateSettings",
+			updatedSettings: { language: "en", hookDefinitions: [validHook, validHook] },
+		})
+
+		expect(mockClineProvider.contextProxy.setValue).not.toHaveBeenCalled()
+		expect(mockClineProvider.postStateToWebview).not.toHaveBeenCalled()
+		expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("must be unique"))
+	})
+
+	it("rejects malformed phases and command values", async () => {
+		await webviewMessageHandler(mockClineProvider, {
+			type: "updateSettings",
+			updatedSettings: {
+				hookDefinitions: [{ ...validHook, phase: "postToolUse", executable: " node " }] as any,
+			},
+		})
+
+		expect(mockClineProvider.contextProxy.setValue).not.toHaveBeenCalled()
+		expect(vscode.window.showErrorMessage).toHaveBeenCalled()
+	})
+
+	it("rejects command fields that schema parsing would otherwise normalize", async () => {
+		await webviewMessageHandler(mockClineProvider, {
+			type: "updateSettings",
+			updatedSettings: { hookDefinitions: [{ ...validHook, executable: " node " }] },
+		})
+
+		expect(mockClineProvider.contextProxy.setValue).not.toHaveBeenCalled()
+		expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("valid as entered"))
+	})
+})
+
 describe("webviewMessageHandler - terminalProfile", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -23,6 +23,7 @@ import {
 	checkoutRestorePayloadSchema,
 	getCompletionCheckpoint,
 	providerIdentifiers,
+	hookDefinitionsSchema,
 } from "@roo-code/types"
 import { customToolRegistry } from "@roo-code/core"
 import { CloudService } from "@roo-code/cloud"
@@ -699,8 +700,49 @@ export const webviewMessageHandler = async (
 					}
 				}
 
+				let parsedHookDefinitions
+				if (Object.prototype.hasOwnProperty.call(message.updatedSettings, "hookDefinitions")) {
+					const result = hookDefinitionsSchema.safeParse(message.updatedSettings.hookDefinitions)
+					if (!result.success) {
+						const details = result.error.issues
+							.map((issue) => `${issue.path.join(".") || "hookDefinitions"}: ${issue.message}`)
+							.join(", ")
+						await vscode.window.showErrorMessage(`Hook settings were not saved: ${details}`)
+						break
+					}
+					const hasNormalizedOrUnsupportedFields = result.data.some((definition, index) => {
+						const raw = (message.updatedSettings?.hookDefinitions as unknown[])[index] as Record<
+							string,
+							unknown
+						>
+						const allowedKeys = new Set([
+							"id",
+							"name",
+							"enabled",
+							"phase",
+							"executable",
+							"argv",
+							...(definition.phase === "preToolUse" ? ["toolMatcher"] : []),
+						])
+						return (
+							Object.keys(raw).some((key) => !allowedKeys.has(key)) ||
+							raw.name !== definition.name ||
+							raw.executable !== definition.executable ||
+							JSON.stringify(raw.argv) !== JSON.stringify(definition.argv) ||
+							JSON.stringify(raw.toolMatcher) !== JSON.stringify(definition.toolMatcher)
+						)
+					})
+					if (hasNormalizedOrUnsupportedFields) {
+						await vscode.window.showErrorMessage(
+							"Hook settings were not saved: command fields must be valid as entered and unsupported fields are not allowed.",
+						)
+						break
+					}
+					parsedHookDefinitions = result.data
+				}
+
 				for (const [key, value] of Object.entries(message.updatedSettings)) {
-					let newValue = value
+					let newValue = key === "hookDefinitions" ? parsedHookDefinitions : value
 
 					if (key === "language") {
 						newValue = value ?? "en"

--- a/webview-ui/src/components/settings/HooksSettings.tsx
+++ b/webview-ui/src/components/settings/HooksSettings.tsx
@@ -1,0 +1,396 @@
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { Cable, Edit, Globe, Plus, Trash2, TriangleAlert, X } from "lucide-react"
+
+import {
+	hookDefinitionSchema,
+	hookDefinitionsSchema,
+	toolNames,
+	type HookDefinition,
+	type HookPhase,
+	type ToolName,
+} from "@roo-code/types"
+
+import { useAppTranslation } from "@/i18n/TranslationContext"
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	Button,
+	Checkbox,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	StandardTooltip,
+} from "@/components/ui"
+
+import { SearchableSetting } from "./SearchableSetting"
+import { SectionHeader } from "./SectionHeader"
+
+type HookDraft = {
+	id: string
+	name: string
+	enabled: boolean
+	phase: HookPhase
+	toolMatcher: ToolName[]
+	executable: string
+	argv: string[]
+}
+
+type HooksSettingsProps = {
+	hookDefinitions: HookDefinition[]
+	onChange: (definitions: HookDefinition[]) => void
+	setErrorMessage: (message: string | undefined) => void
+}
+
+const createDraft = (): HookDraft => ({
+	id: crypto.randomUUID(),
+	name: "",
+	enabled: false,
+	phase: "sessionStart",
+	toolMatcher: [],
+	executable: "",
+	argv: [],
+})
+
+const toDefinition = (draft: HookDraft): unknown =>
+	draft.phase === "preToolUse"
+		? { ...draft, toolMatcher: draft.toolMatcher }
+		: {
+				id: draft.id,
+				name: draft.name,
+				enabled: draft.enabled,
+				phase: draft.phase,
+				executable: draft.executable,
+				argv: draft.argv,
+			}
+
+export const HooksSettings: React.FC<HooksSettingsProps> = ({ hookDefinitions, onChange, setErrorMessage }) => {
+	const { t } = useAppTranslation()
+	const [editorOpen, setEditorOpen] = useState(false)
+	const [draft, setDraft] = useState<HookDraft>(createDraft)
+	const [editingId, setEditingId] = useState<string>()
+	const [deleteId, setDeleteId] = useState<string>()
+	const ownsError = useRef(false)
+
+	const draftResult = useMemo(() => hookDefinitionSchema.safeParse(toDefinition(draft)), [draft])
+	const draftIsExact =
+		draftResult.success && draftResult.data.name === draft.name && draftResult.data.executable === draft.executable
+	const definitionsResult = useMemo(() => hookDefinitionsSchema.safeParse(hookDefinitions), [hookDefinitions])
+	const validationMessage = !definitionsResult.success
+		? definitionsResult.error.issues[0]?.message
+		: editorOpen && !draftIsExact
+			? draftResult.success
+				? "Name and executable must not have leading or trailing whitespace"
+				: draftResult.error.issues[0]?.message
+			: undefined
+
+	useEffect(() => {
+		if (validationMessage) {
+			ownsError.current = true
+			setErrorMessage(t("settings:hooks.validation.invalid", { message: validationMessage }))
+		} else if (ownsError.current) {
+			ownsError.current = false
+			setErrorMessage(undefined)
+		}
+	}, [setErrorMessage, t, validationMessage])
+
+	useEffect(
+		() => () => {
+			if (ownsError.current) setErrorMessage(undefined)
+		},
+		[setErrorMessage],
+	)
+
+	const openAdd = () => {
+		setEditingId(undefined)
+		setDraft(createDraft())
+		setEditorOpen(true)
+	}
+
+	const openEdit = (definition: HookDefinition) => {
+		setEditingId(definition.id)
+		setDraft({
+			...definition,
+			toolMatcher: definition.phase === "preToolUse" ? [...definition.toolMatcher] : [],
+			argv: [...definition.argv],
+		})
+		setEditorOpen(true)
+	}
+
+	const saveDraft = () => {
+		if (!draftResult.success || !draftIsExact) return
+		const definition = draftResult.data
+		onChange(
+			editingId
+				? hookDefinitions.map((item) => (item.id === editingId ? definition : item))
+				: [...hookDefinitions, definition],
+		)
+		setEditorOpen(false)
+	}
+
+	const toggleTool = (tool: ToolName, checked: boolean) => {
+		setDraft((current) => ({
+			...current,
+			toolMatcher: checked ? [...current.toolMatcher, tool] : current.toolMatcher.filter((item) => item !== tool),
+		}))
+	}
+
+	return (
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex-shrink-0">
+				<SectionHeader>{t("settings:sections.hooks")}</SectionHeader>
+				<div className="flex flex-col gap-3 px-5 py-2">
+					<SearchableSetting
+						settingId="hooks-overview"
+						section="hooks"
+						label={t("settings:hooks.description")}>
+						<p className="text-vscode-descriptionForeground text-sm m-0">
+							{t("settings:hooks.description")}
+						</p>
+					</SearchableSetting>
+					<SearchableSetting
+						settingId="hooks-security"
+						section="hooks"
+						label={t("settings:hooks.securityWarning")}>
+						<div className="flex gap-2 rounded border border-vscode-inputValidation-warningBorder bg-vscode-inputValidation-warningBackground p-2 text-sm">
+							<TriangleAlert className="size-4 shrink-0 mt-0.5" />
+							<span>{t("settings:hooks.securityWarning")}</span>
+						</div>
+					</SearchableSetting>
+					<Button variant="secondary" className="py-1" onClick={openAdd} data-testid="add-hook">
+						<Plus />
+						{t("settings:hooks.add")}
+					</Button>
+				</div>
+			</div>
+
+			<SearchableSetting
+				settingId="hooks-definitions"
+				section="hooks"
+				label={t("settings:hooks.search.definitions")}
+				className="flex-1 overflow-y-auto px-4 py-2 min-h-0">
+				<div className="flex items-center gap-2 px-2 py-2 mt-2">
+					<Globe className="size-4 shrink-0" />
+					<span className="font-medium text-lg">{t("settings:hooks.global")}</span>
+				</div>
+				{hookDefinitions.length === 0 ? (
+					<div className="px-2 pb-4 text-sm text-vscode-descriptionForeground">
+						{t("settings:hooks.empty")}
+					</div>
+				) : (
+					hookDefinitions.map((definition) => (
+						<div key={definition.id} className="p-2.5 px-2 rounded-xl border border-transparent">
+							<div className="flex items-start justify-between gap-2 flex-col min-[400px]:flex-row overflow-hidden">
+								<div className="flex-1 min-w-0">
+									<div className="flex items-center gap-2 overflow-hidden">
+										<span className="font-medium truncate">{definition.name}</span>
+										<span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-vscode-badge-background text-vscode-badge-foreground shrink-0">
+											{t(`settings:hooks.phase.${definition.phase}`)}
+										</span>
+										<span className="text-xs text-vscode-descriptionForeground shrink-0">
+											{definition.enabled
+												? t("settings:hooks.enabled")
+												: t("settings:hooks.disabled")}
+										</span>
+									</div>
+									{definition.phase === "preToolUse" && (
+										<div className="text-xs text-vscode-descriptionForeground mt-1 truncate">
+											{definition.toolMatcher.join(", ")}
+										</div>
+									)}
+									<div className="text-xs text-vscode-descriptionForeground mt-1 truncate font-mono">
+										{[definition.executable, ...definition.argv].join(" ")}
+									</div>
+								</div>
+								<div className="flex items-center gap-1 flex-shrink-0">
+									<StandardTooltip content={t("settings:hooks.edit")}>
+										<Button variant="ghost" size="icon" onClick={() => openEdit(definition)}>
+											<Edit />
+										</Button>
+									</StandardTooltip>
+									<StandardTooltip content={t("settings:hooks.delete")}>
+										<Button variant="ghost" size="icon" onClick={() => setDeleteId(definition.id)}>
+											<Trash2 className="text-destructive" />
+										</Button>
+									</StandardTooltip>
+								</div>
+							</div>
+						</div>
+					))
+				)}
+			</SearchableSetting>
+
+			<SearchableSetting
+				settingId="hooks-command-format"
+				section="hooks"
+				label={t("settings:hooks.search.commandFormat")}>
+				<div className="px-6 py-1 text-sm border-t border-vscode-panel-border text-muted-foreground flex items-center gap-2">
+					<Cable className="size-3.5 shrink-0" />
+					<span>{t("settings:hooks.footer")}</span>
+				</div>
+			</SearchableSetting>
+
+			<Dialog open={editorOpen} onOpenChange={setEditorOpen}>
+				<DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+					<DialogHeader>
+						<DialogTitle>
+							{editingId ? t("settings:hooks.dialog.editTitle") : t("settings:hooks.dialog.addTitle")}
+						</DialogTitle>
+						<DialogDescription>{t("settings:hooks.dialog.description")}</DialogDescription>
+					</DialogHeader>
+					<div className="flex flex-col gap-4">
+						<label className="flex flex-col gap-1">
+							<span>{t("settings:hooks.fields.name")}</span>
+							<Input
+								value={draft.name}
+								onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+								data-testid="hook-name"
+							/>
+						</label>
+						<label className="flex flex-col gap-1">
+							<span>{t("settings:hooks.fields.phase")}</span>
+							<Select
+								value={draft.phase}
+								onValueChange={(phase: HookPhase) => setDraft({ ...draft, phase })}>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="sessionStart">
+										{t("settings:hooks.phase.sessionStart")}
+									</SelectItem>
+									<SelectItem value="preToolUse">{t("settings:hooks.phase.preToolUse")}</SelectItem>
+								</SelectContent>
+							</Select>
+						</label>
+						{draft.phase === "preToolUse" && (
+							<fieldset className="flex flex-col gap-1 border-0 p-0 m-0">
+								<legend>{t("settings:hooks.fields.tools")}</legend>
+								<p className="text-xs text-vscode-descriptionForeground m-0">
+									{t("settings:hooks.fields.toolsHint")}
+								</p>
+								<div className="grid grid-cols-2 gap-1 max-h-40 overflow-y-auto">
+									{toolNames.map((tool) => (
+										<label key={tool} className="flex items-center gap-2 font-mono text-xs">
+											<Checkbox
+												checked={draft.toolMatcher.includes(tool)}
+												onCheckedChange={(checked) => toggleTool(tool, checked === true)}
+											/>
+											{tool}
+										</label>
+									))}
+								</div>
+							</fieldset>
+						)}
+						<label className="flex flex-col gap-1">
+							<span>{t("settings:hooks.fields.executable")}</span>
+							<Input
+								value={draft.executable}
+								onChange={(event) => setDraft({ ...draft, executable: event.target.value })}
+								data-testid="hook-executable"
+							/>
+							<span className="text-xs text-vscode-descriptionForeground">
+								{t("settings:hooks.fields.executableHint")}
+							</span>
+						</label>
+						<fieldset className="flex flex-col gap-2 border-0 p-0 m-0">
+							<legend>{t("settings:hooks.fields.arguments")}</legend>
+							<p className="text-xs text-vscode-descriptionForeground m-0">
+								{t("settings:hooks.fields.argumentsHint")}
+							</p>
+							{draft.argv.map((argument, index) => (
+								<div key={index} className="flex gap-1">
+									<Input
+										className="font-mono flex-1"
+										value={argument}
+										aria-label={t("settings:hooks.fields.argument", { number: index + 1 })}
+										onChange={(event) =>
+											setDraft({
+												...draft,
+												argv: draft.argv.map((item, itemIndex) =>
+													itemIndex === index ? event.target.value : item,
+												),
+											})
+										}
+									/>
+									<Button
+										variant="ghost"
+										size="icon"
+										onClick={() =>
+											setDraft({
+												...draft,
+												argv: draft.argv.filter((_, itemIndex) => itemIndex !== index),
+											})
+										}>
+										<X />
+									</Button>
+								</div>
+							))}
+							<Button
+								variant="secondary"
+								onClick={() => setDraft({ ...draft, argv: [...draft.argv, ""] })}>
+								{t("settings:hooks.fields.addArgument")}
+							</Button>
+						</fieldset>
+						<label className="flex items-center gap-2">
+							<Checkbox
+								checked={draft.enabled}
+								onCheckedChange={(checked) => setDraft({ ...draft, enabled: checked === true })}
+								data-testid="hook-enabled"
+							/>
+							{t("settings:hooks.fields.enabled")}
+						</label>
+						{validationMessage && (
+							<p className="text-vscode-errorForeground text-sm m-0" role="alert">
+								{t("settings:hooks.validation.invalid", { message: validationMessage })}
+							</p>
+						)}
+					</div>
+					<DialogFooter>
+						<Button variant="secondary" onClick={() => setEditorOpen(false)}>
+							{t("settings:common.cancel")}
+						</Button>
+						<Button onClick={saveDraft} disabled={!draftIsExact} data-testid="save-hook">
+							{editingId ? t("settings:hooks.dialog.update") : t("settings:hooks.dialog.add")}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog open={Boolean(deleteId)} onOpenChange={(open) => !open && setDeleteId(undefined)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>{t("settings:hooks.deleteDialog.title")}</AlertDialogTitle>
+						<AlertDialogDescription>{t("settings:hooks.deleteDialog.description")}</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel onClick={() => setDeleteId(undefined)}>
+							{t("settings:common.cancel")}
+						</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								onChange(hookDefinitions.filter(({ id }) => id !== deleteId))
+								setDeleteId(undefined)
+							}}>
+							{t("settings:hooks.delete")}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	)
+}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -29,6 +29,7 @@ import {
 	GitCommitVertical,
 	GraduationCap,
 	ScrollText,
+	Cable,
 } from "lucide-react"
 
 import {
@@ -81,6 +82,7 @@ import PromptsSettings from "./PromptsSettings"
 import { SlashCommandsSettings } from "./SlashCommandsSettings"
 import { SkillsSettings } from "./SkillsSettings"
 import { RulesSettings } from "./RulesSettings"
+import { HooksSettings } from "./HooksSettings"
 import { UISettings } from "./UISettings"
 import ModesView from "../modes/ModesView"
 import McpView from "../mcp/McpView"
@@ -105,6 +107,7 @@ export const sectionNames = [
 	"slashCommands",
 	"skills",
 	"rules",
+	"hooks",
 	"checkpoints",
 	"notifications",
 	"contextManagement",
@@ -217,6 +220,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 		autoCloseZooOpenedFiles,
 		autoCloseZooOpenedFilesAfterUserEdited,
 		autoCloseZooOpenedNewFiles,
+		hookDefinitions,
 	} = cachedState
 
 	const apiConfiguration = useMemo(() => cachedState.apiConfiguration ?? {}, [cachedState.apiConfiguration])
@@ -448,6 +452,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 					openRouterImageGenerationSelectedModel,
 					experiments,
 					customSupportPrompts,
+					hookDefinitions: hookDefinitions ?? [],
 				},
 			})
 
@@ -539,6 +544,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			{ id: "skills", icon: GraduationCap },
 			{ id: "slashCommands", icon: SquareSlash },
 			{ id: "rules", icon: ScrollText },
+			{ id: "hooks", icon: Cable },
 			{ id: "autoApprove", icon: CheckCheck },
 			{ id: "mcp", icon: Server },
 			{ id: "checkpoints", icon: GitCommitVertical },
@@ -835,6 +841,15 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 
 						{/* Rules Section */}
 						{renderTab === "rules" && <RulesSettings />}
+
+						{/* Hooks Section */}
+						{renderTab === "hooks" && (
+							<HooksSettings
+								hookDefinitions={hookDefinitions ?? []}
+								onChange={(definitions) => setCachedStateField("hookDefinitions", definitions)}
+								setErrorMessage={setErrorMessage}
+							/>
+						)}
 
 						{/* Checkpoints Section */}
 						{renderTab === "checkpoints" && (

--- a/webview-ui/src/components/settings/__tests__/HooksSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/HooksSettings.spec.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+
+import { fireEvent, render, screen } from "@/utils/test-utils"
+
+import { HooksSettings } from "../HooksSettings"
+
+vi.mock("@/components/ui", () => ({
+	Button: ({ children, onClick, disabled, ...props }: any) => (
+		<button onClick={onClick} disabled={disabled} {...props}>
+			{children}
+		</button>
+	),
+	Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+		<input
+			type="checkbox"
+			checked={checked}
+			onChange={(event) => onCheckedChange(event.target.checked)}
+			{...props}
+		/>
+	),
+	Input: (props: any) => <input {...props} />,
+	StandardTooltip: ({ children }: any) => children,
+	Dialog: ({ children, open }: any) => (open ? <div data-testid="hook-dialog">{children}</div> : null),
+	DialogContent: ({ children }: any) => <div>{children}</div>,
+	DialogDescription: ({ children }: any) => <p>{children}</p>,
+	DialogFooter: ({ children }: any) => <div>{children}</div>,
+	DialogHeader: ({ children }: any) => <div>{children}</div>,
+	DialogTitle: ({ children }: any) => <h2>{children}</h2>,
+	Select: ({ children, value, onValueChange }: any) => (
+		<select value={value} onChange={(event) => onValueChange(event.target.value)}>
+			{children}
+		</select>
+	),
+	SelectContent: ({ children }: any) => <>{children}</>,
+	SelectItem: ({ children, value }: any) => <option value={value}>{children}</option>,
+	SelectTrigger: ({ children }: any) => <>{children}</>,
+	SelectValue: () => null,
+	AlertDialog: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+	AlertDialogAction: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+	AlertDialogCancel: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+	AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+	AlertDialogDescription: ({ children }: any) => <p>{children}</p>,
+	AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+	AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+	AlertDialogTitle: ({ children }: any) => <h2>{children}</h2>,
+}))
+
+describe("HooksSettings", () => {
+	beforeEach(() => {
+		vi.stubGlobal("crypto", { randomUUID: () => "new-hook-id" })
+	})
+
+	afterEach(() => vi.unstubAllGlobals())
+
+	it("creates a disabled hook and preserves exact argv boundaries", () => {
+		const onChange = vi.fn()
+		render(<HooksSettings hookDefinitions={[]} onChange={onChange} setErrorMessage={vi.fn()} />)
+
+		fireEvent.click(screen.getByTestId("add-hook"))
+		expect(screen.getByTestId("hook-enabled")).not.toBeChecked()
+		fireEvent.change(screen.getByTestId("hook-name"), { target: { value: "Load context" } })
+		fireEvent.change(screen.getByTestId("hook-executable"), { target: { value: "node" } })
+		fireEvent.click(screen.getByText("settings:hooks.fields.addArgument"))
+		fireEvent.change(screen.getByLabelText("settings:hooks.fields.argument"), {
+			target: { value: " argument with spaces " },
+		})
+		fireEvent.click(screen.getByTestId("save-hook"))
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				id: "new-hook-id",
+				name: "Load context",
+				enabled: false,
+				phase: "sessionStart",
+				executable: "node",
+				argv: [" argument with spaces "],
+			},
+		])
+	})
+
+	it("requires exact tool selection for before-tool hooks", () => {
+		const setErrorMessage = vi.fn()
+		render(<HooksSettings hookDefinitions={[]} onChange={vi.fn()} setErrorMessage={setErrorMessage} />)
+		fireEvent.click(screen.getByTestId("add-hook"))
+		fireEvent.change(screen.getByTestId("hook-name"), { target: { value: "Guard edits" } })
+		fireEvent.change(screen.getByTestId("hook-executable"), { target: { value: "guard" } })
+		fireEvent.change(screen.getByRole("combobox"), { target: { value: "preToolUse" } })
+
+		expect(screen.getByTestId("save-hook")).toBeDisabled()
+		fireEvent.click(screen.getByLabelText("apply_diff"))
+		expect(screen.getByTestId("save-hook")).toBeEnabled()
+		expect(setErrorMessage).toHaveBeenCalledWith("settings:hooks.validation.invalid")
+	})
+})

--- a/webview-ui/src/components/settings/__tests__/HooksSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/HooksSettings.spec.tsx
@@ -1,5 +1,7 @@
 import React from "react"
 
+import type { HookDefinition } from "@roo-code/types"
+
 import { fireEvent, render, screen } from "@/utils/test-utils"
 
 import { HooksSettings } from "../HooksSettings"
@@ -19,7 +21,12 @@ vi.mock("@/components/ui", () => ({
 		/>
 	),
 	Input: (props: any) => <input {...props} />,
-	StandardTooltip: ({ children }: any) => children,
+	StandardTooltip: ({ children, content }: any) => (
+		<div>
+			<span>{content}</span>
+			{children}
+		</div>
+	),
 	Dialog: ({ children, open }: any) => (open ? <div data-testid="hook-dialog">{children}</div> : null),
 	DialogContent: ({ children }: any) => <div>{children}</div>,
 	DialogDescription: ({ children }: any) => <p>{children}</p>,
@@ -46,6 +53,31 @@ vi.mock("@/components/ui", () => ({
 }))
 
 describe("HooksSettings", () => {
+	const sessionHook: HookDefinition = {
+		id: "session-hook",
+		name: "Session context",
+		enabled: true,
+		phase: "sessionStart",
+		executable: "node",
+		argv: ["context.js"],
+	}
+
+	const preToolHook: HookDefinition = {
+		id: "pre-tool-hook",
+		name: "Guard edits",
+		enabled: true,
+		phase: "preToolUse",
+		toolMatcher: ["apply_diff"],
+		executable: "guard",
+		argv: [],
+	}
+
+	const getTooltipButton = (label: string): HTMLButtonElement => {
+		const button = screen.getByText(label).parentElement?.querySelector("button")
+		if (!(button instanceof HTMLButtonElement)) throw new Error(`Missing tooltip button: ${label}`)
+		return button
+	}
+
 	beforeEach(() => {
 		vi.stubGlobal("crypto", { randomUUID: () => "new-hook-id" })
 	})
@@ -90,5 +122,83 @@ describe("HooksSettings", () => {
 		fireEvent.click(screen.getByLabelText("apply_diff"))
 		expect(screen.getByTestId("save-hook")).toBeEnabled()
 		expect(setErrorMessage).toHaveBeenCalledWith("settings:hooks.validation.invalid")
+	})
+
+	it("edits a hook and updates exact tool and argument selections", () => {
+		const onChange = vi.fn()
+		render(<HooksSettings hookDefinitions={[preToolHook]} onChange={onChange} setErrorMessage={vi.fn()} />)
+
+		fireEvent.click(getTooltipButton("settings:hooks.edit"))
+		fireEvent.change(screen.getByTestId("hook-name"), { target: { value: "Guard reads" } })
+		fireEvent.click(screen.getByLabelText("apply_diff"))
+		expect(screen.getByTestId("save-hook")).toBeDisabled()
+		fireEvent.click(screen.getByLabelText("read_file"))
+		fireEvent.click(screen.getByText("settings:hooks.fields.addArgument"))
+		fireEvent.change(screen.getByLabelText("settings:hooks.fields.argument"), {
+			target: { value: "--strict" },
+		})
+		fireEvent.click(screen.getByTestId("save-hook"))
+
+		expect(onChange).toHaveBeenCalledWith([
+			{
+				...preToolHook,
+				name: "Guard reads",
+				toolMatcher: ["read_file"],
+				argv: ["--strict"],
+			},
+		])
+	})
+
+	it("removes an existing argument while editing", () => {
+		const onChange = vi.fn()
+		render(<HooksSettings hookDefinitions={[sessionHook]} onChange={onChange} setErrorMessage={vi.fn()} />)
+
+		fireEvent.click(getTooltipButton("settings:hooks.edit"))
+		const argument = screen.getByLabelText("settings:hooks.fields.argument")
+		const removeButton = argument.parentElement?.querySelector("button")
+		if (!(removeButton instanceof HTMLButtonElement)) throw new Error("Missing remove-argument button")
+		fireEvent.click(removeButton)
+		fireEvent.click(screen.getByTestId("save-hook"))
+
+		expect(onChange).toHaveBeenCalledWith([{ ...sessionHook, argv: [] }])
+	})
+
+	it("deletes an existing hook after confirmation", () => {
+		const onChange = vi.fn()
+		render(<HooksSettings hookDefinitions={[sessionHook]} onChange={onChange} setErrorMessage={vi.fn()} />)
+
+		fireEvent.click(getTooltipButton("settings:hooks.delete"))
+		fireEvent.click(screen.getByRole("button", { name: "settings:hooks.delete" }))
+
+		expect(onChange).toHaveBeenCalledWith([])
+	})
+
+	it("rejects normalized command fields and clears its error when cancelled", () => {
+		const setErrorMessage = vi.fn()
+		render(<HooksSettings hookDefinitions={[]} onChange={vi.fn()} setErrorMessage={setErrorMessage} />)
+
+		fireEvent.click(screen.getByTestId("add-hook"))
+		fireEvent.change(screen.getByTestId("hook-name"), { target: { value: " Invalid name " } })
+		fireEvent.change(screen.getByTestId("hook-executable"), { target: { value: "node" } })
+
+		expect(screen.getByRole("alert")).toHaveTextContent("settings:hooks.validation.invalid")
+		expect(screen.getByTestId("save-hook")).toBeDisabled()
+		fireEvent.click(screen.getByRole("button", { name: "settings:common.cancel" }))
+
+		expect(screen.queryByTestId("hook-dialog")).not.toBeInTheDocument()
+		expect(setErrorMessage).toHaveBeenLastCalledWith(undefined)
+	})
+
+	it("clears an owned validation error when unmounted", () => {
+		const setErrorMessage = vi.fn()
+		const { unmount } = render(
+			<HooksSettings hookDefinitions={[]} onChange={vi.fn()} setErrorMessage={setErrorMessage} />,
+		)
+
+		fireEvent.click(screen.getByTestId("add-hook"))
+		expect(setErrorMessage).toHaveBeenCalledWith("settings:hooks.validation.invalid")
+		unmount()
+
+		expect(setErrorMessage).toHaveBeenLastCalledWith(undefined)
 	})
 })

--- a/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx
@@ -21,6 +21,34 @@ vi.mock("../ApiConfigManager", () => ({
 	),
 }))
 
+vi.mock("../HooksSettings", () => ({
+	HooksSettings: ({ hookDefinitions, onChange }: any) => (
+		<div data-testid="hooks-settings">
+			<span data-testid="hook-count">{hookDefinitions.length}</span>
+			<button
+				data-testid="add-cached-hook"
+				onClick={() =>
+					onChange([
+						...hookDefinitions,
+						{
+							id: "new-hook",
+							name: "New hook",
+							enabled: false,
+							phase: "sessionStart",
+							executable: "node",
+							argv: [],
+						},
+					])
+				}>
+				Add cached hook
+			</button>
+			<button data-testid="clear-cached-hooks" onClick={() => onChange([])}>
+				Clear cached hooks
+			</button>
+		</div>
+	),
+}))
+
 vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 	VSCodeButton: ({ children, onClick, appearance, "data-testid": dataTestId }: any) =>
 		appearance === "icon" ? (
@@ -571,6 +599,65 @@ describe("SettingsView - Sound Settings", () => {
 				}),
 			}),
 		)
+	})
+})
+
+describe("SettingsView - Hooks Settings", () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it("keeps hook edits cached until Save and includes the complete array", () => {
+		const { activateTab, getSettingsContent } = renderSettingsView({ hookDefinitions: [] })
+		activateTab("hooks")
+
+		fireEvent.click(within(getSettingsContent()).getByTestId("add-cached-hook"))
+		expect(vscode.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "updateSettings" }))
+
+		fireEvent.click(screen.getByTestId("save-button"))
+		expect(vscode.postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({
+					hookDefinitions: [expect.objectContaining({ id: "new-hook", enabled: false })],
+				}),
+			}),
+		)
+	})
+
+	it("sends an explicit empty array when clearing hooks", () => {
+		const { activateTab, getSettingsContent } = renderSettingsView({
+			currentApiConfigName: "hooks-profile",
+			hookDefinitions: [
+				{
+					id: "existing",
+					name: "Existing",
+					enabled: false,
+					phase: "sessionStart",
+					executable: "node",
+					argv: [],
+				},
+			],
+		})
+		activateTab("hooks")
+
+		fireEvent.click(within(getSettingsContent()).getByTestId("clear-cached-hooks"))
+		fireEvent.click(screen.getByTestId("save-button"))
+
+		expect(vscode.postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "updateSettings",
+				updatedSettings: expect.objectContaining({ hookDefinitions: [] }),
+			}),
+		)
+	})
+
+	it("does not overwrite dirty hook edits on ordinary extension-state pushes", () => {
+		const { activateTab, getSettingsContent } = renderSettingsView({ hookDefinitions: [] })
+		activateTab("hooks")
+		fireEvent.click(within(getSettingsContent()).getByTestId("add-cached-hook"))
+
+		act(() => mockPostMessage({ hookDefinitions: [] }))
+
+		expect(within(getSettingsContent()).getByTestId("hook-count")).toHaveTextContent("1")
 	})
 })
 

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Descartar canvis"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Proveïdors",
 		"modes": "Modes",
 		"mcp": "Servidors MCP",
@@ -43,6 +44,49 @@
 		"about": "Sobre Zoo Code",
 		"skills": "Skills",
 		"rules": "Regles"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Änderungen verwerfen"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Anbieter",
 		"modes": "Modi",
 		"mcp": "MCP-Server",
@@ -43,6 +44,49 @@
 		"about": "Über Zoo Code",
 		"skills": "Skills",
 		"rules": "Regeln"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -38,11 +38,60 @@
 		"terminal": "Terminal",
 		"slashCommands": "Slash Commands",
 		"rules": "Rules",
+		"hooks": "Hooks",
 		"prompts": "Prompts",
 		"ui": "UI",
 		"experimental": "Experimental",
 		"language": "Language",
 		"about": "About Zoo Code"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": {
+			"sessionStart": "Session start",
+			"preToolUse": "Before tool use"
+		},
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": {
+			"invalid": "Invalid hook definition: {{message}}"
+		}
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Descartar cambios"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Proveedores",
 		"modes": "Modos",
 		"mcp": "Servidores MCP",
@@ -43,6 +44,49 @@
 		"about": "Acerca de Zoo Code",
 		"skills": "Skills",
 		"rules": "Reglas"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Ignorer les modifications"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Fournisseurs",
 		"modes": "Modes",
 		"mcp": "Serveurs MCP",
@@ -43,6 +44,49 @@
 		"about": "À propos de Zoo Code",
 		"skills": "Skills",
 		"rules": "Règles"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "परिवर्तन छोड़ें"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "प्रदाता",
 		"modes": "मोड",
 		"mcp": "एमसीपी सर्वर",
@@ -43,6 +44,49 @@
 		"about": "परिचय",
 		"skills": "Skills",
 		"rules": "नियम"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Buang perubahan"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Provider",
 		"modes": "Mode",
 		"mcp": "Server MCP",
@@ -43,6 +44,49 @@
 		"about": "Tentang Zoo Code",
 		"skills": "Skills",
 		"rules": "Aturan"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Scarta modifiche"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Fornitori",
 		"modes": "Modalità",
 		"mcp": "Server MCP",
@@ -43,6 +44,49 @@
 		"about": "Informazioni su Zoo Code",
 		"skills": "Skills",
 		"rules": "Regole"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "変更を破棄"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "プロバイダー",
 		"modes": "モード",
 		"mcp": "MCPサーバー",
@@ -43,6 +44,49 @@
 		"about": "Zoo Codeについて",
 		"skills": "Skills",
 		"rules": "ルール"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "변경 사항 버리기"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "공급자",
 		"modes": "모드",
 		"mcp": "MCP 서버",
@@ -43,6 +44,49 @@
 		"about": "Zoo Code 정보",
 		"skills": "Skills",
 		"rules": "규칙"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Wijzigingen negeren"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Providers",
 		"modes": "Modi",
 		"mcp": "MCP-servers",
@@ -43,6 +44,49 @@
 		"about": "Over Zoo Code",
 		"skills": "Skills",
 		"rules": "Regels"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Odrzuć zmiany"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Dostawcy",
 		"modes": "Tryby",
 		"mcp": "Serwery MCP",
@@ -43,6 +44,49 @@
 		"about": "O Zoo Code",
 		"skills": "Skills",
 		"rules": "Reguły"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Descartar alterações"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Provedores",
 		"modes": "Modos",
 		"mcp": "Servidores MCP",
@@ -43,6 +44,49 @@
 		"about": "Sobre",
 		"skills": "Skills",
 		"rules": "Regras"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Отменить изменения"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Провайдеры",
 		"modes": "Режимы",
 		"mcp": "Серверы MCP",
@@ -43,6 +44,49 @@
 		"about": "О Zoo Code",
 		"skills": "Skills",
 		"rules": "Правила"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Değişiklikleri At"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Sağlayıcılar",
 		"modes": "Modlar",
 		"mcp": "MCP Sunucuları",
@@ -43,6 +44,49 @@
 		"about": "Zoo Code Hakkında",
 		"skills": "Skills",
 		"rules": "Kurallar"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "Hủy thay đổi"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "Nhà cung cấp",
 		"modes": "Chế độ",
 		"mcp": "Máy chủ MCP",
@@ -43,6 +44,49 @@
 		"about": "Giới thiệu",
 		"skills": "Skills",
 		"rules": "Quy tắc"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "放弃更改"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "提供商",
 		"modes": "模式",
 		"mcp": "MCP 服务",
@@ -43,6 +44,49 @@
 		"about": "关于 Zoo Code",
 		"skills": "Skills",
 		"rules": "规则"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -26,6 +26,7 @@
 		"discardButton": "取消變更"
 	},
 	"sections": {
+		"hooks": "Hooks",
 		"providers": "供應商",
 		"modes": "模式",
 		"mcp": "MCP 伺服器",
@@ -43,6 +44,49 @@
 		"about": "關於 Zoo Code",
 		"skills": "Skills",
 		"rules": "規則"
+	},
+	"hooks": {
+		"description": "Configure global lifecycle hooks. Definitions are saved only when you use the Settings Save button.",
+		"securityWarning": "Enabled hooks execute trusted code on the VS Code extension host at the task workspace cwd and are not sandboxed.",
+		"add": "Add hook",
+		"edit": "Edit hook",
+		"delete": "Delete hook",
+		"global": "Global hooks",
+		"empty": "No hooks configured. Session start hooks run at task start; before-tool hooks match exact tool names. Execution is unavailable until hook runner support is added.",
+		"enabled": "Enabled",
+		"disabled": "Disabled",
+		"footer": "Commands use a fixed 10-second timeout. Executable and argument boundaries are preserved exactly.",
+		"phase": { "sessionStart": "Session start", "preToolUse": "Before tool use" },
+		"search": {
+			"definitions": "Enabled hooks, phases, and exact tool matching",
+			"commandFormat": "Executable, exact arguments, and fixed timeout"
+		},
+		"fields": {
+			"name": "Name",
+			"phase": "Phase",
+			"tools": "Exact tool matches",
+			"toolsHint": "Select one or more exact tool names. This applies only before tool use.",
+			"executable": "Executable",
+			"executableHint": "Enter only the executable path or name, without shell syntax or arguments.",
+			"arguments": "Arguments",
+			"argumentsHint": "Each row is passed as exactly one argv value. Empty rows are empty arguments.",
+			"argument": "Argument {{number}}",
+			"addArgument": "Add argument",
+			"enabled": "Enabled"
+		},
+		"dialog": {
+			"addTitle": "Add hook",
+			"editTitle": "Edit hook",
+			"description": "Hook changes remain local until you save Settings. New hooks are disabled by default.",
+			"add": "Add",
+			"update": "Update"
+		},
+		"deleteDialog": {
+			"title": "Delete hook",
+			"description": "Delete this hook from the pending settings changes?",
+			"confirm": "Delete"
+		},
+		"validation": { "invalid": "Invalid hook definition: {{message}}" }
 	},
 	"about": {
 		"bugReport": {


### PR DESCRIPTION
## Stack

This is **2 of 4** in the Zoo Code hooks MVP stack. Review and merge from the bottom upward. Do not merge this PR until [#1153](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1153) is merged.

| Position | Pull request | Base | Scope |
| --- | --- | --- | --- |
| 1 | [#1153](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1153) | `main` | Hook contracts and policies |
| **2 (this PR)** | [#1154](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1154) | `fm/zoo-hooks-contracts` | Global settings and Hooks panel |
| 3 | [#1156](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1156) | `fm/zoo-hooks-settings` | Runner and `sessionStart` integration |
| 4 | [#1155](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1155) | `fm/zoo-hooks-session-start` | `preToolUse`, E2E, and documentation |

## Summary

Add the complete persisted-settings round trip and a dedicated Hooks settings panel, while keeping unsaved edits isolated in `SettingsView.cachedState`.

## Scope

- Add `hookDefinitions` to global settings, extension state, `ContextProxy`, and `ClineProvider` state returned to the webview.
- Validate updates atomically in `webviewMessageHandler`; malformed definitions are rejected without partially persisting data.
- Exclude executable hook configuration from settings import/export because commands are machine-local and security-sensitive.
- Add a searchable, deep-linkable Hooks panel for adding, editing, enabling, disabling, and removing definitions.
- Bind all controls to local `cachedState` and persist only through the existing explicit Save flow.
- Add localized settings copy for every supported locale.
- Test schema persistence, webview round trips, malformed payload rejection, import/export exclusion, and cached-state UI behavior.

## Settings Flow

```mermaid
flowchart LR
    A[Hooks panel controls] --> B[SettingsView cachedState]
    B -->|Save| C[updateSettings message]
    C --> D[Atomic schema validation]
    D -->|valid| E[ContextProxy persistence]
    D -->|invalid| F[Localized error, no write]
    E --> G[ClineProvider state]
    G --> H[Webview refresh]
    H --> B
```

## Tests

- `packages/types/src/__tests__/hooks.test.ts`
- `src/core/config/__tests__/ContextProxy.spec.ts`
- `src/core/config/__tests__/importExport.spec.ts`
- `src/core/webview/__tests__/ClineProvider.spec.ts`
- `src/core/webview/__tests__/webviewMessageHandler.spec.ts`
- `webview-ui/src/components/settings/__tests__/HooksSettings.spec.tsx`
- `webview-ui/src/components/settings/__tests__/SettingsView.spec.tsx`
- Focused settings coverage validation: 29 tests passed; `HooksSettings.tsx` reached 95.08% line coverage.
- Full stack validation at the top branch: `pnpm test` (437 files passed, 7,356 tests passed, 39 skipped).
- Full stack validation at the top branch: `pnpm check-types`, `pnpm lint`, and `pnpm build` passed.
- Full stack VS Code smoke validation: `USE_MOCK=true TEST_FILE=hooks.test pnpm --filter @roo-code/vscode-e2e test:run` passed.

## Risks

- Hook commands can execute local programs, so import/export intentionally does not transport them between machines.
- Settings controls must remain bound to `cachedState`; binding them to live extension state would reintroduce save races and discarded edits.
- Atomic validation rejects the entire hook list if any entry is malformed. This favors predictable persisted state over partial recovery.
- Localization touches every supported settings locale, but only adds the new Hooks namespace content.

## Review Notes

- The unique diff is against `fm/zoo-hooks-contracts`, not `main`.
- Additive follow-up `8089b3c4a` fixes the malformed-payload test type and expands panel interaction coverage; no published history was rewritten.
- No hook process is executed in this layer.
- No changeset is included, per repository guidance.
- Merge order is `#1153` -> `#1154` -> `#1156` -> `#1155`.
