### PR TITLE
fix(semble): increase archive download limit

### DIFF
--- a/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
+++ b/src/services/code-index/semble/__tests__/semble-downloader.spec.ts
@@ -97,6 +97,7 @@ import {
 	downloadSemble,
 	getSembleBinaryPath,
 	SEMBLE_SHA256,
+	SEMBLE_MAX_ARCHIVE_BYTES,
 } from "../semble-downloader"
 import * as https from "https"
 import { spawn } from "child_process"
@@ -108,6 +109,12 @@ import { spawn } from "child_process"
 describe("SEMBLE_SHA256 checksum fixture", () => {
 	it("the local CHECKSUMS table matches the exported SEMBLE_SHA256 constant", () => {
 		expect(CHECKSUMS).toEqual(SEMBLE_SHA256)
+	})
+})
+
+describe("Semble archive download limit", () => {
+	it("allows 100 MiB for future release growth", () => {
+		expect(SEMBLE_MAX_ARCHIVE_BYTES).toBe(100 * 1024 * 1024)
 	})
 })
 

--- a/src/services/code-index/semble/semble-downloader.ts
+++ b/src/services/code-index/semble/semble-downloader.ts
@@ -26,7 +26,8 @@ const SEMBLE_ARCHIVES: Record<string, { archive: string; binary: string }> = {
 export const SEMBLE_VERSION = "v0.4.1"
 const DOWNLOAD_BASE_URL = `https://github.com/Zoo-Code-Org/sembleexec/releases/download/${SEMBLE_VERSION}`
 const VERSION_FILE = ".semble-version"
-const MAX_ARCHIVE_BYTES = 50 * 1024 * 1024
+// Leave room for future release growth while still rejecting anomalous downloads.
+export const SEMBLE_MAX_ARCHIVE_BYTES = 100 * 1024 * 1024
 
 /**
  * SHA-256 checksums for each platform archive at SEMBLE_VERSION.
@@ -122,7 +123,7 @@ export async function downloadSemble(storageDir: string): Promise<string | undef
 				name: "Semble",
 				trustedDomains: TRUSTED_DOWNLOAD_DOMAINS,
 				timeoutMs: 120_000,
-				maxBytes: MAX_ARCHIVE_BYTES,
+				maxBytes: SEMBLE_MAX_ARCHIVE_BYTES,
 			}),
 		verifyArchive: (archivePath) => verifyChecksum(archivePath, expectedChecksum),
 		extractArchive: async (archivePath, stagingDir) => {


### PR DESCRIPTION
### Related GitHub Issue

Closes: #1305

### Description

Raises the Semble archive download cap from 50 MiB to 100 MiB. The previous cap was below both v0.4.1 Linux release assets (59.2 MiB for ARM64 and 61.5 MiB for x64), causing official downloads to fail before installation.

The implementation keeps the shared managed-binary size protection in place while providing headroom for future Semble release growth. It also exports the Semble-specific limit and adds a focused regression assertion so an accidental reduction is caught by the downloader test suite.

### Test Procedure

1. From `src`, run:
   `npx vitest run services/code-index/semble/__tests__/semble-downloader.spec.ts`
2. Confirm all 32 tests pass, including `allows 100 MiB for future release growth`.
3. Run repository lint and type checks (also run by the commit/push hooks).

Validation completed:
- Semble downloader Vitest suite: 32 passed
- Repository lint: passed
- Repository type checks: passed

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Visual Snapshot** (UI changes only): Not applicable; this change has no UI-rendering impact.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

Not applicable; no UI changes.

### Videos (interaction / animation only)

Not applicable; no interaction or animation changes.

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required.

### Additional Notes

The 50 MiB limit was added by the managed-binary hardening in commit `7918f6b6b`. The current Semble v0.4.1 Linux assets already exceeded it, while macOS ARM64 and Windows x64 remained below it.

### Get in Touch

GitHub: @navedmerchant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum supported Semble archive download size from 50 MiB to 100 MiB.

- **Bug Fixes**
  - Improved handling of larger archive downloads while preserving checksum validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->