### PR TITLE
feat(models): add Gemini 3.5 Flash Lite and 3.1 Flash Lite to Gemini API provider

### DIFF
--- a/packages/types/src/__tests__/google-models.test.ts
+++ b/packages/types/src/__tests__/google-models.test.ts
@@ -27,6 +27,9 @@ describe.each([
 it("exposes the documented thinking levels and pricing for Gemini 3.5 Flash Lite", () => {
 	const model = geminiModels["gemini-3.5-flash-lite"]
 	expect(model.supportsReasoningEffort).toEqual(["minimal", "low", "medium", "high"])
+	// The documented API default is On (minimal):
+	// https://ai.google.dev/gemini-api/docs/thinking
+	expect(model.reasoningEffort).toBe("minimal")
 	expect(model.inputPrice).toBe(0.3)
 	expect(model.outputPrice).toBe(2.5)
 	expect(model.cacheReadsPrice).toBe(0.03)
@@ -38,6 +41,8 @@ it("exposes the documented thinking levels and pricing for Gemini 3.1 Flash Lite
 	// https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite
 	// "choosing from minimal, low, medium, or high thinking levels"
 	expect(model.supportsReasoningEffort).toEqual(["minimal", "low", "medium", "high"])
+	// Lowest supported level, matching the cheap/free Flash Lite tier.
+	expect(model.reasoningEffort).toBe("minimal")
 	expect(model.inputPrice).toBe(0.25)
 	expect(model.outputPrice).toBe(1.5)
 	expect(model.cacheReadsPrice).toBe(0.025)

--- a/packages/types/src/__tests__/google-models.test.ts
+++ b/packages/types/src/__tests__/google-models.test.ts
@@ -10,3 +10,34 @@ describe.each([
 		expect(model.cacheWritesPrice).toBe(0.5)
 	})
 })
+
+describe.each([
+	["gemini-3.5-flash-lite", geminiModels["gemini-3.5-flash-lite"]],
+	["gemini-3.1-flash-lite", geminiModels["gemini-3.1-flash-lite"]],
+])("Gemini 3.x Flash Lite model %s", (_modelId, model) => {
+	it("is registered with the documented limits and multimodal support", () => {
+		expect(model.maxTokens).toBe(65_536)
+		expect(model.contextWindow).toBe(1_048_576)
+		expect(model.supportsImages).toBe(true)
+		expect(model.supportsPromptCache).toBe(true)
+		expect(model.supportsReasoningBudget).toBe(false)
+	})
+})
+
+it("exposes the documented thinking levels and pricing for Gemini 3.5 Flash Lite", () => {
+	const model = geminiModels["gemini-3.5-flash-lite"]
+	expect(model.supportsReasoningEffort).toEqual(["minimal", "low", "medium", "high"])
+	expect(model.inputPrice).toBe(0.3)
+	expect(model.outputPrice).toBe(2.5)
+	expect(model.cacheReadsPrice).toBe(0.03)
+	expect(model.cacheWritesPrice).toBe(1.0)
+})
+
+it("exposes the documented thinking levels and pricing for Gemini 3.1 Flash Lite", () => {
+	const model = geminiModels["gemini-3.1-flash-lite"]
+	expect(model.supportsReasoningEffort).toEqual(["low", "medium", "high"])
+	expect(model.inputPrice).toBe(0.25)
+	expect(model.outputPrice).toBe(1.5)
+	expect(model.cacheReadsPrice).toBe(0.025)
+	expect(model.cacheWritesPrice).toBe(1.0)
+})

--- a/packages/types/src/__tests__/google-models.test.ts
+++ b/packages/types/src/__tests__/google-models.test.ts
@@ -35,7 +35,9 @@ it("exposes the documented thinking levels and pricing for Gemini 3.5 Flash Lite
 
 it("exposes the documented thinking levels and pricing for Gemini 3.1 Flash Lite", () => {
 	const model = geminiModels["gemini-3.1-flash-lite"]
-	expect(model.supportsReasoningEffort).toEqual(["low", "medium", "high"])
+	// https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite
+	// "choosing from minimal, low, medium, or high thinking levels"
+	expect(model.supportsReasoningEffort).toEqual(["minimal", "low", "medium", "high"])
 	expect(model.inputPrice).toBe(0.25)
 	expect(model.outputPrice).toBe(1.5)
 	expect(model.cacheReadsPrice).toBe(0.025)

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -164,7 +164,7 @@ export const geminiModels = {
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: true,
-		supportsReasoningEffort: ["low", "medium", "high"],
+		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
 		reasoningEffort: "medium",
 		inputPrice: 0.25,
 		outputPrice: 1.5,

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -145,6 +145,34 @@ export const geminiModels = {
 		outputPrice: 3.0,
 		cacheReadsPrice: 0.05,
 	},
+	// 3.x Flash Lite models
+	"gemini-3.5-flash-lite": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
+		reasoningEffort: "medium",
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.03,
+		cacheWritesPrice: 1.0,
+		supportsReasoningBudget: false,
+	},
+	"gemini-3.1-flash-lite": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		supportsReasoningEffort: ["low", "medium", "high"],
+		reasoningEffort: "medium",
+		inputPrice: 0.25,
+		outputPrice: 1.5,
+		cacheReadsPrice: 0.025,
+		cacheWritesPrice: 1.0,
+		supportsReasoningBudget: false,
+	},
+
 	// 2.5 Pro models
 	"gemini-2.5-pro": {
 		maxTokens: 64_000,

--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -152,7 +152,8 @@ export const geminiModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
-		reasoningEffort: "medium",
+		// Matches the documented API default thinking level (On (minimal)).
+		reasoningEffort: "minimal",
 		inputPrice: 0.3,
 		outputPrice: 2.5,
 		cacheReadsPrice: 0.03,
@@ -165,7 +166,9 @@ export const geminiModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
-		reasoningEffort: "medium",
+		// Lowest level of the supported set: keeps the cheap/free tier's
+		// default latency and cost in line with the Flash Lite tier.
+		reasoningEffort: "minimal",
 		inputPrice: 0.25,
 		outputPrice: 1.5,
 		cacheReadsPrice: 0.025,


### PR DESCRIPTION
Fixes #1251

Adds the two new stable Flash Lite models to the Gemini API provider's model list so users can pick them directly instead of relying only on `gemini-flash-lite-latest`:

- `gemini-3.5-flash-lite` (stable, updated Jul 2026)
- `gemini-3.1-flash-lite` (stable, updated May 2026)

### Verification

Both model ids were cross-checked against three independent sources:

1. Official Gemini API model pages (linked below)
2. The [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing) and the [thinking levels table](https://ai.google.dev/gemini-api/docs/thinking)
3. The live OpenRouter model catalog (`google/gemini-3.5-flash-lite`, `google/gemini-3.1-flash-lite`)

| | `gemini-3.5-flash-lite` | `gemini-3.1-flash-lite` |
| --- | --- | --- |
| Input context | 1,048,576 | 1,048,576 |
| Max output | 65,536 | 65,536 |
| Thinking levels | minimal / low / medium / high | minimal / low / medium / high |
| Input ($/1M tokens) | 0.30 | 0.25 |
| Output ($/1M tokens) | 2.50 | 1.50 |
| Cache read ($/1M tokens) | 0.03 | 0.025 |
| Cache storage ($/1M tokens/h) | 1.00 | 1.00 |

Notes on the fields chosen:

- `cacheWritesPrice` follows the existing convention in `gemini.ts` of storing the context-cache **storage** price there (e.g. `gemini-3.7-flash` → `0.5`).
- `gemini-3.5-flash-lite` is listed in the [official thinking table](https://ai.google.dev/gemini-api/docs/thinking) with `minimal`/`low`/`medium`/`high` and a documented API default of `On (minimal)`. `gemini-3.1-flash-lite` supports the same levels per its [Cloud docs model page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite) ("choosing from minimal, low, medium, or high thinking levels"). Both default to `reasoningEffort: "minimal"` so unset users keep the cheap tier's default latency/cost instead of being upgraded to a higher thinking level. Neither is a budget-style model, so `supportsReasoningBudget` is `false` like the other 3.x entries.
- `cacheWritesPrice` stores the context-cache **storage** price, matching the existing convention for the 3.x entries (e.g. `gemini-3.6-flash` → `1.0`).
- `gemini-3.1-flash-lite-preview` was retired by Google, so it is intentionally not added.

Sources:

- https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite
- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite
- https://ai.google.dev/gemini-api/docs/pricing
- https://ai.google.dev/gemini-api/docs/thinking
- https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-lite

### Tests

- `packages/types`: `pnpm --dir packages/types test` — 368 passed (including new cases in `google-models.test.ts`)
- `src`: `pnpm --dir src exec vitest run api/providers/__tests__/gemini.spec.ts shared/__tests__/api.spec.ts` — 63 passed
- `tsc --noEmit` and `eslint --max-warnings=0` clean on the touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Gemini 3.5 Flash Lite and Gemini 3.1 Flash Lite models.
  - Added multimodal input, prompt caching, reasoning-level controls, and model-specific token limits.
  - Configured minimal reasoning as the default for both models.
  - Added pricing information for the new models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->