### PR TITLE
fix(task): mark interrupted tool calls as errors in persisted history

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -2101,10 +2101,16 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 						const toolUseBlocks = content.filter(
 							(block) => block.type === "tool_use",
 						) as Anthropic.Messages.ToolUseBlock[]
+						// Mark the synthetic results as errors (is_error: true) so the persisted
+						// history cannot be misread as a successful completion of the interrupted
+						// tool calls (e.g. attempt_completion). The task list already records the
+						// task as interrupted; the API history must agree.
+						// See: https://github.com/Zoo-Code-Org/Zoo-Code/issues/1283
 						const toolResponses: Anthropic.ToolResultBlockParam[] = toolUseBlocks.map((block) => ({
 							type: "tool_result",
 							tool_use_id: block.id,
 							content: "Task was interrupted before this tool call could be completed.",
+							is_error: true,
 						}))
 						modifiedApiConversationHistory = [...existingApiConversationHistory] // no changes
 						modifiedOldUserContent = [...toolResponses]
@@ -2140,10 +2146,13 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 									(toolUse) =>
 										!existingToolResults.some((result) => result.tool_use_id === toolUse.id),
 								)
+								// is_error: true — same rationale as the assistant-last case above.
+								// See: https://github.com/Zoo-Code-Org/Zoo-Code/issues/1283
 								.map((toolUse) => ({
 									type: "tool_result",
 									tool_use_id: toolUse.id,
 									content: "Task was interrupted before this tool call could be completed.",
+									is_error: true,
 								}))
 
 							modifiedApiConversationHistory = existingApiConversationHistory.slice(0, -1) // removes the last user message

--- a/src/core/task/__tests__/Task.persistence.spec.ts
+++ b/src/core/task/__tests__/Task.persistence.spec.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode"
 
 import type { ClineMessage, GlobalState, ProviderSettings } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
+import type { Anthropic } from "@anthropic-ai/sdk"
 
 import { Task } from "../Task"
 import { ClineProvider } from "../../webview/ClineProvider"
@@ -15,6 +16,7 @@ import { providerIdentifiers } from "@roo-code/types/provider-identifiers"
 type TaskPersistenceAccess = {
 	resumeTaskFromHistory: () => Promise<void>
 	saveClineMessages: () => Promise<boolean>
+	initiateTaskLoop: (userContent: Anthropic.Messages.ContentBlockParam[]) => Promise<void>
 }
 
 function getTaskPersistenceAccess(task: Task): TaskPersistenceAccess {
@@ -581,6 +583,140 @@ describe("Task persistence", () => {
 
 			expect(saveClineMessagesSpy).toHaveBeenCalledTimes(1)
 			expect(mockSaveTaskMessages).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	// ── resumeTaskFromHistory — interrupted tool calls must be recorded as errors ──
+
+	describe("resumeTaskFromHistory interrupted tool calls", () => {
+		const interruptedToolResultContent = "Task was interrupted before this tool call could be completed."
+
+		it("marks synthetic tool_results from an interrupted assistant turn as errors", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				historyItem: {
+					id: "interrupted-subtask",
+					number: 1,
+					ts: Date.now(),
+					task: "Interrupted subtask",
+					tokensIn: 10,
+					tokensOut: 5,
+					totalCost: 0.001,
+				},
+				startTask: false,
+				initialStatus: "interrupted",
+			})
+			// Stop the resume flow right before the agentic loop so the test only
+			// exercises history reconstruction; the loop would make a real API call.
+			const initiateTaskLoopSpy = vi
+				.spyOn(getTaskPersistenceAccess(task), "initiateTaskLoop")
+				.mockResolvedValue(undefined)
+			vi.spyOn(task, "ask").mockResolvedValue({ response: "noButtonClicked" })
+
+			// The persisted history ends with an assistant turn whose tool calls
+			// (attempt_completion) were never answered because the task was
+			// interrupted. See: https://github.com/Zoo-Code-Org/Zoo-Code/issues/1283
+			mockReadApiMessages.mockResolvedValue([
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Wrapping up" },
+						{
+							type: "tool_use",
+							id: "toolu_interrupted_1",
+							name: "attempt_completion",
+							input: { result: "done" },
+						},
+					],
+				},
+			])
+
+			await getTaskPersistenceAccess(task).resumeTaskFromHistory()
+
+			expect(initiateTaskLoopSpy).toHaveBeenCalledTimes(1)
+			const newUserContent = initiateTaskLoopSpy.mock.calls[0][0]
+			const toolResults = newUserContent.filter((block) => block.type === "tool_result")
+			// The synthetic tool_result must be recorded as an error so the history
+			// cannot be misread as a successful completion of the interrupted call.
+			expect(toolResults).toEqual([
+				{
+					type: "tool_result",
+					tool_use_id: "toolu_interrupted_1",
+					content: interruptedToolResultContent,
+					is_error: true,
+				},
+			])
+		})
+
+		it("marks missing tool_results for an interrupted trailing user turn as errors", async () => {
+			const task = new Task({
+				provider: mockProvider,
+				apiConfiguration: mockApiConfig,
+				historyItem: {
+					id: "interrupted-subtask-2",
+					number: 2,
+					ts: Date.now(),
+					task: "Interrupted subtask 2",
+					tokensIn: 10,
+					tokensOut: 5,
+					totalCost: 0.001,
+				},
+				startTask: false,
+				initialStatus: "interrupted",
+			})
+			const initiateTaskLoopSpy = vi
+				.spyOn(getTaskPersistenceAccess(task), "initiateTaskLoop")
+				.mockResolvedValue(undefined)
+			vi.spyOn(task, "ask").mockResolvedValue({ response: "noButtonClicked" })
+
+			// The persisted history ends with a user turn that only answered the
+			// first of two parallel tool calls.
+			mockReadApiMessages.mockResolvedValue([
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "toolu_int_a",
+							name: "execute_command",
+							input: { command: "ls" },
+						},
+						{ type: "tool_use", id: "toolu_int_b", name: "read_file", input: { path: "a.txt" } },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "toolu_int_a",
+							content: "partial result",
+						},
+					],
+				},
+			])
+
+			await getTaskPersistenceAccess(task).resumeTaskFromHistory()
+
+			expect(initiateTaskLoopSpy).toHaveBeenCalledTimes(1)
+			const newUserContent = initiateTaskLoopSpy.mock.calls[0][0]
+			const toolResults = newUserContent.filter((block) => block.type === "tool_result")
+			// The pre-existing result is preserved untouched; the synthesized one
+			// for the unanswered tool call is marked as an error.
+			expect(toolResults).toEqual([
+				{
+					type: "tool_result",
+					tool_use_id: "toolu_int_a",
+					content: "partial result",
+				},
+				{
+					type: "tool_result",
+					tool_use_id: "toolu_int_b",
+					content: interruptedToolResultContent,
+					is_error: true,
+				},
+			])
 		})
 	})
 


### PR DESCRIPTION
### Related GitHub Issue

Closes #1283

### Description

When a task is interrupted while an assistant turn's tool calls (e.g. an unconfirmed `attempt_completion`) are still unanswered, `resumeTaskFromHistory` synthesizes `tool_result` blocks so the persisted API conversation stays valid. Those synthetic blocks did not carry `is_error: true`, so the persisted `api_conversation_history.json` ended with a success-looking completion while the task list recorded the task as **interrupted** — and the parent stayed delegated. Any consumer that infers completion from the history (imports, tooling, future delegation logic) was fooled into thinking the task finished.

This fix sets `is_error: true` on the two synthetic tool_result sites in `Task.resumeTaskFromHistory`:

- assistant-last case: tool results synthesized for every `tool_use` in the final assistant turn,
- missing-results case: results synthesized for `tool_use` blocks the final user turn did not answer.

This matches the existing error tool_result pattern already used for `new_task` truncation in the same file, so the task-list status and the persisted conversation now agree.

### Test Procedure

Added two regression tests in `src/core/task/__tests__/Task.persistence.spec.ts` (describe: "resumeTaskFromHistory interrupted tool calls"). Both spy on `initiateTaskLoop` to stop the flow right before the agentic loop, feed a persisted history that ends mid-tool-call with `initialStatus: "interrupted"`, and assert the synthetic `tool_result` blocks passed to the loop carry `is_error: true` with the correct `tool_use_id` (the second test also asserts a pre-existing partial result is preserved untouched).

```shell
cd src
pnpm exec vitest run core/task/__tests__/Task.persistence.spec.ts   # 15/15 passing (13 pre-existing + 2 new)
pnpm exec eslint --prune-suppressions --max-warnings=0 core/task/Task.ts core/task/__tests__/Task.persistence.spec.ts   # clean, no suppression count changes
pnpm check-types   # 11/11 packages passing
```

No manual testing required: the change only alters metadata on persisted history and is fully covered by unit tests. No UI changes, so no visual snapshot needed.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (see "Test Procedure").
- [x] **Visual Snapshot** (UI changes only): N/A — no UI changes.
- [x] **Documentation Impact**: No documentation updates are required.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Get in Touch

easonLiangWorldedtech


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupted tool calls now correctly appear as errors when a task resumes.
  * Existing tool results and interruption details remain unchanged.

* **Tests**
  * Added coverage for task recovery in multiple conversation-history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->