### PR TITLE
fix(kimi-code): correct maxTokens defaults and add server-side override

### DIFF
--- a/packages/types/src/providers/kimi-code.ts
+++ b/packages/types/src/providers/kimi-code.ts
@@ -7,13 +7,20 @@ export const kimiCodeReasoningEfforts = ["low", "high", "max"] as const
 
 export const kimiCodeDefaultModelInfo: ModelInfo = {
 	contextWindow: 262_144,
-	maxTokens: 32_768,
+	maxTokens: 131_072,
 	supportsImages: false,
 	supportsPromptCache: false,
 	supportsReasoningEffort: [...kimiCodeReasoningEfforts],
 	requiredReasoningEffort: true,
 	reasoningEffort: "max",
 	description: "Kimi Code's coding model for subscription and API-key access.",
+}
+
+export const kimiCodeModelDefaults: Record<string, { maxTokens: number }> = {
+	k3: { maxTokens: 131_072 },
+	"k3-256k": { maxTokens: 131_072 },
+	"kimi-for-coding": { maxTokens: 131_072 },
+	"kimi-for-coding-highspeed": { maxTokens: 131_072 },
 }
 
 export const kimiCodeModels = {

--- a/src/api/providers/fetchers/__tests__/kimi-code.spec.ts
+++ b/src/api/providers/fetchers/__tests__/kimi-code.spec.ts
@@ -1,6 +1,4 @@
-import { kimiCodeDefaultModelInfo, kimiCodeModelDefaults } from "@roo-code/types"
-
-import { getKimiCodeModels, mapKimiCodeModel } from "../kimi-code"
+import { getKimiCodeModels, kimiCodeModelSchema, mapKimiCodeModel } from "../kimi-code"
 
 describe("Kimi Code model discovery", () => {
 	beforeEach(() => vi.restoreAllMocks())
@@ -121,15 +119,35 @@ describe("Kimi Code model discovery", () => {
 		expect(models["kimi-for-coding"].maxTokens).toBe(200_000)
 	})
 
-	it("falls back to per-model defaults from kimiCodeModelDefaults", () => {
-		for (const [modelId, defaults] of Object.entries(kimiCodeModelDefaults)) {
+	it("falls back to per-model defaults for known model ids", () => {
+		const expected: Record<string, number> = {
+			k3: 131_072,
+			"k3-256k": 131_072,
+			"kimi-for-coding": 131_072,
+			"kimi-for-coding-highspeed": 131_072,
+		}
+		for (const [modelId, maxTokens] of Object.entries(expected)) {
 			const mapped = mapKimiCodeModel({ id: modelId })
-			expect(mapped.maxTokens).toBe(defaults.maxTokens)
+			expect(mapped.maxTokens).toBe(maxTokens)
 		}
 	})
 
 	it("falls back to kimiCodeDefaultModelInfo.maxTokens for unknown model ids", () => {
 		const mapped = mapKimiCodeModel({ id: "unknown-model" })
-		expect(mapped.maxTokens).toBe(kimiCodeDefaultModelInfo.maxTokens)
+		expect(mapped.maxTokens).toBe(131_072)
+	})
+
+	it("rejects fractional max_tokens from server response", () => {
+		const mapped = mapKimiCodeModel({
+			id: "kimi-for-coding",
+			max_tokens: 131072.5,
+		})
+		// Zod .int() would reject at schema level, but mapKimiCodeModel receives
+		// already-parsed data. Verify the schema rejects fractional values.
+		const result = kimiCodeModelSchema.safeParse({
+			id: "kimi-for-coding",
+			max_tokens: 131072.5,
+		})
+		expect(result.success).toBe(false)
 	})
 })

--- a/src/api/providers/fetchers/__tests__/kimi-code.spec.ts
+++ b/src/api/providers/fetchers/__tests__/kimi-code.spec.ts
@@ -1,3 +1,5 @@
+import { kimiCodeDefaultModelInfo, kimiCodeModelDefaults } from "@roo-code/types"
+
 import { getKimiCodeModels, mapKimiCodeModel } from "../kimi-code"
 
 describe("Kimi Code model discovery", () => {
@@ -96,5 +98,38 @@ describe("Kimi Code model discovery", () => {
 		await result
 		expect(vi.mocked(fetch).mock.calls[0][1]?.signal?.aborted).toBe(true)
 		expect(vi.getTimerCount()).toBe(0)
+	})
+
+	it("overrides maxTokens from server max_tokens in mapKimiCodeModel", () => {
+		const mapped = mapKimiCodeModel({
+			id: "kimi-for-coding",
+			max_tokens: 200_000,
+		})
+		expect(mapped.maxTokens).toBe(200_000)
+	})
+
+	it("overrides maxTokens from server max_tokens at fetcher level in getKimiCodeModels", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					data: [{ id: "kimi-for-coding", context_length: 262144, max_tokens: 200_000 }],
+				}),
+				{ status: 200 },
+			),
+		)
+		const models = await getKimiCodeModels("token")
+		expect(models["kimi-for-coding"].maxTokens).toBe(200_000)
+	})
+
+	it("falls back to per-model defaults from kimiCodeModelDefaults", () => {
+		for (const [modelId, defaults] of Object.entries(kimiCodeModelDefaults)) {
+			const mapped = mapKimiCodeModel({ id: modelId })
+			expect(mapped.maxTokens).toBe(defaults.maxTokens)
+		}
+	})
+
+	it("falls back to kimiCodeDefaultModelInfo.maxTokens for unknown model ids", () => {
+		const mapped = mapKimiCodeModel({ id: "unknown-model" })
+		expect(mapped.maxTokens).toBe(kimiCodeDefaultModelInfo.maxTokens)
 	})
 })

--- a/src/api/providers/fetchers/kimi-code.ts
+++ b/src/api/providers/fetchers/kimi-code.ts
@@ -9,10 +9,10 @@ import {
 	type ModelRecord,
 } from "@roo-code/types"
 
-const kimiCodeModelSchema = z.object({
+export const kimiCodeModelSchema = z.object({
 	id: z.string().min(1),
 	context_length: z.number().positive().optional(),
-	max_tokens: z.number().positive().optional(),
+	max_tokens: z.number().int().positive().optional(),
 	supports_reasoning: z.boolean().optional(),
 	supports_image_in: z.boolean().optional(),
 	display_name: z.string().optional(),

--- a/src/api/providers/fetchers/kimi-code.ts
+++ b/src/api/providers/fetchers/kimi-code.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import {
 	KIMI_CODE_BASE_URL,
 	kimiCodeDefaultModelInfo,
+	kimiCodeModelDefaults,
 	kimiCodeReasoningEfforts,
 	type ModelInfo,
 	type ModelRecord,
@@ -11,6 +12,7 @@ import {
 const kimiCodeModelSchema = z.object({
 	id: z.string().min(1),
 	context_length: z.number().positive().optional(),
+	max_tokens: z.number().positive().optional(),
 	supports_reasoning: z.boolean().optional(),
 	supports_image_in: z.boolean().optional(),
 	display_name: z.string().optional(),
@@ -22,9 +24,11 @@ const KIMI_CODE_MODELS_TIMEOUT_MS = 10_000
 
 export function mapKimiCodeModel(model: z.infer<typeof kimiCodeModelSchema>): ModelInfo {
 	const supportsReasoning = model.supports_reasoning ?? false
+	const defaults = kimiCodeModelDefaults[model.id] ?? {}
 	return {
 		...kimiCodeDefaultModelInfo,
 		contextWindow: model.context_length ?? kimiCodeDefaultModelInfo.contextWindow,
+		maxTokens: model.max_tokens ?? defaults.maxTokens ?? kimiCodeDefaultModelInfo.maxTokens,
 		supportsReasoningEffort: supportsReasoning ? [...kimiCodeReasoningEfforts] : false,
 		requiredReasoningEffort: supportsReasoning,
 		reasoningEffort: supportsReasoning ? "max" : undefined,


### PR DESCRIPTION
## Summary

Fixes #1215

Kimi Code OAuth provider displayed incorrect **Max Output** values (32,768) for all models. According to [Kimi's official documentation](https://www.kimi.com/help/kimi-api/api-troubleshooting), the correct default for `kimi-k3` is **131,072**.

### Root Cause

Three issues in the codebase:

1. `kimiCodeDefaultModelInfo.maxTokens` was hardcoded to `32_768` instead of `131_072`
2. The Zod schema for `/models` API response didn't include `max_tokens` field (silently stripped)
3. `mapKimiCodeModel()` overrode `contextWindow` from server but not `maxTokens`

### Changes (3 files, +47/-1)

| File | Change |
|---|---|
| `packages/types/src/providers/kimi-code.ts` | Update `maxTokens` to `131_072`, add `kimiCodeModelDefaults` for per-model fallback |
| `src/api/providers/fetchers/kimi-code.ts` | Add `max_tokens` to Zod schema, override in `mapKimiCodeModel()` |
| `src/api/providers/fetchers/__tests__/kimi-code.spec.ts` | Add 4 tests for maxTokens override and fallback |

### Fallback Chain

```
maxTokens = server.max_tokens
         ?? kimiCodeModelDefaults[model.id].maxTokens
         ?? kimiCodeDefaultModelInfo.maxTokens (131,072)
```

This ensures automatic updates when the server provides `max_tokens`, with per-model and global fallbacks.

### Verification

- Vitest: 11/11 passed (7 existing + 4 new)
- ESLint: clean
- TypeScript: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum token capacity for supported Kimi Code models to 131,072 tokens.
  * Added model-specific token limits for improved handling of available models.
  * Added support for reading token limits provided by the Kimi Code service.

* **Bug Fixes**
  * Kimi Code now prioritizes server-provided limits, followed by model-specific and global defaults.
  * Invalid fractional token limits are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->