### PR TITLE
fix(zoo-gateway): stop inventing UI cost from default model prices

### DIFF
--- a/src/api/providers/__tests__/kenari.spec.ts
+++ b/src/api/providers/__tests__/kenari.spec.ts
@@ -34,6 +34,10 @@ vitest.mock("../fetchers/modelCache", () => ({
 			},
 		}),
 	),
+	refreshModels: vitest.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 	getModelsFromCache: vitest.fn().mockReturnValue(undefined),
 }))
 

--- a/src/api/providers/__tests__/kimi-code.spec.ts
+++ b/src/api/providers/__tests__/kimi-code.spec.ts
@@ -17,7 +17,10 @@ vi.mock("../../../integrations/kimi-code/oauth", () => ({
 	},
 }))
 
-vi.mock("../fetchers/modelCache", () => ({ getModels: mockGetModels }))
+vi.mock("../fetchers/modelCache", () => ({
+	getModels: mockGetModels,
+	refreshModels: mockGetModels,
+}))
 
 describe("KimiCodeHandler", () => {
 	beforeEach(() => {

--- a/src/api/providers/__tests__/lite-llm.spec.ts
+++ b/src/api/providers/__tests__/lite-llm.spec.ts
@@ -58,6 +58,10 @@ vi.mock("../fetchers/modelCache", () => ({
 			"vertex_ai/gemini-3-pro": { ...litellmDefaultModelInfo, maxTokens: 8192 },
 		})
 	}),
+	refreshModels: vi.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 	getModelsFromCache: vi.fn().mockReturnValue(undefined),
 }))
 

--- a/src/api/providers/__tests__/nanogpt.spec.ts
+++ b/src/api/providers/__tests__/nanogpt.spec.ts
@@ -23,6 +23,15 @@ vi.mock("../fetchers/modelCache", () => ({
 			supportsReasoningEffort: ["low", "medium", "high"],
 		},
 	}),
+	refreshModels: vi.fn().mockResolvedValue({
+		"model:thinking": {
+			maxTokens: 128000,
+			contextWindow: 1050000,
+			supportsImages: true,
+			supportsPromptCache: false,
+			supportsReasoningEffort: ["low", "medium", "high"],
+		},
+	}),
 	getModelsFromCache: vi.fn(),
 }))
 

--- a/src/api/providers/__tests__/opencode-go.spec.ts
+++ b/src/api/providers/__tests__/opencode-go.spec.ts
@@ -36,6 +36,12 @@ vitest.mock("../fetchers/modelCache", () => ({
 			"qwen3.7-max": { ...opencodeGoModels["qwen3.7-max"] },
 		})
 	}),
+	refreshModels: vitest.fn().mockImplementation(function () {
+		return Promise.resolve({
+			"glm-5.1": { ...opencodeGoModels["glm-5.1"] },
+			"qwen3.7-max": { ...opencodeGoModels["qwen3.7-max"] },
+		})
+	}),
 	getModelsFromCache: vitest.fn().mockReturnValue(undefined),
 }))
 

--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -102,6 +102,10 @@ vitest.mock("../fetchers/modelCache", () => ({
 			},
 		})
 	}),
+	refreshModels: vitest.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 }))
 
 describe("OpenRouterHandler", () => {

--- a/src/api/providers/__tests__/requesty.spec.ts
+++ b/src/api/providers/__tests__/requesty.spec.ts
@@ -96,6 +96,10 @@ vitest.mock("../fetchers/modelCache", () => ({
 			},
 		})
 	}),
+	refreshModels: vitest.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 }))
 
 describe("RequestyHandler", () => {

--- a/src/api/providers/__tests__/unbound.spec.ts
+++ b/src/api/providers/__tests__/unbound.spec.ts
@@ -32,6 +32,10 @@ vi.mock("../fetchers/modelCache", () => ({
 			description: "GPT-4o",
 		},
 	}),
+	refreshModels: vi.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 }))
 
 describe("UnboundHandler", () => {

--- a/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
+++ b/src/api/providers/__tests__/vercel-ai-gateway.spec.ts
@@ -99,6 +99,10 @@ vitest.mock("../fetchers/modelCache", () => ({
 			},
 		})
 	}),
+	refreshModels: vitest.fn(async (options) => {
+		const { getModels } = await import("../fetchers/modelCache")
+		return getModels(options)
+	}),
 	getModelsFromCache: vitest.fn().mockReturnValue(undefined),
 }))
 

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -311,6 +311,39 @@ describe("ZooGatewayHandler", () => {
 			})
 		})
 
+		it("defaults totalCost to 0 when usage omits cost", async () => {
+			mockCreate.mockImplementation(async () =>
+				asyncStreamFrom([
+					{
+						choices: [{ delta: { content: "ok" }, index: 0 }],
+						usage: null,
+					},
+					{
+						choices: [{ delta: {}, index: 0 }],
+						usage: {
+							prompt_tokens: 10,
+							completion_tokens: 5,
+							total_tokens: 15,
+						},
+					},
+				]),
+			)
+
+			const handler = new ZooGatewayHandler(mockOptions)
+			const chunks = await collectStream(
+				handler.createMessage("You are helpful.", [{ role: "user", content: "Hello" }]),
+			)
+
+			expect(chunks).toContainEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+				cacheWriteTokens: undefined,
+				cacheReadTokens: undefined,
+				totalCost: 0,
+			})
+		})
+
 		it("forwards task and mode metadata as request headers", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
 
@@ -694,43 +727,49 @@ describe("ZooGatewayHandler", () => {
 		})
 
 		it("refetches when the configured model is missing from a populated map", async () => {
-			const { getModels } = await import("../fetchers/modelCache")
-			vitest.mocked(getModels).mockResolvedValueOnce({
-				"anthropic/claude-sonnet-4": {
-					maxTokens: 64000,
-					contextWindow: 200000,
-					supportsImages: true,
-					supportsPromptCache: true,
-					inputPrice: 3,
-					outputPrice: 15,
-				},
-			})
+			vitest.useFakeTimers()
+			try {
+				const { getModels } = await import("../fetchers/modelCache")
+				vitest.mocked(getModels).mockResolvedValueOnce({
+					"anthropic/claude-sonnet-4": {
+						maxTokens: 64000,
+						contextWindow: 200000,
+						supportsImages: true,
+						supportsPromptCache: true,
+						inputPrice: 3,
+						outputPrice: 15,
+					},
+				})
 
-			const handler = new ZooGatewayHandler({
-				...mockOptions,
-				zooGatewayModelId: "alibaba/qwen3.8-max",
-			})
+				const handler = new ZooGatewayHandler({
+					...mockOptions,
+					zooGatewayModelId: "alibaba/qwen3.8-max",
+				})
 
-			await handler.ensureModelFetched()
-			expect(handler.getModel().info.inputPrice).toBe(0)
+				await handler.ensureModelFetched()
+				expect(handler.getModel().info.inputPrice).toBe(0)
 
-			vitest.mocked(getModels).mockClear()
-			vitest.mocked(getModels).mockResolvedValueOnce({
-				"alibaba/qwen3.8-max": {
-					maxTokens: 65536,
-					contextWindow: 1_000_000,
-					supportsImages: true,
-					supportsPromptCache: true,
-					inputPrice: 0.222,
-					outputPrice: 0.667,
-				},
-			})
+				vitest.mocked(getModels).mockClear()
+				vitest.mocked(getModels).mockResolvedValueOnce({
+					"alibaba/qwen3.8-max": {
+						maxTokens: 65536,
+						contextWindow: 1_000_000,
+						supportsImages: true,
+						supportsPromptCache: true,
+						inputPrice: 0.222,
+						outputPrice: 0.667,
+					},
+				})
 
-			await handler.ensureModelFetched()
+				vitest.advanceTimersByTime(5 * 60 * 1000 + 1)
+				await handler.ensureModelFetched()
 
-			expect(getModels).toHaveBeenCalled()
-			expect(handler.getModel().info.inputPrice).toBe(0.222)
-			expect(handler.getModel().info.outputPrice).toBe(0.667)
+				expect(getModels).toHaveBeenCalled()
+				expect(handler.getModel().info.inputPrice).toBe(0.222)
+				expect(handler.getModel().info.outputPrice).toBe(0.667)
+			} finally {
+				vitest.useRealTimers()
+			}
 		})
 
 		it("does not reuse default model prices for an unknown configured model", async () => {
@@ -750,6 +789,34 @@ describe("ZooGatewayHandler", () => {
 			expect(info.outputPrice).toBe(0)
 			expect(info.cacheWritesPrice).toBe(0)
 			expect(info.cacheReadsPrice).toBe(0)
+		})
+
+		it("does not refetch an unresolved model on every ensureModelFetched call", async () => {
+			const { getModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValue({
+				"anthropic/claude-sonnet-4": {
+					maxTokens: 64000,
+					contextWindow: 200000,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 3,
+					outputPrice: 15,
+				},
+			})
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+			vitest.mocked(getModels).mockClear()
+
+			await handler.ensureModelFetched()
+			await handler.ensureModelFetched()
+
+			expect(getModels).not.toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0)
 		})
 
 		it("deduplicates concurrent calls into a single fetch", async () => {

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -277,6 +277,40 @@ describe("ZooGatewayHandler", () => {
 			])
 		})
 
+		it("forwards gateway usage.cost as totalCost so the panel matches billing", async () => {
+			mockCreate.mockImplementation(async () =>
+				asyncStreamFrom([
+					{
+						choices: [{ delta: { content: "ok" }, index: 0 }],
+						usage: null,
+					},
+					{
+						choices: [{ delta: {}, index: 0 }],
+						usage: {
+							prompt_tokens: 25694,
+							completion_tokens: 829,
+							total_tokens: 26523,
+							cost: 0.006262,
+						},
+					},
+				]),
+			)
+
+			const handler = new ZooGatewayHandler(mockOptions)
+			const chunks = await collectStream(
+				handler.createMessage("You are helpful.", [{ role: "user", content: "Hello" }]),
+			)
+
+			expect(chunks).toContainEqual({
+				type: "usage",
+				inputTokens: 25694,
+				outputTokens: 829,
+				cacheWriteTokens: undefined,
+				cacheReadTokens: undefined,
+				totalCost: 0.006262,
+			})
+		})
+
 		it("forwards task and mode metadata as request headers", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
 
@@ -657,6 +691,65 @@ describe("ZooGatewayHandler", () => {
 
 			await handler.fetchModel()
 			expect(getModels).not.toHaveBeenCalled()
+		})
+
+		it("refetches when the configured model is missing from a populated map", async () => {
+			const { getModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValueOnce({
+				"anthropic/claude-sonnet-4": {
+					maxTokens: 64000,
+					contextWindow: 200000,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 3,
+					outputPrice: 15,
+				},
+			})
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+			expect(handler.getModel().info.inputPrice).toBe(0)
+
+			vitest.mocked(getModels).mockClear()
+			vitest.mocked(getModels).mockResolvedValueOnce({
+				"alibaba/qwen3.8-max": {
+					maxTokens: 65536,
+					contextWindow: 1_000_000,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 0.222,
+					outputPrice: 0.667,
+				},
+			})
+
+			await handler.ensureModelFetched()
+
+			expect(getModels).toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0.222)
+			expect(handler.getModel().info.outputPrice).toBe(0.667)
+		})
+
+		it("does not reuse default model prices for an unknown configured model", async () => {
+			const { getModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValueOnce({})
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+
+			const { id, info } = handler.getModel()
+			expect(id).toBe("alibaba/qwen3.8-max")
+			expect(info.inputPrice).toBe(0)
+			expect(info.outputPrice).toBe(0)
+			expect(info.cacheWritesPrice).toBe(0)
+			expect(info.cacheReadsPrice).toBe(0)
 		})
 
 		it("deduplicates concurrent calls into a single fetch", async () => {

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -819,6 +819,24 @@ describe("ZooGatewayHandler", () => {
 			expect(handler.getModel().info.inputPrice).toBe(0)
 		})
 
+		it("negative-caches an empty catalog response for a missing model", async () => {
+			const { getModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValue({})
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+			vitest.mocked(getModels).mockClear()
+
+			await handler.ensureModelFetched()
+
+			expect(getModels).not.toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0)
+		})
+
 		it("deduplicates concurrent calls into a single fetch", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
 			const { getModels } = await import("../fetchers/modelCache")

--- a/src/api/providers/__tests__/zoo-gateway.spec.ts
+++ b/src/api/providers/__tests__/zoo-gateway.spec.ts
@@ -43,32 +43,37 @@ vitest.mock("delay", () => ({
 		return Promise.resolve()
 	}),
 }))
+const DEFAULT_MODEL_CATALOG = vitest.hoisted(() => ({
+	"anthropic/claude-sonnet-4": {
+		maxTokens: 64000,
+		contextWindow: 200000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 3,
+		outputPrice: 15,
+		cacheWritesPrice: 3.75,
+		cacheReadsPrice: 0.3,
+		description: "Claude Sonnet 4",
+	},
+	"anthropic/claude-3.5-haiku": {
+		maxTokens: 32000,
+		contextWindow: 200000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 1,
+		outputPrice: 5,
+		cacheWritesPrice: 1.25,
+		cacheReadsPrice: 0.1,
+		description: "Claude 3.5 Haiku",
+	},
+}))
+
 vitest.mock("../fetchers/modelCache", () => ({
 	getModels: vitest.fn().mockImplementation(function () {
-		return Promise.resolve({
-			"anthropic/claude-sonnet-4": {
-				maxTokens: 64000,
-				contextWindow: 200000,
-				supportsImages: true,
-				supportsPromptCache: true,
-				inputPrice: 3,
-				outputPrice: 15,
-				cacheWritesPrice: 3.75,
-				cacheReadsPrice: 0.3,
-				description: "Claude Sonnet 4",
-			},
-			"anthropic/claude-3.5-haiku": {
-				maxTokens: 32000,
-				contextWindow: 200000,
-				supportsImages: true,
-				supportsPromptCache: true,
-				inputPrice: 1,
-				outputPrice: 5,
-				cacheWritesPrice: 1.25,
-				cacheReadsPrice: 0.1,
-				description: "Claude 3.5 Haiku",
-			},
-		})
+		return Promise.resolve(DEFAULT_MODEL_CATALOG)
+	}),
+	refreshModels: vitest.fn().mockImplementation(function () {
+		return Promise.resolve(DEFAULT_MODEL_CATALOG)
 	}),
 	getModelsFromCache: vitest.fn().mockReturnValue(undefined),
 }))
@@ -119,8 +124,22 @@ describe("ZooGatewayHandler", () => {
 		zooGatewayModelId: "anthropic/claude-sonnet-4",
 	}
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		clearAllMocks()
+		const { getModels, refreshModels, getModelsFromCache } = await import("../fetchers/modelCache")
+		vitest
+			.mocked(getModels)
+			.mockReset()
+			.mockImplementation(function () {
+				return Promise.resolve(DEFAULT_MODEL_CATALOG)
+			})
+		vitest
+			.mocked(refreshModels)
+			.mockReset()
+			.mockImplementation(function () {
+				return Promise.resolve(DEFAULT_MODEL_CATALOG)
+			})
+		vitest.mocked(getModelsFromCache).mockReset().mockReturnValue(undefined)
 		mockSessionCleared.value = false
 		mockGetCachedZooCodeToken.mockReturnValue(undefined)
 		mockCreate.mockClear()
@@ -695,42 +714,47 @@ describe("ZooGatewayHandler", () => {
 	describe("ensureModelFetched", () => {
 		it("fetches models when instance models are empty", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 
 			expect(handler.getModel().info.contextWindow).toBe(200000)
 
 			await handler.ensureModelFetched()
 
 			expect(getModels).toHaveBeenCalled()
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 
 		it("skips the fetch when models are already populated", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 
 			await handler.ensureModelFetched()
 			vitest.mocked(getModels).mockClear()
+			vitest.mocked(refreshModels).mockClear()
 
 			await handler.ensureModelFetched()
 			expect(getModels).not.toHaveBeenCalled()
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 
 		it("short-circuits a subsequent fetchModel call after models are populated", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 
 			await handler.ensureModelFetched()
 			vitest.mocked(getModels).mockClear()
+			vitest.mocked(refreshModels).mockClear()
 
 			await handler.fetchModel()
 			expect(getModels).not.toHaveBeenCalled()
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 
 		it("refetches when the configured model is missing from a populated map", async () => {
 			vitest.useFakeTimers()
 			try {
-				const { getModels } = await import("../fetchers/modelCache")
-				vitest.mocked(getModels).mockResolvedValueOnce({
+				const { getModels, refreshModels } = await import("../fetchers/modelCache")
+				const staleCatalog = {
 					"anthropic/claude-sonnet-4": {
 						maxTokens: 64000,
 						contextWindow: 200000,
@@ -739,7 +763,9 @@ describe("ZooGatewayHandler", () => {
 						inputPrice: 3,
 						outputPrice: 15,
 					},
-				})
+				}
+				vitest.mocked(getModels).mockResolvedValueOnce(staleCatalog)
+				vitest.mocked(refreshModels).mockResolvedValueOnce(staleCatalog)
 
 				const handler = new ZooGatewayHandler({
 					...mockOptions,
@@ -749,8 +775,7 @@ describe("ZooGatewayHandler", () => {
 				await handler.ensureModelFetched()
 				expect(handler.getModel().info.inputPrice).toBe(0)
 
-				vitest.mocked(getModels).mockClear()
-				vitest.mocked(getModels).mockResolvedValueOnce({
+				const freshCatalog = {
 					"alibaba/qwen3.8-max": {
 						maxTokens: 65536,
 						contextWindow: 1_000_000,
@@ -759,12 +784,16 @@ describe("ZooGatewayHandler", () => {
 						inputPrice: 0.222,
 						outputPrice: 0.667,
 					},
-				})
+				}
+				vitest.mocked(getModels).mockClear()
+				vitest.mocked(refreshModels).mockClear()
+				vitest.mocked(getModels).mockResolvedValueOnce(freshCatalog)
 
 				vitest.advanceTimersByTime(5 * 60 * 1000 + 1)
 				await handler.ensureModelFetched()
 
 				expect(getModels).toHaveBeenCalled()
+				expect(refreshModels).not.toHaveBeenCalled()
 				expect(handler.getModel().info.inputPrice).toBe(0.222)
 				expect(handler.getModel().info.outputPrice).toBe(0.667)
 			} finally {
@@ -773,8 +802,9 @@ describe("ZooGatewayHandler", () => {
 		})
 
 		it("does not reuse default model prices for an unknown configured model", async () => {
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 			vitest.mocked(getModels).mockResolvedValueOnce({})
+			vitest.mocked(refreshModels).mockResolvedValueOnce({})
 
 			const handler = new ZooGatewayHandler({
 				...mockOptions,
@@ -792,8 +822,61 @@ describe("ZooGatewayHandler", () => {
 		})
 
 		it("does not refetch an unresolved model on every ensureModelFetched call", async () => {
-			const { getModels } = await import("../fetchers/modelCache")
-			vitest.mocked(getModels).mockResolvedValue({
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
+			const catalog = {
+				"anthropic/claude-sonnet-4": {
+					maxTokens: 64000,
+					contextWindow: 200000,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 3,
+					outputPrice: 15,
+				},
+			}
+			vitest.mocked(getModels).mockResolvedValue(catalog)
+			vitest.mocked(refreshModels).mockResolvedValue(catalog)
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+			vitest.mocked(getModels).mockClear()
+			vitest.mocked(refreshModels).mockClear()
+
+			await handler.ensureModelFetched()
+			await handler.ensureModelFetched()
+
+			expect(getModels).not.toHaveBeenCalled()
+			expect(refreshModels).not.toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0)
+		})
+
+		it("negative-caches an empty catalog response for a missing model", async () => {
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValue({})
+			vitest.mocked(refreshModels).mockResolvedValue({})
+
+			const handler = new ZooGatewayHandler({
+				...mockOptions,
+				zooGatewayModelId: "alibaba/qwen3.8-max",
+			})
+
+			await handler.ensureModelFetched()
+			vitest.mocked(getModels).mockClear()
+			vitest.mocked(refreshModels).mockClear()
+
+			await handler.ensureModelFetched()
+
+			expect(getModels).not.toHaveBeenCalled()
+			expect(refreshModels).not.toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0)
+		})
+
+		it("force-refreshes before negative-caching when shared catalog is stale", async () => {
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
+			vitest.mocked(getModels).mockResolvedValueOnce({
 				"anthropic/claude-sonnet-4": {
 					maxTokens: 64000,
 					contextWindow: 200000,
@@ -803,6 +886,16 @@ describe("ZooGatewayHandler", () => {
 					outputPrice: 15,
 				},
 			})
+			vitest.mocked(refreshModels).mockResolvedValueOnce({
+				"alibaba/qwen3.8-max": {
+					maxTokens: 65536,
+					contextWindow: 1_000_000,
+					supportsImages: true,
+					supportsPromptCache: true,
+					inputPrice: 0.222,
+					outputPrice: 0.667,
+				},
+			})
 
 			const handler = new ZooGatewayHandler({
 				...mockOptions,
@@ -810,41 +903,29 @@ describe("ZooGatewayHandler", () => {
 			})
 
 			await handler.ensureModelFetched()
+
+			expect(getModels).toHaveBeenCalled()
+			expect(refreshModels).toHaveBeenCalled()
+			expect(handler.getModel().info.inputPrice).toBe(0.222)
+			expect(handler.getModel().info.outputPrice).toBe(0.667)
+
 			vitest.mocked(getModels).mockClear()
-
+			vitest.mocked(refreshModels).mockClear()
 			await handler.ensureModelFetched()
-			await handler.ensureModelFetched()
-
 			expect(getModels).not.toHaveBeenCalled()
-			expect(handler.getModel().info.inputPrice).toBe(0)
-		})
-
-		it("negative-caches an empty catalog response for a missing model", async () => {
-			const { getModels } = await import("../fetchers/modelCache")
-			vitest.mocked(getModels).mockResolvedValue({})
-
-			const handler = new ZooGatewayHandler({
-				...mockOptions,
-				zooGatewayModelId: "alibaba/qwen3.8-max",
-			})
-
-			await handler.ensureModelFetched()
-			vitest.mocked(getModels).mockClear()
-
-			await handler.ensureModelFetched()
-
-			expect(getModels).not.toHaveBeenCalled()
-			expect(handler.getModel().info.inputPrice).toBe(0)
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 
 		it("deduplicates concurrent calls into a single fetch", async () => {
 			const handler = new ZooGatewayHandler(mockOptions)
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 			vitest.mocked(getModels).mockClear()
+			vitest.mocked(refreshModels).mockClear()
 
 			await Promise.all([handler.ensureModelFetched(), handler.ensureModelFetched()])
 
 			expect(getModels).toHaveBeenCalledTimes(1)
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 
 		it("recovers after a rejected fetch so later calls are not poisoned", async () => {
@@ -868,7 +949,7 @@ describe("ZooGatewayHandler", () => {
 		})
 
 		it("makes getModel return the fetched context window instead of the default", async () => {
-			const { getModels } = await import("../fetchers/modelCache")
+			const { getModels, refreshModels } = await import("../fetchers/modelCache")
 			vitest.mocked(getModels).mockResolvedValueOnce({
 				"google/gemini-2.5-pro": {
 					maxTokens: 65536,
@@ -888,6 +969,7 @@ describe("ZooGatewayHandler", () => {
 			await handler.ensureModelFetched()
 
 			expect(handler.getModel().info.contextWindow).toBe(1048576)
+			expect(refreshModels).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/src/api/providers/router-provider.ts
+++ b/src/api/providers/router-provider.ts
@@ -5,7 +5,7 @@ import { type ModelInfo, type ModelRecord } from "@roo-code/types"
 import { ApiHandlerOptions, RouterName } from "../../shared/api"
 
 import { BaseProvider } from "./base-provider"
-import { getModels, getModelsFromCache } from "./fetchers/modelCache"
+import { getModels, getModelsFromCache, refreshModels } from "./fetchers/modelCache"
 
 import { DEFAULT_HEADERS, NOT_PROVIDED } from "./constants"
 
@@ -74,23 +74,35 @@ export abstract class RouterProvider extends BaseProvider {
 		}
 
 		if (!this.modelFetchPromise) {
-			this.modelFetchPromise = getModels({
+			const fetchOptions = {
 				provider: this.name,
 				apiKey: this.apiKey,
 				baseUrl: this.client.baseURL,
-			})
-				.then((models) => {
+			}
+
+			this.modelFetchPromise = (async () => {
+				let models = await getModels(fetchOptions)
+				this.models = models
+
+				// getModels may return a shared cached catalog that predates this
+				// model. Force a provider refresh before recording a miss so
+				// newly listed models are not blocked for MISSING_MODEL_RETRY_MS.
+				// Auth-scoped providers already bypass that cache in getModels;
+				// refreshModels is then a no-op extra live fetch only on true misses.
+				if (!models[id]) {
+					models = await refreshModels(fetchOptions)
 					this.models = models
-					if (models[id]) {
-						this.missingModelRefreshAt.delete(id)
-					} else {
-						this.missingModelRefreshAt.set(id, Date.now())
-					}
-					return this.getModel()
-				})
-				.finally(() => {
-					this.modelFetchPromise = undefined
-				})
+				}
+
+				if (models[id]) {
+					this.missingModelRefreshAt.delete(id)
+				} else {
+					this.missingModelRefreshAt.set(id, Date.now())
+				}
+				return this.getModel()
+			})().finally(() => {
+				this.modelFetchPromise = undefined
+			})
 		}
 
 		return this.modelFetchPromise

--- a/src/api/providers/router-provider.ts
+++ b/src/api/providers/router-provider.ts
@@ -51,12 +51,26 @@ export abstract class RouterProvider extends BaseProvider {
 	}
 
 	private modelFetchPromise?: Promise<{ id: string; info: ModelInfo }>
+	/** Last catalog refresh attempt per missing model id (ms), for negative caching. */
+	private missingModelRefreshAt = new Map<string, number>()
+	private static readonly MISSING_MODEL_RETRY_MS = 5 * 60 * 1000
 
 	public async fetchModel() {
 		// Refetch when the selected model is missing — a stale non-empty map
 		// would otherwise keep serving defaultModelInfo prices for cost estimates.
 		const id = this.modelId || this.defaultModelId
 		if (this.models[id]) {
+			return this.getModel()
+		}
+
+		// After a catalog fetch that still lacks this id, don't hammer getModels
+		// on every createMessage; retry only after the negative-cache window.
+		const lastMissingAttempt = this.missingModelRefreshAt.get(id)
+		if (
+			lastMissingAttempt !== undefined &&
+			Date.now() - lastMissingAttempt < RouterProvider.MISSING_MODEL_RETRY_MS &&
+			Object.keys(this.models).length > 0
+		) {
 			return this.getModel()
 		}
 
@@ -68,6 +82,11 @@ export abstract class RouterProvider extends BaseProvider {
 			})
 				.then((models) => {
 					this.models = models
+					if (models[id]) {
+						this.missingModelRefreshAt.delete(id)
+					} else {
+						this.missingModelRefreshAt.set(id, Date.now())
+					}
 					return this.getModel()
 				})
 				.finally(() => {

--- a/src/api/providers/router-provider.ts
+++ b/src/api/providers/router-provider.ts
@@ -53,7 +53,10 @@ export abstract class RouterProvider extends BaseProvider {
 	private modelFetchPromise?: Promise<{ id: string; info: ModelInfo }>
 
 	public async fetchModel() {
-		if (Object.keys(this.models).length > 0) {
+		// Refetch when the selected model is missing — a stale non-empty map
+		// would otherwise keep serving defaultModelInfo prices for cost estimates.
+		const id = this.modelId || this.defaultModelId
+		if (this.models[id]) {
 			return this.getModel()
 		}
 
@@ -107,10 +110,21 @@ export abstract class RouterProvider extends BaseProvider {
 			return { id, info: cachedModels[id] }
 		}
 
-		// Last resort: preserve the configured model ID (falling back to the default
-		// only when none is configured) so an as-yet-unfetched model isn't silently
-		// swapped for the hardcoded default. info still comes from defaults since we
-		// have no fetched or cached metadata for the configured model at this point.
+		// Last resort: keep the configured id so we don't swap models, but zero
+		// prices so we don't bill the UI with defaultModelInfo's $/token rates.
+		if (id !== this.defaultModelId) {
+			return {
+				id,
+				info: {
+					...this.defaultModelInfo,
+					inputPrice: 0,
+					outputPrice: 0,
+					cacheWritesPrice: 0,
+					cacheReadsPrice: 0,
+				},
+			}
+		}
+
 		return { id, info: this.defaultModelInfo }
 	}
 

--- a/src/api/providers/router-provider.ts
+++ b/src/api/providers/router-provider.ts
@@ -68,8 +68,7 @@ export abstract class RouterProvider extends BaseProvider {
 		const lastMissingAttempt = this.missingModelRefreshAt.get(id)
 		if (
 			lastMissingAttempt !== undefined &&
-			Date.now() - lastMissingAttempt < RouterProvider.MISSING_MODEL_RETRY_MS &&
-			Object.keys(this.models).length > 0
+			Date.now() - lastMissingAttempt < RouterProvider.MISSING_MODEL_RETRY_MS
 		) {
 			return this.getModel()
 		}


### PR DESCRIPTION
## Summary
- Refetch router models when the selected id is missing from a stale in-memory map, so new catalog models get real pricing metadata.
- When falling back to `defaultModelInfo` for a non-default model id, zero $/token rates so the panel cannot invent Sonnet-priced costs.
- Negative-cache missing (and empty-catalog) lookups for 5 minutes so every `createMessage` does not re-hit `getModels`.
- Before recording a miss, call `refreshModels` so non-auth-scoped providers bust a stale shared catalog instead of blocking newly listed models for that window.
- When gateway streaming usage omits `cost`, emit `totalCost: 0` instead of inventing a local estimate.

## Test plan
- [x] `pnpm --dir src exec vitest run api/providers/__tests__/zoo-gateway.spec.ts` (48 passed)
- [x] `pnpm run check-types`
- [ ] Manual: select a newly added Zoo Gateway model (e.g. `alibaba/qwen3.8-max`), run a short task, confirm API Cost matches server `usage.cost` / credit deduction
- [ ] Manual: with models already loaded for another id, switch to a model not yet in the map and confirm a refetch occurs (no Sonnet-rate estimate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming usage now handles missing gateway cost data correctly by defaulting charges to zero.
  - Configured models that are unavailable now show zero pricing instead of inaccurate values.
  - Model catalogs no longer refresh repeatedly when a configured model cannot be found.

- **Improvements**
  - Missing models are rechecked periodically, allowing newly available models to be detected.
  - Successful model discovery clears previous unavailable-model status.
  - Model availability updates are deduplicated to reduce unnecessary refresh requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->