### PR TITLE
fix(openai-codex): complete prompts over the streaming transport

### DIFF
--- a/src/api/providers/__tests__/openai-codex-native-tool-calls.spec.ts
+++ b/src/api/providers/__tests__/openai-codex-native-tool-calls.spec.ts
@@ -475,15 +475,20 @@ describe("OpenAiCodexHandler native tool calls", () => {
 		vi.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
 		vi.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
 
+		// Completions stream like everything else, so the SDK path is forced to fail and the
+		// hand-built SSE request is what these assertions inspect.
+		Reflect.set(handler, "client", {
+			responses: { create: vi.fn().mockRejectedValue(new Error("SDK unavailable")) },
+		})
 		const mockFetch = vi.fn().mockResolvedValue({
 			ok: true,
-			json: vi.fn().mockResolvedValue({
-				output: [
-					{
-						type: "message",
-						content: [{ type: "output_text", text: "done" }],
-					},
-				],
+			body: new ReadableStream({
+				start(controller) {
+					controller.enqueue(
+						new TextEncoder().encode('data: {"type":"response.output_text.delta","delta":"done"}\n\n'),
+					)
+					controller.close()
+				},
 			}),
 		})
 		global.fetch = mockFetch as any

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -471,7 +471,42 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 		const mockFetch = vitest.fn()
 		vitest.stubGlobal("fetch", mockFetch)
 
-		await expect(handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })).rejects.toThrow()
+		await expect(handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })).rejects.toMatchObject({
+			name: "AbortError",
+		})
+		expect(mockFetch).not.toHaveBeenCalled()
+	})
+
+	// The abort arrives while the request is still in flight, before any event, which is the case
+	// that only works if the caller's signal is genuinely linked to the internal controller. A
+	// broken link would leave the request hanging on a signal that never fires.
+	it("aborts the in-flight request when the caller cancels before any event", async () => {
+		const handler = createHandler()
+		const controller = new AbortController()
+		let signalDuringRequest: AbortSignal | undefined
+
+		const create = vitest.fn().mockImplementation(
+			(_body: unknown, options: { signal: AbortSignal }) =>
+				new Promise((_resolve, reject) => {
+					signalDuringRequest = options.signal
+					// Reject the way the SDK does once the signal it was handed aborts.
+					options.signal.addEventListener("abort", () => reject(new Error("Request was aborted")), {
+						once: true,
+					})
+				}),
+		)
+		Reflect.set(handler, "client", { responses: { create } })
+		const mockFetch = vitest.fn()
+		vitest.stubGlobal("fetch", mockFetch)
+
+		const completion = handler.completePrompt("Hello", { abortSignal: controller.signal })
+		// The token lookup and the listener that links the two signals are both async, so aborting
+		// synchronously here would fire before anything is listening.
+		await vitest.waitFor(() => expect(create).toHaveBeenCalled())
+		controller.abort()
+
+		await expect(completion).rejects.toMatchObject({ name: "AbortError" })
+		expect(signalDuringRequest!.aborted).toBe(true)
 		expect(mockFetch).not.toHaveBeenCalled()
 	})
 

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -247,28 +247,182 @@ describe("OpenAiCodexHandler.completePrompt service tier", () => {
 	it.each<[string, OpenAiCodexServiceTier | undefined, typeof OpenAiCodexServiceTier.Priority | undefined]>([
 		["Fast", OpenAiCodexServiceTier.Priority, OpenAiCodexServiceTier.Priority],
 		["Standard", undefined, undefined],
-	])("uses the %s preference in non-streaming requests", async (_mode, configuredTier, expectedTier) => {
+	])("uses the %s preference in completion requests", async (_mode, configuredTier, expectedTier) => {
 		const handler = new OpenAiCodexHandler({
 			apiModelId: "gpt-5.6-sol",
 			...(configuredTier ? { [OPEN_AI_CODEX_SERVICE_TIER_KEY]: configuredTier } : {}),
 		})
 		vitest.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
 		vitest.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
-		const mockFetch = vitest.fn().mockResolvedValue({
-			ok: true,
-			json: vitest.fn().mockResolvedValue({ text: "Complete" }),
-		})
-		vitest.stubGlobal("fetch", mockFetch)
+		const create = vitest.fn().mockResolvedValue(
+			asyncStreamFrom([
+				{ type: "response.output_text.delta", delta: "Complete" },
+				{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+			]),
+		)
+		Reflect.set(handler, "client", { responses: { create } })
 
 		await expect(handler.completePrompt("Hello")).resolves.toBe("Complete")
 
-		const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-		expect(body.stream).toBe(false)
+		const body = create.mock.calls[0][0]
+		// The Codex subscription endpoint rejects `stream: false` outright.
+		expect(body.stream).toBe(true)
 		if (expectedTier) {
 			expect(body[SERVICE_TIER_KEY]).toBe(expectedTier)
 		} else {
 			expect(body).not.toHaveProperty(SERVICE_TIER_KEY)
 		}
+	})
+})
+
+describe("OpenAiCodexHandler.completePrompt streaming", () => {
+	function createHandler() {
+		const handler = new OpenAiCodexHandler({ apiModelId: "gpt-5.6-sol" })
+		vitest.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
+		vitest.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
+		return handler
+	}
+
+	function injectStream(handler: OpenAiCodexHandler, events: unknown[]) {
+		const create = vitest.fn().mockResolvedValue(asyncStreamFrom(events))
+		Reflect.set(handler, "client", { responses: { create } })
+		return create
+	}
+
+	afterEach(() => {
+		vitest.restoreAllMocks()
+		vitest.unstubAllGlobals()
+	})
+
+	it("joins consecutive text deltas into one string", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.output_text.delta", delta: "feat: " },
+			{ type: "response.output_text.delta", delta: "add commit messages" },
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("feat: add commit messages")
+	})
+
+	// A commit message is written straight into the Source Control box, so reasoning must never
+	// become part of it.
+	it("omits reasoning from the completion", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.reasoning_summary_text.delta", delta: "Thinking about the diff" },
+			{ type: "response.output_text.delta", delta: "fix: correct the parser" },
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		const result = await handler.completePrompt("Hello")
+
+		expect(result).toBe("fix: correct the parser")
+		expect(result).not.toContain("Thinking")
+	})
+
+	it("omits usage and tool calls from the completion", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.output_text.delta", delta: "chore: tidy" },
+			{
+				type: "response.output_item.done",
+				item: { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "r1",
+					status: "completed",
+					output: [],
+					usage: { input_tokens: 10, output_tokens: 5 },
+				},
+			},
+		])
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("chore: tidy")
+	})
+
+	// The SDK path swallows its own errors into the SSE fallback, so an auth failure only reaches
+	// the retry loop from the fallback - the same shape the streaming Luna retry test relies on.
+	it("retries once with a refreshed token when the first attempt is unauthorized", async () => {
+		const handler = createHandler()
+		const refresh = vitest
+			.spyOn(openAiCodexOAuthManager, "forceRefreshAccessToken")
+			.mockResolvedValue("fresh-token")
+		Reflect.set(handler, "client", {
+			responses: { create: vitest.fn().mockRejectedValue(new Error("SDK unavailable")) },
+		})
+		const mockFetch = vitest
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				text: vitest.fn().mockResolvedValue('{"error":{"message":"Codex API invalid token"}}'),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				body: new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								'data: {"type":"response.output_text.delta","delta":"docs: update"}\n\n',
+							),
+						)
+						controller.close()
+					},
+				}),
+			})
+		vitest.stubGlobal("fetch", mockFetch)
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("docs: update")
+		expect(refresh).toHaveBeenCalled()
+		expect(mockFetch).toHaveBeenCalledTimes(2)
+	})
+
+	// The caller's signal is linked to the internal controller rather than passed through, so what
+	// matters is that aborting the caller's one aborts the signal the request is actually using.
+	it("passes the caller's abort signal down to the request", async () => {
+		const handler = createHandler()
+		const controller = new AbortController()
+		let signalDuringRequest: AbortSignal | undefined
+
+		const create = vitest.fn().mockImplementation((_body: unknown, options: { signal: AbortSignal }) => {
+			signalDuringRequest = options.signal
+			// Abort mid-flight, while `executeRequest`'s listener is still attached.
+			controller.abort()
+			return Promise.resolve(
+				asyncStreamFrom([
+					{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+				]),
+			)
+		})
+		Reflect.set(handler, "client", { responses: { create } })
+
+		await handler.completePrompt("Hello", { abortSignal: controller.signal })
+
+		expect(signalDuringRequest).toBeInstanceOf(AbortSignal)
+		expect(signalDuringRequest!.aborted).toBe(true)
+	})
+
+	it("aborts immediately when the caller's signal is already aborted", async () => {
+		const handler = createHandler()
+		const create = injectStream(handler, [
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		await handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })
+
+		expect(create.mock.calls[0][1].signal.aborted).toBe(true)
+	})
+
+	it("wraps failures from both transports as a completion error", async () => {
+		const handler = createHandler()
+		const create = vitest.fn().mockRejectedValue(new Error("sdk down"))
+		Reflect.set(handler, "client", { responses: { create } })
+		vitest.stubGlobal("fetch", vitest.fn().mockRejectedValue(new Error("network down")))
+
+		await expect(handler.completePrompt("Hello")).rejects.toThrow(/completionError|network down/)
 	})
 })
 
@@ -601,15 +755,20 @@ describe("OpenAiCodexHandler Luna Responses Lite requests", () => {
 		const handler = new OpenAiCodexHandler({ apiModelId: "gpt-5.6-luna", reasoningEffort: "disable" })
 		vitest.spyOn(openAiCodexOAuthManager, "getAccessToken").mockResolvedValue("test-token")
 		vitest.spyOn(openAiCodexOAuthManager, "getAccountId").mockResolvedValue("acct_test")
+		// Forcing the SDK path to fail exercises the SSE fallback, which is where the request body
+		// and the Codex-specific headers are assembled by hand.
+		Reflect.set(handler, "client", {
+			responses: { create: vitest.fn().mockRejectedValue(new Error("SDK unavailable")) },
+		})
 		const mockFetch = vitest.fn().mockResolvedValue({
 			ok: true,
-			json: vitest.fn().mockResolvedValue({
-				output: [
-					{
-						type: "message",
-						content: [{ type: "output_text", text: "Complete" }],
-					},
-				],
+			body: new ReadableStream({
+				start(controller) {
+					controller.enqueue(
+						new TextEncoder().encode('data: {"type":"response.output_text.delta","delta":"Complete"}\n\n'),
+					)
+					controller.close()
+				},
 			}),
 		})
 		vitest.stubGlobal("fetch", mockFetch)
@@ -622,7 +781,7 @@ describe("OpenAiCodexHandler Luna Responses Lite requests", () => {
 		expect(sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
 		expect(body).toMatchObject({
 			model: "gpt-5.6-luna",
-			stream: false,
+			stream: true,
 			tool_choice: "auto",
 			parallel_tool_calls: false,
 			reasoning: { context: "all_turns" },

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -382,7 +382,9 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 
 	// The caller's signal is linked to the internal controller rather than passed through, so what
 	// matters is that aborting the caller's one aborts the signal the request is actually using.
-	it("passes the caller's abort signal down to the request", async () => {
+	// The stream then ends quietly, so rejecting is the only thing that tells the caller apart a
+	// cancelled generation from a finished one.
+	it("rejects and stops the request when cancelled mid-stream", async () => {
 		const handler = createHandler()
 		const controller = new AbortController()
 		let signalDuringRequest: AbortSignal | undefined
@@ -393,27 +395,50 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 			controller.abort()
 			return Promise.resolve(
 				asyncStreamFrom([
+					{ type: "response.output_text.delta", delta: "feat: half a" },
 					{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
 				]),
 			)
 		})
 		Reflect.set(handler, "client", { responses: { create } })
 
-		await handler.completePrompt("Hello", { abortSignal: controller.signal })
+		await expect(handler.completePrompt("Hello", { abortSignal: controller.signal })).rejects.toMatchObject({
+			name: "AbortError",
+		})
 
 		expect(signalDuringRequest).toBeInstanceOf(AbortSignal)
 		expect(signalDuringRequest!.aborted).toBe(true)
 	})
 
-	it("aborts immediately when the caller's signal is already aborted", async () => {
+	it("rejects when the caller's signal is already aborted", async () => {
 		const handler = createHandler()
 		const create = injectStream(handler, [
 			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
 		])
 
-		await handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })
+		await expect(handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })).rejects.toMatchObject({
+			name: "AbortError",
+		})
 
 		expect(create.mock.calls[0][1].signal.aborted).toBe(true)
+	})
+
+	// The SSE fallback is for an SDK that could not be used at all. Replaying the request after the
+	// SDK has already produced output would append a second generation to the first.
+	it("does not replay over SSE when the SDK fails after emitting", async () => {
+		const handler = createHandler()
+		const create = vitest.fn().mockResolvedValue(
+			(async function* () {
+				yield { type: "response.output_text.delta", delta: "feat: add" }
+				throw new Error("stream broke")
+			})(),
+		)
+		Reflect.set(handler, "client", { responses: { create } })
+		const mockFetch = vitest.fn()
+		vitest.stubGlobal("fetch", mockFetch)
+
+		await expect(handler.completePrompt("Hello")).rejects.toThrow(/completionError|stream broke/)
+		expect(mockFetch).not.toHaveBeenCalled()
 	})
 
 	it("wraps failures from both transports as a completion error", async () => {

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -305,8 +305,8 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 		await expect(handler.completePrompt("Hello")).resolves.toBe("feat: add commit messages")
 	})
 
-	// A commit message is written straight into the Source Control box, so reasoning must never
-	// become part of it.
+	// The enhanced prompt is written straight into the input box, so reasoning must never become
+	// part of it.
 	it("omits reasoning from the completion", async () => {
 		const handler = createHandler()
 		injectStream(handler, [
@@ -341,6 +341,70 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 		])
 
 		await expect(handler.completePrompt("Hello")).resolves.toBe("chore: tidy")
+	})
+
+	// A refusal is streamed as text so the chat can show it, but the non-streaming request this
+	// replaced read `output_text`, which never carries refusals. Keeping them would paste
+	// "[Refusal] ..." into the prompt enhancer's input box as if the model had answered.
+	it("omits refusals from the completion", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.refusal.delta", delta: "I cannot help " },
+			{ type: "response.refusal.delta", delta: "with that request." },
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("")
+	})
+
+	it("keeps the answer when a refusal arrives alongside output text", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.output_text.delta", delta: "docs: update the readme" },
+			{ type: "response.refusal.delta", delta: "I cannot help with the rest." },
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("docs: update the readme")
+	})
+
+	// The SSE transport parses its own events, so it has a second refusal branch to keep aligned.
+	it("omits refusals streamed over the SSE fallback", async () => {
+		const handler = createHandler()
+		Reflect.set(handler, "client", {
+			responses: { create: vitest.fn().mockRejectedValue(new Error("SDK unavailable")) },
+		})
+		vitest.stubGlobal(
+			"fetch",
+			vitest.fn().mockResolvedValue({
+				ok: true,
+				body: new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(
+								'data: {"type":"response.refusal.delta","delta":"I cannot help with that."}\n\n',
+							),
+						)
+						controller.close()
+					},
+				}),
+			}),
+		)
+
+		await expect(handler.completePrompt("Hello")).resolves.toBe("")
+	})
+
+	// Dropping the refusal is specific to the one-shot completion: a chat still has to show it.
+	it("still surfaces refusals to the chat stream", async () => {
+		const handler = createHandler()
+		injectStream(handler, [
+			{ type: "response.refusal.delta", delta: "I cannot help with that." },
+			{ type: "response.completed", response: { id: "r1", status: "completed", output: [] } },
+		])
+
+		const chunks = await collectStream(handler.createMessage("system", [{ role: "user", content: "Hello" }]))
+
+		expect(chunks).toContainEqual({ type: "text", text: "[Refusal] I cannot help with that." })
 	})
 
 	// The SDK path swallows its own errors into the SSE fallback, so an auth failure only reaches

--- a/src/api/providers/__tests__/openai-codex.spec.ts
+++ b/src/api/providers/__tests__/openai-codex.spec.ts
@@ -441,6 +441,40 @@ describe("OpenAiCodexHandler.completePrompt streaming", () => {
 		expect(mockFetch).not.toHaveBeenCalled()
 	})
 
+	// The service has accepted the request by the time it emits, so refreshing the token and
+	// sending it again would bill a second generation and hand the caller both.
+	it("does not retry with a refreshed token when the SDK fails after emitting", async () => {
+		const handler = createHandler()
+		const refresh = vitest.spyOn(openAiCodexOAuthManager, "forceRefreshAccessToken")
+		const create = vitest.fn().mockResolvedValue(
+			(async function* () {
+				yield { type: "response.output_text.delta", delta: "feat: add" }
+				throw new Error("Codex API invalid token")
+			})(),
+		)
+		Reflect.set(handler, "client", { responses: { create } })
+		const mockFetch = vitest.fn()
+		vitest.stubGlobal("fetch", mockFetch)
+
+		await expect(handler.completePrompt("Hello")).rejects.toThrow(/completionError|invalid token/)
+		expect(refresh).not.toHaveBeenCalled()
+		expect(create).toHaveBeenCalledTimes(1)
+		expect(mockFetch).not.toHaveBeenCalled()
+	})
+
+	// An abort is not a transport failure, so spending a second request on an already-aborted
+	// signal only turns the cancellation into a connection error.
+	it("does not fall back to SSE when the SDK fails because the caller aborted", async () => {
+		const handler = createHandler()
+		const create = vitest.fn().mockRejectedValue(new Error("Request was aborted"))
+		Reflect.set(handler, "client", { responses: { create } })
+		const mockFetch = vitest.fn()
+		vitest.stubGlobal("fetch", mockFetch)
+
+		await expect(handler.completePrompt("Hello", { abortSignal: AbortSignal.abort() })).rejects.toThrow()
+		expect(mockFetch).not.toHaveBeenCalled()
+	})
+
 	it("wraps failures from both transports as a completion error", async () => {
 		const handler = createHandler()
 		const create = vitest.fn().mockRejectedValue(new Error("sdk down"))

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -456,6 +456,11 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 			}
 		}
 
+		// Once the SDK stream has produced an event the request has been accepted and its output is
+		// already with the caller, so replaying it over SSE would append a second generation to the
+		// first. The fallback below is only for an SDK that could not be used at all.
+		let sawSdkEvent = false
+
 		try {
 			// Prefer OpenAI SDK streaming (same approach as openai-native) so event handling
 			// is consistent across providers.
@@ -493,6 +498,10 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 						break
 					}
 
+					// Set before the event is processed, not after: `processEvent` also mutates
+					// response state, so a throw from it must not replay either.
+					sawSdkEvent = true
+
 					for await (const outChunk of this.processEvent(event, model)) {
 						if (outChunk.type === "text") {
 							this.sawTextOutputInCurrentResponse = true
@@ -500,7 +509,11 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 						yield outChunk
 					}
 				}
-			} catch (_sdkErr) {
+			} catch (sdkErr) {
+				if (sawSdkEvent) {
+					throw sdkErr
+				}
+
 				// Fallback to manual SSE via fetch (Codex backend).
 				yield* this.makeCodexRequest(requestBody, model, accessToken, effectiveSessionId)
 			}
@@ -1302,8 +1315,21 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				}
 			}
 
+			// Both transports end quietly on abort - they break out of their loops rather than
+			// throwing - so returning here would report a cancelled generation as a finished one and
+			// hand the caller whatever partial text had arrived.
+			if (options?.abortSignal?.aborted) {
+				throw new DOMException("OpenAI Codex completion was aborted", "AbortError")
+			}
+
 			return text
 		} catch (error) {
+			// Cancelling is the caller's own doing, not a provider failure, so it is neither
+			// reported to telemetry nor relabelled as a completion error.
+			if (options?.abortSignal?.aborted) {
+				throw error
+			}
+
 			const errorModel = this.getModel()
 			const errorMessage = error instanceof Error ? error.message : String(error)
 			const apiError = new ApiProviderError(errorMessage, this.providerName, errorModel.id, "completePrompt")

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -1335,9 +1335,13 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 			return text
 		} catch (error) {
 			// Cancelling is the caller's own doing, not a provider failure, so it is neither
-			// reported to telemetry nor relabelled as a completion error.
+			// reported to telemetry nor relabelled as a completion error. A transport that rejects
+			// on abort reports it in its own words, so it is restated here: callers get one abort
+			// result whether the stream ended quietly or the request threw.
 			if (options?.abortSignal?.aborted) {
-				throw error
+				throw error instanceof DOMException && error.name === "AbortError"
+					? error
+					: new DOMException("OpenAI Codex completion was aborted", "AbortError")
 			}
 
 			const errorModel = this.getModel()

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -42,6 +42,13 @@ const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
 const LUNA_MODEL_ID = "gpt-5.6-luna"
 const LUNA_CODEX_VERSION = "0.144.0"
 
+/**
+ * A refusal is streamed as text so the chat still shows why the model declined, but it is not part
+ * of the answer: the Responses API keeps refusals out of `output_text`. `completePrompt` relies on
+ * this prefix to tell the two apart, so both refusal branches must emit it.
+ */
+const REFUSAL_TEXT_PREFIX = "[Refusal] "
+
 const getOpenAiCodexServiceTier = (options: ApiHandlerOptions): OpenAiCodexRequestServiceTier | undefined =>
 	options[OPEN_AI_CODEX_SERVICE_TIER_KEY] === OpenAiCodexServiceTier.Priority
 		? OpenAiCodexServiceTier.Priority
@@ -867,7 +874,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 								if (parsed.delta) {
 									hasContent = true
 									this.sawTextOutputInCurrentResponse = true
-									yield { type: "text", text: `[Refusal] ${parsed.delta}` }
+									yield { type: "text", text: `${REFUSAL_TEXT_PREFIX}${parsed.delta}` }
 								}
 							} else if (parsed.type === "response.output_item.added") {
 								if (parsed.item) {
@@ -1059,7 +1066,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		if (event?.type === "response.refusal.delta") {
 			if (event?.delta) {
 				this.sawTextOutputInCurrentResponse = true
-				yield { type: "text", text: `[Refusal] ${event.delta}` }
+				yield { type: "text", text: `${REFUSAL_TEXT_PREFIX}${event.delta}` }
 			}
 			return
 		}
@@ -1308,7 +1315,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 			const model = this.getModel()
 
 			// Only the answer is wanted. Reasoning is deliberately dropped rather than concatenated:
-			// callers such as commit-message generation write this straight into the editor.
+			// the prompt enhancer writes this straight into the input box.
 			let text = ""
 
 			for await (const chunk of this.handleResponsesApiMessage(
@@ -1320,7 +1327,10 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				{ taskId: this.sessionId },
 				options?.abortSignal,
 			)) {
-				if (chunk.type === "text") {
+				// Refusals are streamed as text for the chat, but they are not output: the
+				// non-streaming request this replaced read `output_text`, which never carries them.
+				// Keeping them would paste "[Refusal] ..." into the input box as if it were an answer.
+				if (chunk.type === "text" && !chunk.text.startsWith(REFUSAL_TEXT_PREFIX)) {
 					text += chunk.text
 				}
 			}

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -217,7 +217,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		metadata?: ApiHandlerCreateMessageMetadata,
 	): ApiStream {
 		const model = this.getModel()
-		yield* this.handleResponsesApiMessage(model, systemPrompt, messages, metadata)
+		yield* this.handleResponsesApiMessage(model, systemPrompt, messages, metadata, metadata?.abortSignal)
 	}
 
 	private async *handleResponsesApiMessage(
@@ -225,6 +225,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		systemPrompt: string,
 		messages: Anthropic.Messages.MessageParam[],
 		metadata?: ApiHandlerCreateMessageMetadata,
+		abortSignal?: AbortSignal,
 	): ApiStream {
 		// Reset state for this request
 		this.lastResponseOutput = undefined
@@ -274,7 +275,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		// Make the request with retry on auth failure
 		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
-				yield* this.executeRequest(requestBody, model, accessToken, effectiveSessionId)
+				yield* this.executeRequest(requestBody, model, accessToken, effectiveSessionId, abortSignal)
 				return
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error)
@@ -438,9 +439,22 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		model: OpenAiCodexModel,
 		accessToken: string,
 		effectiveSessionId: string,
+		abortSignal?: AbortSignal,
 	): ApiStream {
 		// Create AbortController for cancellation
 		this.abortController = new AbortController()
+
+		// A caller's signal has to be linked rather than used directly, since both transports below
+		// abort through `this.abortController`. Without this the signal never reaches the wire.
+		const abortFromCaller = () => this.abortController?.abort()
+
+		if (abortSignal) {
+			if (abortSignal.aborted) {
+				this.abortController.abort()
+			} else {
+				abortSignal.addEventListener("abort", abortFromCaller, { once: true })
+			}
+		}
 
 		try {
 			// Prefer OpenAI SDK streaming (same approach as openai-native) so event handling
@@ -491,6 +505,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				yield* this.makeCodexRequest(requestBody, model, accessToken, effectiveSessionId)
 			}
 		} finally {
+			abortSignal?.removeEventListener("abort", abortFromCaller)
 			this.abortController = undefined
 		}
 	}
@@ -1256,98 +1271,38 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		return this.lastResponseId
 	}
 
+	/**
+	 * The Codex subscription endpoint only accepts streaming requests - a body with `stream: false`
+	 * is rejected with `Stream must be set to true` - so a one-shot completion is the streaming
+	 * request with its text chunks joined back together.
+	 *
+	 * Going through `handleResponsesApiMessage` rather than issuing its own request is what keeps
+	 * the OAuth refresh-and-retry, the SDK-then-SSE fallback, the Luna body and the service tier
+	 * from having to be duplicated here.
+	 */
 	async completePrompt(prompt: string, options?: CompletePromptOptions): Promise<string> {
-		this.abortController = new AbortController()
-
 		try {
 			const model = this.getModel()
 
-			// Get access token
-			const accessToken = await openAiCodexOAuthManager.getAccessToken()
-			if (!accessToken) {
-				throw new Error(
-					t("common:errors.openAiCodex.notAuthenticated", {
-						defaultValue:
-							"Not authenticated with OpenAI Codex. Please sign in using the OpenAI Codex OAuth flow.",
-					}),
-				)
-			}
+			// Only the answer is wanted. Reasoning is deliberately dropped rather than concatenated:
+			// callers such as commit-message generation write this straight into the editor.
+			let text = ""
 
-			const reasoningEffort = this.getReasoningEffort(model)
-			const serviceTier = getOpenAiCodexServiceTier(this.options)
-
-			const baseRequestBody: any = {
-				model: model.id,
-				input: [
-					{
-						role: "user",
-						content: [{ type: "input_text", text: prompt }],
-					},
-				],
-				stream: false,
-				store: false,
-				...(serviceTier ? { [SERVICE_TIER_KEY]: serviceTier } : {}),
-				...(reasoningEffort ? { include: ["reasoning.encrypted_content"] } : {}),
-			}
-
-			if (reasoningEffort) {
-				baseRequestBody.reasoning = {
-					effort: reasoningEffort,
-					summary: "auto" as const,
+			for await (const chunk of this.handleResponsesApiMessage(
+				model,
+				"",
+				[{ role: "user", content: prompt }],
+				// `taskId` is required, and resolves to the same session id this used to send
+				// directly, so `prompt_cache_key` is unchanged.
+				{ taskId: this.sessionId },
+				options?.abortSignal,
+			)) {
+				if (chunk.type === "text") {
+					text += chunk.text
 				}
 			}
 
-			const requestBody =
-				model.id === LUNA_MODEL_ID
-					? this.buildLunaRequestBody(baseRequestBody, this.sessionId)
-					: baseRequestBody
-
-			const url = `${CODEX_API_BASE_URL}/responses`
-
-			// Get ChatGPT account ID for organization subscriptions
-			const accountId = await openAiCodexOAuthManager.getAccountId()
-
-			// Build headers with required Codex-specific fields
-			const headers: Record<string, string> = {
-				...this.buildCodexHeaders(model, this.sessionId, accountId),
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${accessToken}`,
-			}
-
-			const response = await fetch(url, {
-				method: "POST",
-				headers,
-				body: JSON.stringify(requestBody),
-				signal: this.abortController.signal,
-			})
-
-			if (!response.ok) {
-				const errorText = await response.text()
-				throw new Error(
-					t("common:errors.openAiCodex.genericError", { status: response.status }) +
-						(errorText ? `: ${errorText}` : ""),
-				)
-			}
-
-			const responseData = await response.json()
-
-			if (responseData?.output && Array.isArray(responseData.output)) {
-				for (const outputItem of responseData.output) {
-					if (outputItem.type === "message" && outputItem.content) {
-						for (const content of outputItem.content) {
-							if (content.type === "output_text" && content.text) {
-								return content.text
-							}
-						}
-					}
-				}
-			}
-
-			if (responseData?.text) {
-				return responseData.text
-			}
-
-			return ""
+			return text
 		} catch (error) {
 			const errorModel = this.getModel()
 			const errorMessage = error instanceof Error ? error.message : String(error)
@@ -1358,8 +1313,6 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				throw new Error(t("common:errors.openAiCodex.completionError", { message: error.message }))
 			}
 			throw error
-		} finally {
-			this.abortController = undefined
 		}
 	}
 }

--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -142,6 +142,10 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 	private sawTextDeltaInCurrentResponse = false
 	// Tracks tool call IDs emitted via streaming partial events to prevent done-event duplicates.
 	private streamedToolCallIds = new Set<string>()
+	// Tracks whether the SDK stream produced an event, which is the point where the service has
+	// accepted the request and its output is already with the caller. Neither transport may be
+	// replayed after that: doing so appends a second generation to the first.
+	private sawSdkEventInCurrentResponse = false
 
 	// Event types handled by the shared event processor
 	private readonly coreHandledEventTypes = new Set<string>([
@@ -234,6 +238,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 		this.pendingToolCallName = undefined
 		this.sawTextOutputInCurrentResponse = false
 		this.sawTextDeltaInCurrentResponse = false
+		this.sawSdkEventInCurrentResponse = false
 		this.streamedToolCallIds.clear()
 
 		// Get access token from OAuth manager
@@ -281,7 +286,10 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 				const message = error instanceof Error ? error.message : String(error)
 				const isAuthFailure = /unauthorized|invalid token|not authenticated|authentication|401/i.test(message)
 
-				if (attempt === 0 && isAuthFailure) {
+				// Retrying is only safe while nothing has come back yet. Once the SDK has emitted,
+				// the service has accepted the request, so a refreshed-token retry would replay it
+				// and append a second generation to output the caller already has.
+				if (attempt === 0 && isAuthFailure && !this.sawSdkEventInCurrentResponse) {
 					// Force refresh the token for retry
 					const refreshed = await openAiCodexOAuthManager.forceRefreshAccessToken()
 					if (!refreshed) {
@@ -456,11 +464,6 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 			}
 		}
 
-		// Once the SDK stream has produced an event the request has been accepted and its output is
-		// already with the caller, so replaying it over SSE would append a second generation to the
-		// first. The fallback below is only for an SDK that could not be used at all.
-		let sawSdkEvent = false
-
 		try {
 			// Prefer OpenAI SDK streaming (same approach as openai-native) so event handling
 			// is consistent across providers.
@@ -500,7 +503,7 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 
 					// Set before the event is processed, not after: `processEvent` also mutates
 					// response state, so a throw from it must not replay either.
-					sawSdkEvent = true
+					this.sawSdkEventInCurrentResponse = true
 
 					for await (const outChunk of this.processEvent(event, model)) {
 						if (outChunk.type === "text") {
@@ -510,7 +513,14 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 					}
 				}
 			} catch (sdkErr) {
-				if (sawSdkEvent) {
+				// The fallback is only for an SDK that could not be used at all. Once the stream has
+				// emitted, the request has been accepted and its output is already with the caller,
+				// so replaying it over SSE would append a second generation to the first.
+				//
+				// A cancellation is not a transport failure either. Falling back would spend a
+				// second request on an already-aborted signal and report the cancellation as a
+				// connection error.
+				if (this.sawSdkEventInCurrentResponse || this.abortController?.signal.aborted) {
 					throw sdkErr
 				}
 

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -396,7 +396,7 @@
 	},
 	"api/providers/openai-codex.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 35
+			"count": 34
 		}
 	},
 	"api/providers/openai-native.ts": {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #1242

### Description

`completePrompt()` built its own request body with `stream: false`, which the Codex subscription endpoint rejects with `400 Stream must be set to true`. Rather than flip the flag and hand-roll SSE parsing, this runs the request through `handleResponsesApiMessage` — the path `createMessage` already uses — and joins the text chunks into one string.

Going through the existing path means the OAuth refresh-and-retry, the SDK→SSE fallback, the Luna body and the service tier all apply without being duplicated. The hand-built body is gone, along with the now-redundant `notAuthenticated` check.

Only `text` chunks are accumulated. Reasoning is deliberately dropped — commit-message generation writes this result straight into the Source Control input box.

Two things worth flagging for review:

- **The spec asserted the bug.** `expect(body.stream).toBe(false)` meant the test suite held the broken behavior in place. That assertion is inverted, and the two `completePrompt` tests now drive real streams.
- **`abortSignal` was dead on this provider.** `executeRequest` always made its own `AbortController` and never linked `metadata?.abortSignal`, so cancelling never reached the wire. The caller's signal is now linked to that controller, which also makes the commit-message stop button actually cancel the request.

Behavior change worth knowing: the old code returned the *first* `output_text` block; concatenating returns all of them. For a one-shot completion that is more correct, and `cleanCommitMessage` already post-processes the result.

An SSE-path failure now produces two telemetry events, since `makeCodexRequest` already captures one of its own. Left alone as it is not worth restructuring the error handling for.

#### Follow-up from review (979269b01)

Two defects @taltas spotted in the above, both fixed:

- **The stream could be replayed after it had already produced output.** The SDK stream and the loop consuming it sat in the same `try`, so an error raised part-way through was handled as "the SDK could not be used at all" and the whole request was replayed over SSE — appending a second generation to text the caller already had. `executeRequest` now tracks whether an SDK event has arrived and only falls back while none has. The flag is set *before* `processEvent` runs, since that mutates response state too, so a throw from it must not replay either. This fixes the chat path as well, since both go through `executeRequest`.
- **An abort resolved as if it had completed.** Both transports end quietly on cancellation — they break out of their loops rather than throwing — so `completePrompt` returned whatever partial text had arrived and callers read a cancelled generation as a finished one. It now rejects with an `AbortError`, and a cancellation passes straight through the catch rather than being captured by telemetry or relabelled as a completion error, since stopping is the caller's own doing.

#### Second review round (c68dae15f)

CodeRabbit caught the two remaining ways back into a request the service had already accepted.

- **The OAuth retry loop was the other replay route.** Closing the SSE fallback left `handleResponsesApiMessage` free to refresh the token and resend after a mid-stream error that reads as an auth failure, so `completePrompt` could still concatenate two generations and the chat path could repeat streamed effects. I had flagged this as knowingly left open; it is now closed. `sawSdkEvent` moved onto the handler as `sawSdkEventInCurrentResponse`, reset per request alongside the other response state, and the retry is skipped once it is set. A refresh *before* any event still retries exactly as before, which is what that loop exists for. Went with a plain field rather than the suggested typed marker, since it carries the same information without an error type to thread across the generator boundary and match on.
- **An abort still reached the SSE fallback.** The SDK rejects when the caller cancels, which read as a transport failure, so it spent a second request on an already-aborted signal and reported the cancellation as a connection error. The fallback now rethrows instead.

#### Third review round (bb2676a81)

A review note about the cancellation tests turned out to have a real bug behind it.

- **The abort result was not consistent.** A stream that ended quietly threw an `AbortError`, but a transport that rejected on abort had its own error passed straight through the catch. What a cancelled `completePrompt` rejected with therefore depended on how far the request had got, which is nothing a caller can key off. An abort is now restated as an `AbortError` unless it already is one. Both cancellation tests fail without the change and pass with it.
- **The in-flight case had no coverage.** Cancelling *after* the request is away but before any event is the case that only works if the caller's signal is genuinely linked to the internal controller, so it is what would catch that link breaking. It has to wait for the request to actually be in flight before aborting, since the token lookup and the listener are both async and a synchronous abort fires before anything is listening.

One suggestion from that round was skipped: asserting that an already-aborted signal never calls `create`. That contradicts the implementation and an existing passing test. `executeRequest` aborts its internal controller and *then* still calls `create` with that aborted signal, which is what makes the SDK reject it.

### Test Procedure

`npx vitest run api/providers/__tests__/openai-codex.spec.ts api/providers/__tests__/openai-codex-native-tool-calls.spec.ts` — 54 pass. The full provider suite passes at 1267. `check-types` and `lint` are clean.

New coverage: joining multiple text deltas, reasoning excluded from the result, tool calls and usage excluded, OAuth retry reaching `completePrompt`, error wrapping when both transports fail, and from the review round — rejection on mid-stream cancellation and on an already-aborted signal, plus a mid-stream SDK failure asserting that SSE is never reached, no refreshed-token retry after the SDK has emitted, the pre-event refresh path left untouched, and no SSE fallback when the SDK fails because the caller aborted.

The pre-existing tests that force `create` to reject *before* any event and then assert the SSE path still pass, which is what proves the fallback only closed for the mid-stream case.

Manually: with a Codex profile selected, run Enhance Prompt or generate a commit message and confirm text comes back instead of a 400. Pressing stop mid-generation leaves the input box as it was, with no error notification.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [x] **Scope**: My changes are focused on the linked issue.
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes.
- [x] **Documentation Impact**: No user-facing documentation change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling for more reliable text generation.
  * Prevented duplicate output when retrying after partial responses.
  * Improved cancellation behavior, including requests aborted before or during processing.
  * Added safer fallback handling when streaming responses fail.
  * Prevented refusal messages from appearing in one-shot completions while preserving them in chat streams.
* **Tests**
  * Expanded coverage for streaming, retries, cancellation, fallback responses, service tiers, refusal handling, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->