### PR TITLE
fix: update deepseek-v4-pro reasoning efforts and mappings

### DIFF
--- a/packages/types/src/providers/deepseek.ts
+++ b/packages/types/src/providers/deepseek.ts
@@ -14,14 +14,14 @@ export const deepSeekModels = {
 		contextWindow: 1_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
-		supportsReasoningEffort: ["disable", "low", "high", "max"], // Updated 2026-08-01
+		supportsReasoningEffort: ["disable", "low", "high", "max"], // Updated 2026-08-13
 		preserveReasoning: true,
 		reasoningEffort: "high",
 		inputPrice: 0, // the inputs are priced as cache read/write, so `inputPrice` should be 0
-		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-01
-		outputPrice: 0.28, // $0.28 per million tokens - Updated 2026-08-01
-		cacheWritesPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated 2026-08-01
-		cacheReadsPrice: 0.0028, // $0.0028 per million tokens (cache hit) - Updated 2026-08-01
+		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-13
+		outputPrice: 0.28, // $0.28 per million tokens - Updated 2026-08-13
+		cacheWritesPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated 2026-08-13
+		cacheReadsPrice: 0.0028, // $0.0028 per million tokens (cache hit) - Updated 2026-08-13
 		description: `DeepSeek-V4-Flash is DeepSeek's fast, cost-efficient V4 model. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
 	},
 	"deepseek-v4-pro": {
@@ -29,14 +29,14 @@ export const deepSeekModels = {
 		contextWindow: 1_000_000,
 		supportsImages: true,
 		supportsPromptCache: true,
-		supportsReasoningEffort: ["disable", "high", "max"], // Updated 2026-08-01
+		supportsReasoningEffort: ["disable", "low", "high", "max"], // Updated 2026-08-13
 		preserveReasoning: true,
 		reasoningEffort: "high",
 		inputPrice: 0, // the inputs are priced as cache read/write, so `inputPrice` should be 0
-		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-01
-		outputPrice: 0.87, // $0.87 per million tokens - Updated 2026-08-01
-		cacheWritesPrice: 0.435, // $0.435 per million tokens (cache miss) - Updated 2026-08-01
-		cacheReadsPrice: 0.003625, // $0.003625 per million tokens (cache hit) - Updated 2026-08-01
+		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-13
+		outputPrice: 0.87, // $0.87 per million tokens - Updated 2026-08-13
+		cacheWritesPrice: 0.435, // $0.435 per million tokens (cache miss) - Updated 2026-08-13
+		cacheReadsPrice: 0.003625, // $0.003625 per million tokens (cache hit) - Updated 2026-08-13
 		description: `DeepSeek-V4-Pro is DeepSeek's strongest V4 model for reasoning, coding, long-context, and agentic workloads. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
 	},
 } as const satisfies Record<string, ModelInfo>

--- a/packages/types/src/providers/deepseek.ts
+++ b/packages/types/src/providers/deepseek.ts
@@ -18,10 +18,10 @@ export const deepSeekModels = {
 		preserveReasoning: true,
 		reasoningEffort: "high",
 		inputPrice: 0, // the inputs are priced as cache read/write, so `inputPrice` should be 0
-		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-13
-		outputPrice: 0.28, // $0.28 per million tokens - Updated 2026-08-13
-		cacheWritesPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated 2026-08-13
-		cacheReadsPrice: 0.0028, // $0.0028 per million tokens (cache hit) - Updated 2026-08-13
+		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-01
+		outputPrice: 0.28, // $0.28 per million tokens - Updated 2026-08-01
+		cacheWritesPrice: 0.14, // $0.14 per million tokens (cache miss) - Updated 2026-08-01
+		cacheReadsPrice: 0.0028, // $0.0028 per million tokens (cache hit) - Updated 2026-08-01
 		description: `DeepSeek-V4-Flash is DeepSeek's fast, cost-efficient V4 model. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
 	},
 	"deepseek-v4-pro": {
@@ -33,10 +33,10 @@ export const deepSeekModels = {
 		preserveReasoning: true,
 		reasoningEffort: "high",
 		inputPrice: 0, // the inputs are priced as cache read/write, so `inputPrice` should be 0
-		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-13
-		outputPrice: 0.87, // $0.87 per million tokens - Updated 2026-08-13
-		cacheWritesPrice: 0.435, // $0.435 per million tokens (cache miss) - Updated 2026-08-13
-		cacheReadsPrice: 0.003625, // $0.003625 per million tokens (cache hit) - Updated 2026-08-13
+		// the peak/off-peak pricing policy has not been implemented yet - Updated 2026-08-01
+		outputPrice: 0.87, // $0.87 per million tokens - Updated 2026-08-01
+		cacheWritesPrice: 0.435, // $0.435 per million tokens (cache miss) - Updated 2026-08-01
+		cacheReadsPrice: 0.003625, // $0.003625 per million tokens (cache hit) - Updated 2026-08-01
 		description: `DeepSeek-V4-Pro is DeepSeek's strongest V4 model for reasoning, coding, long-context, and agentic workloads. It supports thinking and non-thinking modes, JSON output, tool calls, chat prefix completion (beta), and FIM completion (beta) in non-thinking mode.`,
 	},
 } as const satisfies Record<string, ModelInfo>

--- a/src/api/providers/__tests__/deepseek.spec.ts
+++ b/src/api/providers/__tests__/deepseek.spec.ts
@@ -617,6 +617,7 @@ describe("DeepSeekHandler", () => {
 
 	describe("normalizeDeepSeekReasoningEffort", () => {
 		// https://api-docs.deepseek.com/guides/thinking_mode/
+		// updated on 2026-08-13
 		it("should map acceptable reasoning efforts the same way as stated by the official documentation", async () => {
 			const mappings: {
 				modelId: DeepSeekModelId
@@ -632,6 +633,11 @@ describe("DeepSeekHandler", () => {
 					modelId: "deepseek-v4-flash",
 					rawReasoningEffort: "low",
 					mappedReasoningEffort: "low",
+				},
+				{
+					modelId: "deepseek-v4-flash",
+					rawReasoningEffort: "medium",
+					mappedReasoningEffort: "high",
 				},
 				{
 					modelId: "deepseek-v4-flash",
@@ -656,6 +662,11 @@ describe("DeepSeekHandler", () => {
 				{
 					modelId: "deepseek-v4-pro",
 					rawReasoningEffort: "low",
+					mappedReasoningEffort: "low",
+				},
+				{
+					modelId: "deepseek-v4-pro",
+					rawReasoningEffort: "medium",
 					mappedReasoningEffort: "high",
 				},
 				{
@@ -666,7 +677,7 @@ describe("DeepSeekHandler", () => {
 				{
 					modelId: "deepseek-v4-pro",
 					rawReasoningEffort: "xhigh",
-					mappedReasoningEffort: "max",
+					mappedReasoningEffort: "high",
 				},
 				{
 					modelId: "deepseek-v4-pro",

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -43,41 +43,23 @@ const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions) 
 
 // https://api-docs.deepseek.com/guides/thinking_mode/
 export const normalizeDeepSeekReasoningEffort = (
-	modelId: DeepSeekModelId,
+	// the mapping became model-agnostic now,
+	// but let's keep the modelId parameter for future flexibility
+	// updated 2026-08-13
+	_modelId: DeepSeekModelId,
 	reasoningEffort?: string,
 ): "low" | "high" | "max" | undefined => {
-	switch (modelId) {
-		case "deepseek-v4-flash":
-			switch (reasoningEffort) {
-				case "low":
-					return "low"
+	switch (reasoningEffort) {
+		case "low":
+			return "low"
 
-				case "high":
-					return "high"
+		case "medium":
+		case "high":
+		case "xhigh":
+			return "high"
 
-				case "xhigh":
-					return "high"
-
-				case "max":
-					return "max"
-			}
-			break
-
-		case "deepseek-v4-pro":
-			switch (reasoningEffort) {
-				case "low":
-					return "high"
-
-				case "high":
-					return "high"
-
-				case "xhigh":
-					return "max"
-
-				case "max":
-					return "max"
-			}
-			break
+		case "max":
+			return "max"
 	}
 
 	return undefined

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -43,23 +43,25 @@ const isDeepSeekThinkingEnabled = (modelId: string, options: ApiHandlerOptions) 
 
 // https://api-docs.deepseek.com/guides/thinking_mode/
 export const normalizeDeepSeekReasoningEffort = (
-	// the mapping became model-agnostic now,
-	// but let's keep the modelId parameter for future flexibility
-	// updated 2026-08-13
-	_modelId: DeepSeekModelId,
+	modelId: DeepSeekModelId,
 	reasoningEffort?: string,
 ): "low" | "high" | "max" | undefined => {
-	switch (reasoningEffort) {
-		case "low":
-			return "low"
+	// still check the modelId so non-supported models won't produce reasoning efforts
+	switch (modelId) {
+		case "deepseek-v4-flash":
+		case "deepseek-v4-pro":
+			switch (reasoningEffort) {
+				case "low":
+					return "low"
 
-		case "medium":
-		case "high":
-		case "xhigh":
-			return "high"
+				case "medium":
+				case "high":
+				case "xhigh":
+					return "high"
 
-		case "max":
-			return "max"
+				case "max":
+					return "max"
+			}
 	}
 
 	return undefined


### PR DESCRIPTION
### Related GitHub Issue

Closes: #1235

### Description

Updated the supported reasoning efforts for `deepseek-v4-pro` and the `normalizeDeepSeekReasoningEffort` function.

### Test Procedure

I built and installed the extension locally and confirmed that it's working fine.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] ~~**Visual Snapshot** (UI changes only): If a user would notice this change at a glance (layout, theme tokens, brand elements, empty/error states), I've added or updated a `*.visual.tsx` snapshot in `webview-ui/`. See `webview-ui/AGENTS.md` → "When a UI change needs a snapshot".~~
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

N/A

### Videos (interaction / animation only)

N/A

### Documentation Updates

N/A

### Additional Notes

N/A

### Get in Touch

I don't use Discord. Please comment in this PR or the linked issue. I signed up for email notifications and will respond promptly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeepSeek V4 Pro now supports the “low” reasoning-effort setting.
  * Reasoning-effort options are handled consistently across DeepSeek V4 Flash and V4 Pro.

* **Updates**
  * Medium and extra-high reasoning requests now map to appropriate supported levels across both models.
  * DeepSeek V4 Flash and V4 Pro metadata comments were updated; pricing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->