### PR TITLE
feat(editor): async post-save diagnostics on chat-diff save path (L1, #1375)

### DIFF
--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1171,7 +1171,7 @@
 	},
 	"integrations/editor/__tests__/DiffViewProvider.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 310
+			"count": 306
 		}
 	},
 	"integrations/editor/__tests__/EditorUtils.spec.ts": {

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1721,7 +1721,7 @@
 	},
 	"utils/safeWriteJson.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 4
+			"count": 3
 		}
 	},
 	"utils/tts.ts": {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -1152,8 +1152,11 @@ export class DiffViewProvider {
 	}> {
 		const absolutePath = path.resolve(this.cwd, relPath)
 
-		// Get diagnostics before editing the file
-		this.preDiagnostics = vscode.languages.getDiagnostics()
+		// Get diagnostics before editing the file. Capture the snapshot locally:
+		// overlapping saveDirectly calls (multi-file edits) must not let a later
+		// call overwrite this one's baseline before its diagnostics tail runs.
+		const preDiagnostics = vscode.languages.getDiagnostics()
+		this.preDiagnostics = preDiagnostics
 
 		// Write the content directly to the file
 		await createDirectoriesForFile(absolutePath)
@@ -1176,23 +1179,64 @@ export class DiffViewProvider {
 				await doc.save()
 			}
 
-			// Force a small delay to ensure diagnostics are triggered
-			await new Promise((resolve) => setTimeout(resolve, 100))
+			// The 100 ms diagnostics-settle wait is carried by the
+			// emitPostSaveDiagnostics tail (inMemoryDocument) instead of here:
+			// blocking the save path delayed every openFile=false save even when
+			// diagnostics were disabled or the write delay was 0.
 		}
 
-		let newProblemsMessage = ""
-
+		// L1 (A2): resolve without awaiting the LSP diagnostics settle. The
+		// diagnostics check becomes a fire-and-forget tail that emits any new
+		// problems via the existing "error" ClineSay type; the returned
+		// newProblemsMessage is therefore always undefined.
 		if (diagnosticsEnabled) {
-			// Add configurable delay to allow linters time to process
-			const safeDelayMs = Math.max(0, writeDelayMs)
+			// The method's outer try/catch guarantees it never rejects, so the
+			// fire-and-forget call needs no .catch wrapper.
+			void this.emitPostSaveDiagnostics(relPath, writeDelayMs, preDiagnostics, !openFile)
+		}
 
-			try {
-				await delay(safeDelayMs)
-			} catch (error) {
-				console.warn(`Failed to apply write delay: ${error}`)
-			}
+		// Store the results for formatFileWriteResponse
+		this.newProblemsMessage = undefined
+		this.userEdits = undefined
+		this.relPath = relPath
+		this.newContent = content
 
-			const postDiagnostics = vscode.languages.getDiagnostics()
+		return {
+			newProblemsMessage: undefined,
+			userEdits: undefined,
+			finalContent: content,
+		}
+	}
+
+	// L1 (A2): fire-and-forget post-save diagnostics. After the write delay,
+	// collects new Error-severity problems and emits them via the existing
+	// "error" ClineSay type (only Error-severity diagnostics reach this branch;
+	// "error" carries no task-failure semantics in core). Abort-safe: say()
+	// rejects when the task is aborted, so the whole body sits inside a
+	// try/catch that degrades to a console.warn — the tail can never reject.
+	private async emitPostSaveDiagnostics(
+		relPath: string,
+		writeDelayMs: number,
+		preDiagnostics: [vscode.Uri, vscode.Diagnostic[]][],
+		inMemoryDocument = false,
+	): Promise<void> {
+		try {
+			// Add configurable delay to allow linters time to process. When the
+			// document was opened in memory (openFile=false), the tail also
+			// carries the 100 ms diagnostics-settle wait that used to block
+			// saveDirectly. delay() never rejects, so no catch is required here.
+			const safeDelayMs = Math.max(0, writeDelayMs) + (inMemoryDocument ? 100 : 0)
+			await delay(safeDelayMs)
+
+			// Filter to the saved file: saveDirectly resolves before this tail
+			// completes, so in a multi-file write sequence (e.g. apply_patch)
+			// a later file's problems must not be attributed to this relPath.
+			const savedFilePath = path.resolve(this.cwd, relPath)
+			// arePathsEqual: case-insensitive on Windows, where a relPath whose
+			// casing differs from the diagnostic URI is still the same file.
+			const postDiagnostics = vscode.languages
+				.getDiagnostics()
+				.filter(([uri]) => arePathsEqual(uri.fsPath, savedFilePath))
 
 			// Get diagnostic settings from state
 			const task = this.taskRef.deref()
@@ -1201,27 +1245,20 @@ export class DiffViewProvider {
 			const maxDiagnosticMessages = state?.maxDiagnosticMessages ?? 50
 
 			const newProblems = await diagnosticsToProblemsString(
-				getNewDiagnostics(this.preDiagnostics, postDiagnostics),
+				getNewDiagnostics(preDiagnostics, postDiagnostics),
 				[vscode.DiagnosticSeverity.Error],
 				this.cwd,
 				includeDiagnosticMessages,
 				maxDiagnosticMessages,
 			)
 
-			newProblemsMessage =
-				newProblems.length > 0 ? `\n\nNew problems detected after saving the file:\n${newProblems}` : ""
-		}
-
-		// Store the results for formatFileWriteResponse
-		this.newProblemsMessage = newProblemsMessage
-		this.userEdits = undefined
-		this.relPath = relPath
-		this.newContent = content
-
-		return {
-			newProblemsMessage,
-			userEdits: undefined,
-			finalContent: content,
+			if (newProblems.length > 0) {
+				await task?.say("error", `New problems detected after saving file: ${relPath}\n\n${newProblems}`)
+			}
+		} catch (error) {
+			// Abort-safe: never let a post-save diagnostic emit become an
+			// unhandled rejection (say() rejects when the task is aborted).
+			console.warn(`Post-save diagnostics emit failed: ${error}`)
 		}
 	}
 }

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -18,6 +18,7 @@ import { arePathsEqual, getReadablePath } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
 import { Task } from "../../core/task/Task"
+import { safeWriteText } from "../../services/file-safety/safeWriteText"
 
 import { DecorationController } from "./DecorationController"
 
@@ -1156,7 +1157,7 @@ export class DiffViewProvider {
 
 		// Write the content directly to the file
 		await createDirectoriesForFile(absolutePath)
-		await fs.writeFile(absolutePath, content, "utf-8")
+		await safeWriteText(absolutePath, content)
 
 		// Open the document to ensure diagnostics are loaded
 		// When openFile is false (PREVENT_FOCUS_DISRUPTION enabled), we only open in memory

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -33,9 +33,14 @@ vi.mock("../../../utils/fs", () => ({
 // Mock path
 vi.mock("path", () => ({
 	resolve: vi.fn((cwd, relPath) => `${cwd}/${relPath}`),
+	normalize: vi.fn((p: string) => p),
 	basename: vi.fn((path) => path.split("/").pop()),
 	dirname: vi.fn((path) => path.split("/").slice(0, -1).join("/") || "/"),
 	join: (...args: string[]) => args.join("/"),
+	// diagnosticsToProblemsString formats its output header via
+	// path.relative(cwd, uri.fsPath).toPosix(); the object-with-toPosix shape
+	// mirrors the repo's own diagnostics.spec.ts mock.
+	relative: vi.fn((cwd: string, p: string) => ({ toPosix: () => p.replace(`${cwd}/`, "") })),
 }))
 
 // Mock vscode
@@ -174,6 +179,8 @@ describe("DiffViewProvider", () => {
 					}),
 				}),
 			},
+			// L1: saveDirectly's fire-and-forget diagnostics tail emits via say().
+			say: vi.fn().mockResolvedValue(true),
 		}
 
 		diffViewProvider = new DiffViewProvider(mockCwd, mockTask)
@@ -811,12 +818,17 @@ describe("DiffViewProvider", () => {
 				{ preview: false, preserveFocus: true },
 			)
 
-			// Verify diagnostics were checked after delay
+			// L1: saveDirectly resolves before the fire-and-forget diagnostics
+			// tail runs; flush one macrotask tick so the mocked delay (and the
+			// post-write getDiagnostics) have been reached before asserting.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			// Verify the tail applied the configured write delay
 			expect(mockDelay).toHaveBeenCalledWith(2000)
 			expect(vscode.languages.getDiagnostics).toHaveBeenCalled()
 
-			// Verify result
-			expect(result.newProblemsMessage).toBe("")
+			// Verify result: L1 no longer returns a problems message
+			expect(result.newProblemsMessage).toBeUndefined()
 			expect(result.userEdits).toBeUndefined()
 			expect(result.finalContent).toBe("new content")
 		})
@@ -847,6 +859,10 @@ describe("DiffViewProvider", () => {
 			expect(mockDelay).not.toHaveBeenCalled()
 			// getDiagnostics is called once for pre-diagnostics, but not for post-diagnostics
 			expect(vscode.languages.getDiagnostics).toHaveBeenCalledTimes(1)
+
+			// L1: no diagnostics tail is launched, so nothing is ever emitted
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			expect(mockTask.say).not.toHaveBeenCalled()
 		})
 
 		it("should handle negative delay values", async () => {
@@ -855,6 +871,9 @@ describe("DiffViewProvider", () => {
 
 			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, -500)
 
+			// L1: the tail runs after resolve; flush one macrotask tick first.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
 			// Verify delay was called with 0 (safe minimum)
 			expect(mockDelay).toHaveBeenCalledWith(0)
 		})
@@ -862,11 +881,172 @@ describe("DiffViewProvider", () => {
 		it("should store results for formatFileWriteResponse", async () => {
 			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 1000)
 
-			// Verify internal state was updated
-			expect((diffViewProvider as any).newProblemsMessage).toBe("")
-			expect((diffViewProvider as any).userEdits).toBeUndefined()
-			expect((diffViewProvider as any).relPath).toBe("test.ts")
-			expect((diffViewProvider as any).newContent).toBe("new content")
+			// Verify internal state was updated (L1: the problems message is no
+			// longer stored; it is emitted asynchronously via say("error"))
+			expect(diffViewProvider["newProblemsMessage"]).toBeUndefined()
+			expect(diffViewProvider["userEdits"]).toBeUndefined()
+			expect(diffViewProvider["relPath"]).toBe("test.ts")
+			expect(diffViewProvider["newContent"]).toBe("new content")
+		})
+
+		it("resolves immediately and emits new problems via say('error') after the write delay", async () => {
+			const mockDelay = vi.mocked(delay)
+			mockDelay.mockClear()
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+
+			// Pre-write diagnostics are empty; the post-write snapshot (read by
+			// the fire-and-forget tail) reports one new Error-severity problem.
+			// vscode.workspace.fs.stat is an unimplemented vi.fn() mock, so
+			// diagnosticsToProblemsString takes its "(unavailable)" fallback
+			// branch and still formats the line.
+			const newDiag: vscode.Diagnostic = {
+				severity: vscode.DiagnosticSeverity.Error,
+				range: new vscode.Range(0, 0, 0, 1),
+				message: "boom",
+			}
+			const postDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [[makeUri(`${mockCwd}/test.ts`), [newDiag]]]
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce([]).mockReturnValue(postDiagnostics)
+
+			const result = await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 100)
+
+			// L1: saveDirectly resolves before the tail emits anything.
+			expect(result.newProblemsMessage).toBeUndefined()
+			expect(mockTask.say).not.toHaveBeenCalled()
+
+			// Flush the fire-and-forget tail (the mocked delay resolves immediately).
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			expect(mockDelay).toHaveBeenCalledWith(100)
+			expect(mockTask.say).toHaveBeenCalledTimes(1)
+			// The existing "error" ClineSay type is used, with the new-problems text.
+			expect(mockTask.say).toHaveBeenCalledWith(
+				"error",
+				expect.stringContaining("New problems detected after saving file: test.ts"),
+			)
+			expect(mockTask.say.mock.calls[0]?.[1]).toContain("boom")
+		})
+
+		it("attributes only the saved file's new problems to the saved file", async () => {
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+
+			// Multi-file write sequence: a later file's new error must not be
+			// attributed to this tail's relPath by the workspace-wide snapshot.
+			const ownDiag: vscode.Diagnostic = {
+				severity: vscode.DiagnosticSeverity.Error,
+				range: new vscode.Range(0, 0, 0, 1),
+				message: "own-problem",
+			}
+			const otherDiag: vscode.Diagnostic = {
+				severity: vscode.DiagnosticSeverity.Error,
+				range: new vscode.Range(0, 0, 0, 1),
+				message: "other-file-problem",
+			}
+			const postDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [
+				[makeUri(`${mockCwd}/test.ts`), [ownDiag]],
+				[makeUri(`${mockCwd}/other.ts`), [otherDiag]],
+			]
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce([]).mockReturnValue(postDiagnostics)
+
+			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 100)
+
+			// Flush the fire-and-forget tail.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			expect(mockTask.say).toHaveBeenCalledTimes(1)
+			expect(mockTask.say.mock.calls[0]?.[1]).toContain("own-problem")
+			expect(mockTask.say.mock.calls[0]?.[1]).not.toContain("other-file-problem")
+		})
+
+		it("attributes diagnostics to the saved file when the URI casing differs (Windows)", async () => {
+			const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32")
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+
+			// The diagnostic URI uses different casing than the saved relPath:
+			// on Windows this is still the same file (arePathsEqual).
+			const newDiag: vscode.Diagnostic = {
+				severity: vscode.DiagnosticSeverity.Error,
+				range: new vscode.Range(0, 0, 0, 1),
+				message: "case-mismatch-problem",
+			}
+			const postDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [[makeUri(`${mockCwd}/Test.ts`), [newDiag]]]
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce([]).mockReturnValue(postDiagnostics)
+
+			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 100)
+
+			// Flush the fire-and-forget tail.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			expect(mockTask.say).toHaveBeenCalledTimes(1)
+			expect(mockTask.say.mock.calls[0]?.[1]).toContain("case-mismatch-problem")
+			platformSpy.mockRestore()
+		})
+
+		it("does not block the save on a diagnostics settle delay when diagnostics are disabled", async () => {
+			// openFile=false used to await a 100 ms settle delay even when
+			// diagnostics were disabled; that delay now lives in the tail, which
+			// does not run at all when diagnosticsEnabled is false.
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([])
+			const mockDelay = vi.mocked(delay)
+			mockDelay.mockClear()
+
+			const result = await diffViewProvider.saveDirectly("test.ts", "new content", false, false)
+
+			expect(result.finalContent).toBe("new content")
+			expect(mockDelay).not.toHaveBeenCalled()
+			expect(mockTask.say).not.toHaveBeenCalled()
+		})
+
+		it("carries the in-memory settle delay in the tail for openFile=false saves", async () => {
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([])
+			const mockDelay = vi.mocked(delay)
+			mockDelay.mockClear()
+
+			await diffViewProvider.saveDirectly("test.ts", "new content", false, true, 100)
+
+			// writeDelayMs (100) + the 100 ms in-memory diagnostics settle, both
+			// applied by the tail instead of the save path.
+			expect(mockDelay).toHaveBeenCalledWith(200)
+		})
+
+		it("never calls say when there are no new problems", async () => {
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([])
+
+			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 50)
+
+			// Flush the fire-and-forget tail (pre/post snapshots are both empty,
+			// so diagnosticsToProblemsString returns "" and nothing is emitted).
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			expect(mockTask.say).not.toHaveBeenCalled()
+		})
+
+		it("logs a warning instead of an unhandled rejection when the post-save say() is aborted", async () => {
+			const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+			vi.mocked(vscode.languages.getDiagnostics).mockClear()
+
+			// One new Error-severity problem so the tail reaches say().
+			const newDiag: vscode.Diagnostic = {
+				severity: vscode.DiagnosticSeverity.Error,
+				range: new vscode.Range(0, 0, 0, 1),
+				message: "boom",
+			}
+			const postDiagnostics: [vscode.Uri, vscode.Diagnostic[]][] = [[makeUri(`${mockCwd}/test.ts`), [newDiag]]]
+			vi.mocked(vscode.languages.getDiagnostics).mockReturnValueOnce([]).mockReturnValue(postDiagnostics)
+
+			// The task is aborted while the diagnostics tail is emitting: say() rejects.
+			mockTask.say.mockRejectedValueOnce(new Error("aborted"))
+
+			await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 0)
+			// Flush the fire-and-forget tail.
+			await new Promise((resolve) => setTimeout(resolve, 0))
+
+			// The method's outer catch swallows the rejection with a warning.
+			expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("Post-save diagnostics emit failed:"))
+
+			consoleWarnSpy.mockRestore()
 		})
 	})
 

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -15,6 +15,14 @@ vi.mock("fs/promises", () => ({
 	readFile: vi.fn().mockResolvedValue("file content"),
 	writeFile: vi.fn().mockResolvedValue(undefined),
 	access: vi.fn().mockResolvedValue(undefined),
+	mkdir: vi.fn().mockResolvedValue(undefined),
+	rename: vi.fn().mockResolvedValue(undefined),
+	unlink: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock safeWriteText (used by saveDirectly)
+vi.mock("../../../services/file-safety/safeWriteText", () => ({
+	safeWriteText: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Mock utils
@@ -26,6 +34,8 @@ vi.mock("../../../utils/fs", () => ({
 vi.mock("path", () => ({
 	resolve: vi.fn((cwd, relPath) => `${cwd}/${relPath}`),
 	basename: vi.fn((path) => path.split("/").pop()),
+	dirname: vi.fn((path) => path.split("/").slice(0, -1).join("/") || "/"),
+	join: (...args: string[]) => args.join("/"),
 }))
 
 // Mock vscode
@@ -791,9 +801,9 @@ describe("DiffViewProvider", () => {
 
 			const result = await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 2000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify file was opened without focus
 			expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
@@ -814,9 +824,9 @@ describe("DiffViewProvider", () => {
 		it("should not open file when openWithoutFocus is false", async () => {
 			await diffViewProvider.saveDirectly("test.ts", "new content", false, true, 1000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify file was NOT opened
 			expect(vscode.window.showTextDocument).not.toHaveBeenCalled()
@@ -829,9 +839,9 @@ describe("DiffViewProvider", () => {
 
 			await diffViewProvider.saveDirectly("test.ts", "new content", true, false, 1000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify delay was NOT called
 			expect(mockDelay).not.toHaveBeenCalled()

--- a/src/services/file-safety/__tests__/safeWriteText.spec.ts
+++ b/src/services/file-safety/__tests__/safeWriteText.spec.ts
@@ -1,0 +1,614 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import { execFile } from "child_process"
+import type { ChildProcess } from "child_process"
+import * as path from "path"
+
+import { safeWriteText, type SafeWriteTextOptions } from "../safeWriteText"
+
+// Full mock for fs/promises — all methods are vi.fn() stubs
+vi.mock("fs/promises", () => ({
+	mkdir: vi.fn(),
+	access: vi.fn(),
+	rename: vi.fn(),
+	unlink: vi.fn(),
+	realpath: vi.fn(),
+}))
+
+// Full mock for fs — all sync methods are vi.fn() stubs. Stats is a bare
+// class stub so tests can build minimal Stats stand-ins via its prototype.
+vi.mock("fs", () => ({
+	openSync: vi.fn(),
+	writeSync: vi.fn(),
+	closeSync: vi.fn(),
+	mkdirSync: vi.fn(),
+	fsyncSync: vi.fn(),
+	chmodSync: vi.fn(),
+	fchmodSync: vi.fn(),
+	statSync: vi.fn(),
+	Stats: class Stats {},
+}))
+
+// Mock child_process.execFile (callback-based — must invoke callback to resolve)
+vi.mock("child_process", () => ({
+	execFile: vi.fn((cmd, args, opts, cb) => {
+		if (typeof cb === "function") cb(null)
+	}),
+}))
+
+// Minimal stand-in for the ChildProcess that callback-form execFile returns.
+const fakeChild = { kill: () => true } as unknown as ChildProcess
+
+// Helper that mirrors safeWriteText's path resolution exactly
+function _resolvedTarget(filePath: string): string {
+	return path.resolve(filePath)
+}
+function _dirPath(filePath: string): string {
+	return path.dirname(_resolvedTarget(filePath))
+}
+function _stagingDir(dir: string): string {
+	return path.join(dir, ".file-safety-staging")
+}
+
+// Minimal Stats stand-in: the SUT only reads `.mode` from it.
+function _stats(mode: number): fsSync.Stats {
+	const s = Object.create(fsSync.Stats.prototype) as fsSync.Stats
+	Object.assign(s, { mode })
+	return s
+}
+
+// ── Test 1: staging file created then cleaned after success ────────────────
+
+describe("safeWriteText", () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+		// After resetAllMocks, vi.fn() returns undefined — restore promise defaults.
+		vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+		vi.mocked(fs.access).mockResolvedValue(undefined)
+		vi.mocked(fs.rename).mockResolvedValue(undefined)
+		vi.mocked(fs.unlink).mockResolvedValue(undefined)
+		// Existing-target default: a regular 0o644 file.
+		vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o644))
+		// Default sync-write behaviour: report that all requested bytes were
+		// written. The Buffer overload passes (fd, buffer, offset, length),
+		// so the fourth argument is the requested length.
+		vi.mocked(fsSync.writeSync).mockImplementation((...args: unknown[]) =>
+			typeof args[3] === "number" ? args[3] : 0,
+		)
+	})
+
+	describe("staging and cleanup", () => {
+		it("creates a temp file in the staging dir, fsyncs it, renames to target, and cleans up on success", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1) // fd=1
+			vi.mocked(fsSync.closeSync).mockReturnValue(undefined)
+
+			await safeWriteText(targetPath, "hello world", { platform: "linux" })
+
+			// staging dir was created with private permissions — use
+			// stringContaining to handle Windows path resolution
+			expect(fsSync.mkdirSync).toHaveBeenCalledWith(expect.stringContaining(".file-safety-staging"), {
+				recursive: true,
+				mode: 0o700,
+			})
+			// a pre-existing staging dir is repaired to private permissions too
+			expect(fsSync.chmodSync).toHaveBeenCalledWith(expect.stringContaining(".file-safety-staging"), 0o700)
+
+			// temp file was opened for writing with the existing target's mode
+			// (default 0o644 from the statSync default mock)
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o644)
+
+			// content was written as a buffer (partial-write loop, full write)
+			expect(fsSync.writeSync).toHaveBeenCalledWith(1, Buffer.from("hello world", "utf8"), 0, 11)
+
+			// fsync (sync form) was called on the fd
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+
+			// file was closed
+			expect(fsSync.closeSync).toHaveBeenCalledWith(1)
+
+			// atomic rename happened — realpath mock returns targetPath, so that's the dest
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// no unlink of temp (it's now the committed file; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 2: fsync ordering ───────────────────────────────────────────────
+
+	describe("fsync ordering", () => {
+		it("calls fsync on the fd before close, and rename after close", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// Verify call order: openSync(temp) → writeSync → fsyncSync(temp)
+			// → closeSync(temp) → rename. On POSIX the parent directory is then
+			// opened and fsynced after the commit rename, so openSync/fsyncSync/
+			// closeSync each have a second (directory) call.
+			expect(vi.mocked(fsSync.openSync).mock.calls.length).toBe(2)
+			expect(vi.mocked(fsSync.writeSync).mock.calls.length).toBe(1)
+			expect(vi.mocked(fsSync.fsyncSync).mock.calls.length).toBe(2)
+			expect(vi.mocked(fsSync.closeSync).mock.calls.length).toBe(2)
+
+			// the temp file was fully closed before the commit rename
+			expect(vi.mocked(fsSync.closeSync).mock.calls[0][0]).toBe(1)
+			expect(fs.rename).toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 3: simulated failure between write and rename leaves target intact ──
+
+	describe("crash/torn-write safety", () => {
+		it("simulated failure between fsync and rename leaves the target byte-identical and no temp left behind", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fs.rename).mockRejectedValue(new Error("ENOSPC"))
+
+			await expect(safeWriteText(targetPath, "new data", { platform: "linux" })).rejects.toThrow("ENOSPC")
+
+			// rename was attempted (the failure point)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// temp file was cleaned up on failure
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+
+			// backup was NOT created (backup:false by default), so target is untouched
+			// The only rename call was temp→target, not a rollback rename
+			expect(fs.rename).toHaveBeenCalledTimes(1)
+		})
+
+		it("a post-commit backup cleanup failure is non-fatal: the target stays committed and no temp is left behind", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// The post-commit backup unlink (SUT step 6) fails — the write must
+			// still succeed; an orphaned backup is the documented acceptable
+			// outcome, so the failure is swallowed instead of rolling back.
+			vi.mocked(fs.unlink).mockRejectedValueOnce(new Error("EPERM"))
+
+			await safeWriteText(targetPath, "data", { backup: true, platform: "linux" })
+
+			// the commit rename (temp -> target) still happened
+			expect(fs.rename).toHaveBeenNthCalledWith(2, expect.stringContaining("safeWriteText_"), targetPath)
+
+			// the failing cleanup was the post-commit backup unlink
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText.bak_"))
+
+			// no rollback rename: the committed target is not restored from the backup
+			expect(fs.rename).toHaveBeenCalledTimes(2)
+
+			// the staging temp was already committed by the rename; nothing
+			// temp-shaped is unlinked afterwards
+			expect(fs.unlink).not.toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+		})
+	})
+
+	// ── Test 4: backup:true keeps old safeWriteJson semantics incl. rollback ──
+
+	describe("backup:true", () => {
+		it("renames target -> backup before commit, deletes backup on success", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "new data", { backup: true })
+
+			// target was accessed (exists check)
+			expect(fs.access).toHaveBeenCalledWith(targetPath)
+
+			// first rename: target -> backup
+			expect(fs.rename).toHaveBeenNthCalledWith(1, targetPath, expect.stringContaining("safeWriteText.bak_"))
+
+			// second rename: temp -> target (realpath mock returns targetPath)
+			expect(fs.rename).toHaveBeenNthCalledWith(2, expect.stringContaining("safeWriteText_"), targetPath)
+
+			// backup was deleted on success
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText.bak_"))
+		})
+
+		it("rollback: on failure after rename target->backup, restores backup to target", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// first rename (target->backup) succeeds, second fails
+			let callCount = 0
+			vi.mocked(fs.rename).mockImplementation(async () => {
+				callCount++
+				if (callCount === 1) return // target -> backup
+				throw new Error("ENOSPC") // temp -> target fails
+			})
+
+			await expect(safeWriteText(targetPath, "new data", { backup: true })).rejects.toThrow("ENOSPC")
+
+			// rollback rename is the 3rd call (after target->backup and temp->target failure)
+			expect(fs.rename).toHaveBeenNthCalledWith(3, expect.stringContaining("safeWriteText.bak_"), targetPath)
+
+			// temp was cleaned up on failure
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+		})
+
+		it("backup:true when target does not exist: no backup created, just commit", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// fs.access resolves for dirPath check, but rejects for target check (backup path)
+			vi.mocked(fs.access).mockImplementation(async (p) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw { code: "ENOENT" }
+			})
+
+			await safeWriteText(targetPath, "new data", { backup: true, platform: "linux" })
+
+			// no backup rename (target didn't exist)
+			expect(fs.access).toHaveBeenCalledWith(targetPath)
+
+			// only one rename: temp -> target
+			expect(fs.rename).toHaveBeenCalledTimes(1)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// no unlink (no backup to delete; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 5: win32 DACL path ──────────────────────────────────────────────
+
+	describe("win32 DACL", () => {
+		it.skipIf(process.platform !== "win32")(
+			"copies target DACL onto staging file via icacls before rename on Windows",
+			async () => {
+				const targetPath = "/tmp/test-dir/target.txt"
+				vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+				await safeWriteText(targetPath, "data", { platform: "win32" })
+
+				// icacls dump + restore were called (execFile is callback-based mock)
+				expect(execFile).toHaveBeenCalledTimes(2)
+			},
+		)
+
+		it("non-win32: DACL path is unreachable when platform is not win32", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// icacls was NOT called on non-win32
+			expect(execFile).not.toHaveBeenCalled()
+		})
+
+		it("win32 DACL failure falls back to plain rename (never fails the write)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// icacls dump fails — the callback-based mock must invoke cb with an error.
+			vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+				if (typeof cb === "function") cb(new Error("icacls error"), "", "")
+				return fakeChild
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// write succeeded despite icacls failure (fallback to plain rename)
+			expect(fs.rename).toHaveBeenCalled()
+		})
+
+		it("win32 DACL save args are [targetPath, /save, dumpPath, /T] before backup rename", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { backup: true, platform: "win32" })
+
+			// icacls was called twice (save + restore)
+			expect(execFile).toHaveBeenCalledTimes(2)
+
+			// First call: save DACL from target before backup rename
+			const firstCall = vi.mocked(execFile).mock.calls[0]
+			expect(firstCall[0]).toBe("icacls")
+			expect(firstCall[1]).toEqual([targetPath, "/save", expect.stringContaining(".acl.tmp"), "/T"])
+
+			// Second call: restore DACL onto directory after commit rename
+			const secondCall = vi.mocked(execFile).mock.calls[1]
+			expect(secondCall[0]).toBe("icacls")
+			expect(secondCall[1]).toEqual([
+				expect.stringContaining("/tmp/test-dir"),
+				"/restore",
+				expect.stringContaining(".acl.tmp"),
+			])
+
+			// dump file was unlinked after restore
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining(".acl.tmp"))
+		})
+
+		it("win32 DACL: dump is unlinked even when restore fails", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			// icacls save succeeds, restore fails
+			let callCount = 0
+			vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+				callCount++
+				if (typeof cb === "function") {
+					cb(callCount === 1 ? null : new Error("icacls restore error"), "", "")
+				}
+				return fakeChild
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// write succeeded despite restore failure (best-effort)
+			expect(fs.rename).toHaveBeenCalled()
+
+			// dump file was still unlinked in finally
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining(".acl.tmp"))
+		})
+
+		it("win32 DACL: when target does not exist, no save/restore/dump", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			// fs.access rejects for targetPath (ENOENT), but resolves for dirPath
+			vi.mocked(fs.access).mockImplementation(async (p) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw { code: "ENOENT" }
+				return undefined
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// icacls was NOT called (target absent → skip DACL entirely)
+			expect(execFile).not.toHaveBeenCalled()
+
+			// no dump file created or unlinked
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 6: pre-written temp path (tempPath option) ──────────────────────
+
+	describe("pre-written temp path", () => {
+		it("uses the provided tempPath, fsyncs it, and renames to target", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			// platform:linux skips DACL entirely so this test focuses on tempPath only
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// openSync was called on the custom temp path (r+ mode for fsync)
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+
+			// fsync was called
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+
+			// rename happened — realpath mock returns targetPath
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+
+			// no unlink of custom temp (caller's concern; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+
+			// a caller-supplied tempPath must not create the staging directory
+			expect(fsSync.mkdirSync).not.toHaveBeenCalled()
+		})
+
+		it("applies the existing target's mode to a caller-supplied tempPath before publishing", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o600))
+			vi.mocked(fsSync.openSync).mockReturnValue(2)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// the caller-staged temp is fchmod'd to the restrictive target mode so
+			// the atomic rename cannot widen a 0o600 target (CWE-732 regression)
+			expect(fsSync.fchmodSync).toHaveBeenCalledWith(2, 0o600)
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+
+		it("keeps the temp's default mode when the target does not exist yet (ENOENT)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			const enoent = Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+			vi.mocked(fsSync.statSync).mockImplementation(() => {
+				throw enoent
+			})
+			vi.mocked(fsSync.openSync).mockReturnValue(2)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// no existing target, so nothing to preserve and no fchmod on the temp
+			expect(fsSync.fchmodSync).not.toHaveBeenCalled()
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+
+		it("opens the temp before applying a read-only target's mode (0o444 does not block the open)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o444))
+			vi.mocked(fsSync.openSync).mockReturnValue(3)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// a 0o444 target must not make openSync(tempPath, "r+") fail: the mode
+			// is applied with fchmodSync on the already-open fd, after the open
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+			expect(fsSync.fchmodSync).toHaveBeenCalledWith(3, 0o444)
+			const openIdx = vi.mocked(fsSync.openSync).mock.invocationCallOrder[0]
+			const fchmodIdx = vi.mocked(fsSync.fchmodSync).mock.invocationCallOrder[0]
+			expect(openIdx).toBeLessThan(fchmodIdx)
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+	})
+
+	// ── Test 7: symlink handling (Finding 4 regression test) ─────────────────
+
+	describe("symlink handling", () => {
+		it("a write through a symlink commits onto the resolved referent, never the link path", async () => {
+			const linkPath = "/tmp/links/link.txt"
+			const referentPath = "/tmp/targets/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(referentPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(linkPath, "new-content", { platform: "linux" })
+
+			// The commit rename must target the realpath result (the referent), never the link itself —
+			// that is what guarantees a write through a symlink replaces the referent's content
+			// and preserves the link.
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), referentPath)
+			expect(fs.rename).not.toHaveBeenCalledWith(expect.anything(), linkPath)
+		})
+
+		it("when realpath reports ENOENT (target absent), uses the given path as-is", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// rename still happened with the fallback path (path.resolve on /tmp → C:\tmp)
+			const resolvedFallback = _resolvedTarget(targetPath)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), resolvedFallback)
+		})
+	})
+
+	// ── Test 8: review fixes (permissions, partial writes, resolution, durability) ──
+
+	describe("review fixes", () => {
+		it("preserves the target's restrictive mode and tolerates a failed staging-dir permission repair", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o600))
+			// a pre-existing staging dir may fail its best-effort permission repair
+			vi.mocked(fsSync.chmodSync).mockImplementationOnce(() => {
+				throw new Error("EACCES")
+			})
+
+			await safeWriteText(targetPath, "secret", { platform: "linux" })
+
+			// the staging file inherits the target's 0o600 mode and the write commits
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o600)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("falls back to the 0o644 default when the target does not exist yet", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fsSync.statSync).mockImplementation(() => {
+				throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+			})
+
+			await safeWriteText(targetPath, "fresh", { platform: "linux" })
+
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o644)
+		})
+
+		it("loops on short writes until the full content is durable before fsync", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const content = "0123456789" // 10 bytes
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			const buffer = Buffer.from(content, "utf8")
+			// first write (offset 0) reports 4 bytes (short write); the loop continues
+			vi.mocked(fsSync.writeSync).mockImplementation((...args: unknown[]) =>
+				args[2] === 0 ? 4 : typeof args[3] === "number" ? args[3] : 0,
+			)
+
+			await safeWriteText(targetPath, content, { platform: "linux" })
+
+			// [0,10) reports 4 bytes, then [4,10) writes the remaining 6
+			expect(fsSync.writeSync).toHaveBeenCalledTimes(2)
+			expect(fsSync.writeSync).toHaveBeenNthCalledWith(1, 1, buffer, 0, 10)
+			expect(fsSync.writeSync).toHaveBeenNthCalledWith(2, 1, buffer, 4, 6)
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("fsyncs the parent directory after the commit rename on POSIX", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			// temp fd=1 then parent-dir fd=2 - distinct fds prove the ordering
+			vi.mocked(fsSync.openSync).mockReturnValueOnce(1).mockReturnValue(2)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// the directory fsync (fd 2) happens only after the file fsync (fd 1);
+			// the dir path assertion is path-agnostic (stringContaining) because
+			// path.dirname renders the same input differently on Windows
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("test-dir"), "r")
+			expect(fsSync.fsyncSync).toHaveBeenNthCalledWith(1, 1)
+			expect(fsSync.fsyncSync).toHaveBeenNthCalledWith(2, 2)
+			expect(fsSync.closeSync).toHaveBeenCalledWith(2)
+		})
+
+		it("treats a failed parent-directory fsync as best-effort", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync)
+				.mockReturnValueOnce(1)
+				.mockImplementationOnce(() => {
+					throw new Error("EBADF")
+				})
+
+			// the content rename already committed; a missing directory fsync is not fatal
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("propagates realpath errors (EACCES and code-less) instead of the fallback path", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const eacces = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+			vi.mocked(fs.realpath).mockRejectedValueOnce(eacces)
+			await expect(safeWriteText(targetPath, "data", { platform: "linux" })).rejects.toBe(eacces)
+			expect(fs.rename).not.toHaveBeenCalled()
+
+			const plain = new Error("resolution failed")
+			vi.mocked(fs.realpath).mockRejectedValueOnce(plain)
+			await expect(safeWriteText(targetPath, "data", { platform: "linux" })).rejects.toBe(plain)
+			expect(fs.rename).not.toHaveBeenCalled()
+		})
+
+		it("backup:true propagates access errors (EACCES and code-less) instead of skipping the backup", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" })
+			const plain = new Error("access failed")
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// each write accesses dirPath then target; only the target access rejects
+			const rejectTarget = (error: Error) => async (p: unknown) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw error
+			}
+			vi.mocked(fs.access)
+				.mockImplementationOnce(rejectTarget(eacces))
+				.mockImplementationOnce(rejectTarget(eacces))
+				.mockImplementationOnce(rejectTarget(plain))
+				.mockImplementationOnce(rejectTarget(plain))
+
+			await expect(safeWriteText(targetPath, "data", { backup: true, platform: "linux" })).rejects.toEqual(
+				expect.objectContaining({ code: "EACCES" }),
+			)
+			await expect(safeWriteText(targetPath, "data", { backup: true, platform: "linux" })).rejects.toThrow(
+				"access failed",
+			)
+			expect(fs.rename).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/services/file-safety/safeWriteText.ts
+++ b/src/services/file-safety/safeWriteText.ts
@@ -1,0 +1,307 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as path from "path"
+import { execFile } from "child_process"
+
+/**
+ * Options for safeWriteText atomic text publish primitive.
+ */
+export interface SafeWriteTextOptions {
+	/**
+	 * When true, preserve the old-file semantics: rename target -> backup first,
+	 * after commit rename delete the backup; on failure roll the backup back to
+	 * the target path.  When false (default) the atomic rename simply replaces
+	 * the target -- crash-safe window is zero.
+	 */
+	backup?: boolean
+
+	/**
+	 * Platform override for testing.  When omitted the real process.platform
+	 * value is used.  Set to "win32" or "linux" / "darwin" from tests so that
+	 * both branches are reachable without needing a real Windows runner.
+	 */
+	platform?: string
+
+	/**
+	 * Custom execFile runner for testing (e.g. vi.fn).  When omitted the real
+	 * child_process.execFile is used.
+	 */
+	execFileRunner?: typeof execFile
+
+	/**
+	 * Pre-written temp path to use for the commit phase.  When provided,
+	 * safeWriteText skips creating its own staging file and uses this path
+	 * instead (it still fsyncs before rename).  Useful when a caller has
+	 * already written data to a temp file via a custom stream.
+	 */
+	tempPath?: string
+}
+
+// -- helpers ---------------------------------------------------------------
+
+/** Generate a unique temp file name in the given directory. */
+function _tempName(dir: string, prefix: string): string {
+	return path.join(dir, "." + prefix + "_" + Date.now() + "_" + Math.random().toString(36).substring(2) + ".tmp")
+}
+
+/** Create a private staging sub-directory inside *dir* so that multiple
+ * concurrent writes never collide on their temp names. */
+function _stagingDir(dir: string): string {
+	const sd = path.join(dir, ".file-safety-staging")
+	// mode:0o700 protects a freshly created staging dir; the best-effort chmod
+	// repairs a pre-existing one (mkdirSync with recursive:true never chmods an
+	// existing directory), so staged temp files are never group/world readable.
+	fsSync.mkdirSync(sd, { recursive: true, mode: 0o700 })
+	try {
+		fsSync.chmodSync(sd, 0o700)
+	} catch {
+		// best-effort: chmod denied or unavailable; a fresh dir was still
+		// created with the requested mode
+	}
+	return sd
+}
+
+/**
+ * fsync a file descriptor so its data is durable before the atomic rename.
+ * Uses the sync form because this repo's @types/node does not declare
+ * fs.promises.fsync; the staging file is small, so the blocking window is bounded.
+ */
+function _fsyncFile(fd: number): void {
+	fsSync.fsyncSync(fd)
+}
+
+/** Save the DACL of *srcPath* to a dump file on Windows.
+ * Returns true when the dump was written successfully; false otherwise.
+ * Never throws — callers treat failure as "skip DACL handling". */
+async function _saveDaclWindows(srcPath: string, dumpPath: string, execFileRunner?: typeof execFile): Promise<boolean> {
+	const runner = execFileRunner ?? execFile
+	try {
+		await new Promise<void>((resolve, reject) => {
+			runner("icacls", [srcPath, "/save", dumpPath, "/T"], { windowsHide: true }, (err) =>
+				err ? reject(err) : resolve(),
+			)
+		})
+		return true
+	} catch {
+		return false
+	}
+}
+
+/** Restore a DACL dump onto *dirPath* on Windows.
+ * Best-effort: content is already committed, so failure is non-fatal. */
+async function _restoreDaclWindows(dirPath: string, dumpPath: string, execFileRunner?: typeof execFile): Promise<void> {
+	const runner = execFileRunner ?? execFile
+	try {
+		await new Promise<void>((resolve, reject) => {
+			runner("icacls", [dirPath, "/restore", dumpPath], { windowsHide: true }, (err) =>
+				err ? reject(err) : resolve(),
+			)
+		})
+	} catch {
+		// best-effort; content already committed
+	}
+}
+
+// -- public API ------------------------------------------------------------
+
+/**
+ * Atomic text publish primitive.
+ *
+ * 1. Write content to a temp file in a private per-write staging subdir
+ *    (same volume -> atomic rename guaranteed).
+ * 2. fsync the temp file, then close it.
+ * 3. win32 only: if target exists save its DACL dump BEFORE backup rename.
+ * 4. Optionally rename target -> backup (when backup:true).
+ * 5. Atomic rename temp -> target.
+ * 6. win32 only: restore DACL onto the directory AFTER commit rename.
+ * 7. On success: delete backup (if any) and unlink DACL dump.
+ * 8. On failure: rollback backup to target path; clean up temp + dump.
+ */
+
+/**
+ * Resolve the publish target: the symlink referent when the given path is an
+ * existing symlink, the path itself otherwise. Only ENOENT (target absent yet)
+ * may fall back to the given path; any other resolution error (EACCES, EIO, ...)
+ * propagates so a broken or unreadable symlink is never written through its
+ * link path. Callers that stage a temp file themselves must stage it beside
+ * the resolved path: the commit is a rename onto the referent, and a rename
+ * across filesystems fails with EXDEV.
+ */
+export async function resolvePublishTarget(absoluteFilePath: string): Promise<string> {
+	return fs.realpath(absoluteFilePath).catch((error: unknown) => {
+		const code =
+			typeof error === "object" && error !== null && "code" in error
+				? (error as { code?: string }).code
+				: undefined
+		if (code !== "ENOENT") throw error
+		return absoluteFilePath
+	})
+}
+
+export async function safeWriteText(filePath: string, content: string, options?: SafeWriteTextOptions): Promise<void> {
+	const absoluteFilePath = path.resolve(filePath)
+
+	// Resolve the symlink referent (see resolvePublishTarget).
+	const targetPath = await resolvePublishTarget(absoluteFilePath)
+	const dirPath = path.dirname(targetPath)
+
+	// Ensure parent directory exists (mirrors safeWriteJson behaviour).
+	await fs.mkdir(dirPath, { recursive: true })
+	await fs.access(dirPath)
+
+	// Create the staging directory only when we generate the temp file there;
+	// callers supplying their own tempPath (e.g. safeWriteJson) must not be left
+	// with an empty .file-safety-staging directory behind.
+	const tempPath = options?.tempPath ?? _tempName(_stagingDir(dirPath), "safeWriteText")
+
+	let backupPath: string | null = null
+	let releaseBackupOnSuccess = false
+	let daclDumpPath: string | null = null // tracked for cleanup in finally
+
+	try {
+		// -- Step 1: write content to staging temp file -------------------
+		if (!options?.tempPath) {
+			// Preserve the existing target's permissions: the staging file must
+			// not be published wider than the file it replaces (a 0o600 target
+			// must not become 0o644 through the atomic rename).
+			let targetMode = 0o644 // default for a fresh target
+			try {
+				targetMode = fsSync.statSync(targetPath).mode & 0o777
+			} catch {
+				// target does not exist yet - keep the default
+			}
+			const fd = fsSync.openSync(tempPath, "w", targetMode)
+			try {
+				// Loop until every byte is written: writeSync can report a short
+				// (partial) write, and publishing a truncated staging file would
+				// commit corrupt content.
+				const buffer = Buffer.from(content, "utf8")
+				let offset = 0
+				while (offset < buffer.length) {
+					offset += fsSync.writeSync(fd, buffer, offset, buffer.length - offset)
+				}
+				_fsyncFile(fd)
+			} finally {
+				fsSync.closeSync(fd)
+			}
+		} else {
+			// Preserve the existing target's mode (CWE-732): the caller-staged
+			// temp carries its own creation mode, and publishing it as-is would
+			// widen a restrictive target (e.g. 0o600 -> 0o644) through rename.
+			// The mode is applied with fchmodSync on the open fd (AFTER openSync):
+			// chmodSync on the path before the open would make a read-only target
+			// (0o400/0o444) fail openSync(tempPath, "r+") with EACCES.
+			let targetMode: number | null = null
+			try {
+				targetMode = fsSync.statSync(targetPath).mode & 0o777
+			} catch {
+				// target does not exist yet - keep the temp's default mode
+			}
+			const fd = fsSync.openSync(tempPath, "r+")
+			try {
+				if (targetMode !== null) {
+					fsSync.fchmodSync(fd, targetMode)
+				}
+				_fsyncFile(fd)
+			} finally {
+				fsSync.closeSync(fd)
+			}
+		}
+
+		// -- Step 2 (win32): save DACL BEFORE backup rename ---------------
+		const platform = options?.platform ?? process.platform
+		if (platform === "win32") {
+			try {
+				await fs.access(targetPath) // target exists?
+				daclDumpPath = targetPath + ".acl.tmp"
+				const saved = await _saveDaclWindows(targetPath, daclDumpPath, options?.execFileRunner)
+				if (!saved) {
+					daclDumpPath = null // skip DACL handling entirely
+				}
+			} catch {
+				// target does not exist or access failed — no DACL handling
+				daclDumpPath = null
+			}
+		}
+
+		try {
+			// -- Step 3 (backup:true): rename target -> backup --------------
+			if (options?.backup) {
+				try {
+					await fs.access(targetPath)
+					backupPath = _tempName(dirPath, "safeWriteText.bak")
+					await fs.rename(targetPath, backupPath)
+					releaseBackupOnSuccess = true
+				} catch (err: unknown) {
+					const code =
+						typeof err === "object" && err !== null && "code" in err
+							? (err as { code?: string }).code
+							: undefined
+					if (code !== "ENOENT") throw err
+				}
+			}
+
+			// -- Step 4: atomic rename temp -> target ---------------------
+			await fs.rename(tempPath, targetPath)
+
+			// -- Step 4b (POSIX): fsync the parent directory so the directory entry
+			// changed by the commit rename is durable, not just the file content.
+			if (platform !== "win32") {
+				try {
+					const dirFd = fsSync.openSync(dirPath, "r")
+					try {
+						_fsyncFile(dirFd)
+					} finally {
+						fsSync.closeSync(dirFd)
+					}
+				} catch {
+					// best-effort: the content rename already committed
+				}
+			}
+
+			// -- Step 5 (win32): restore DACL AFTER commit rename ---------
+			if (platform === "win32" && daclDumpPath !== null) {
+				const restoredDir = path.dirname(targetPath)
+				await _restoreDaclWindows(restoredDir, daclDumpPath, options?.execFileRunner)
+			}
+
+			// -- Step 6 (backup:true): delete backup on success -----------
+			if (releaseBackupOnSuccess && backupPath) {
+				try {
+					await fs.unlink(backupPath)
+				} catch {
+					// non-fatal — orphaned backup is acceptable
+				}
+			}
+		} finally {
+			// Unlink DACL dump regardless of success/failure in this span.
+			if (daclDumpPath !== null) {
+				await fs.unlink(daclDumpPath).catch(() => {})
+			}
+		}
+
+		// tempPath is now the committed file; no cleanup needed.
+	} catch (originalError: unknown) {
+		// -- Rollback / cleanup on failure ----------------------------------
+		if (backupPath && releaseBackupOnSuccess) {
+			try {
+				await fs.rename(backupPath, targetPath)
+			} catch {
+				// rollback failed — do not mask original error
+			}
+		}
+
+		// Always clean up the staging temp file on failure.
+		try {
+			await fs.unlink(tempPath).catch(() => {})
+		} catch {
+			// cleanup failure is non-fatal
+		}
+
+		if (daclDumpPath !== null) {
+			await fs.unlink(daclDumpPath).catch(() => {})
+		}
+
+		throw originalError
+	}
+}

--- a/src/utils/__tests__/safeWriteJson.test.ts
+++ b/src/utils/__tests__/safeWriteJson.test.ts
@@ -312,9 +312,8 @@ describe("safeWriteJson", () => {
 		expect(content).toEqual(newData)
 	})
 
-	// Test for console error suppression during backup deletion
-	test("should suppress console.error when backup deletion fails", async () => {
-		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {}) // Suppress console.error
+	// Test for best-effort backup deletion (the backup lifecycle now lives in safeWriteText)
+	test("does not fail the write when backup deletion fails (orphaned backup is acceptable)", async () => {
 		const initialData = { message: "Initial" }
 		const newData = { message: "New" }
 
@@ -322,18 +321,23 @@ describe("safeWriteJson", () => {
 
 		// fs.unlink is already vi.fn() — use vi.mocked to avoid double-wrapping via vi.spyOn
 		vi.mocked(fs.unlink).mockImplementation(async (filePath: any) => {
-			if (filePath.toString().includes(".bak_")) {
+			if (filePath.toString().includes("safeWriteText.bak_")) {
 				throw new Error("Backup deletion failed")
 			}
 			return fsPromisesActuals.unlink!(filePath)
 		})
 
+		// The write must still succeed: backup cleanup is best-effort inside
+		// safeWriteText and never masks the committed content.
 		await safeWriteJson(currentTestFilePath, newData)
 
-		// Verify console.error was called with the expected message
-		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Successfully wrote"), expect.any(Error))
+		const content = await readFileContent(currentTestFilePath)
+		expect(content).toEqual(newData)
 
-		consoleErrorSpy.mockRestore()
+		// The orphaned backup is still on disk because its deletion failed.
+		const entries = await fs.readdir(tempDir)
+		expect(entries.some((entry) => entry.includes("safeWriteText.bak_"))).toBe(true)
+
 		vi.mocked(fs.unlink).mockRestore()
 	})
 
@@ -434,9 +438,9 @@ describe("safeWriteJson", () => {
 		expect(vi.mocked(fs.access)).toHaveBeenCalled()
 	})
 
-	// Test for rollback failure scenario
-	test("should log error and re-throw original if rollback fails", async () => {
-		const initialData = { message: "Initial, should be lost if rollback fails" }
+	// Test for rollback failure scenario (the rollback rename now lives in safeWriteText)
+	test("re-throws the original error when the rollback rename fails, leaving an orphaned backup", async () => {
+		const initialData = { message: "Initial, orphaned when rollback fails" }
 		const newData = { message: "New content" }
 
 		await fsPromisesActuals.writeFile!(currentTestFilePath, JSON.stringify(initialData))
@@ -451,20 +455,20 @@ describe("safeWriteJson", () => {
 				// Second call: tempNewFilePath -> filePath (fail)
 				throw new Error("Primary rename failed")
 			} else if (renameCallCount === 3) {
-				// Third call: tempBackupFilePath -> filePath (rollback, also fail)
+				// Third call: backup -> filePath (rollback, also fail)
 				throw new Error("Rollback rename failed")
 			}
 			return fsPromisesActuals.rename!(oldPath, newPath)
 		})
 
-		// Should throw the original error, not the rollback error
+		// The original error must propagate, not the rollback error
 		await expect(safeWriteJson(currentTestFilePath, newData)).rejects.toThrow("Primary rename failed")
 
-		// Verify console.error was called for the rollback failure
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Failed to restore backup"),
-			expect.objectContaining({ message: "Rollback rename failed" }),
-		)
+		// The rollback failed inside safeWriteText, so the target is gone and
+		// the backup is orphaned on disk.
+		expect(await fileExists(currentTestFilePath)).toBe(false)
+		const entries = await fs.readdir(tempDir)
+		expect(entries.some((entry) => entry.includes("safeWriteText.bak_"))).toBe(true)
 
 		consoleErrorSpy.mockRestore()
 	})
@@ -542,4 +546,53 @@ describe("safeWriteJson", () => {
 		const content = await readFileContent(currentTestFilePath)
 		expect(content).toEqual({ c: 3 })
 	})
+
+	// The commit rename targets the symlink referent. The staged temp file must
+	// therefore be created beside the RESOLVED target — staging beside the link
+	// would make the commit rename fail with EXDEV when the referent is on
+	// another filesystem. (Real symlinks are unavailable in this CI lane, so the
+	// resolution is simulated by mocking fs.realpath the same way.)
+	test("stages the temp file beside the symlink referent and commits onto it", async () => {
+		const referentDir = path.join(tempDir, "referent")
+		const linkDir = path.join(tempDir, "link")
+		await fs.mkdir(referentDir, { recursive: true })
+		await fs.mkdir(linkDir, { recursive: true })
+		// caller-visible path (the link) vs the resolved referent path
+		const callerPath = path.join(linkDir, "test-file.json")
+		const referentPath = path.join(referentDir, "test-file.json")
+		// Seed the RESOLVED referent with real content (via the actual fs) so the
+		// write exercises replacement of an EXISTING referent: the lock is
+		// acquired on the caller path (realpath:false, which may be absent) while
+		// the backup + commit happen on the referent.
+		await fsPromisesActuals.writeFile!(referentPath, JSON.stringify({ seed: true }))
+
+		vi.spyOn(fs, "realpath").mockResolvedValue(referentPath)
+
+		await safeWriteJson(callerPath, { after: true })
+
+		// the temp file was created next to the resolved referent, NOT beside the link
+		const tempPaths = vi.mocked(fsSyncActual.createWriteStream).mock.calls.map((call) => String(call[0]))
+		expect(tempPaths.some((p) => p.startsWith(referentDir + path.sep) && p.includes(".new_"))).toBe(true)
+		expect(tempPaths.some((p) => p.startsWith(linkDir + path.sep))).toBe(false)
+
+		// the content was committed onto the referent
+		expect(await readFileContent(referentPath)).toEqual({ after: true })
+	})
+
+	// CWE-732 regression: safeWriteJson stages the temp itself and passes it
+	// via tempPath, so safeWriteText must apply the existing target's mode to
+	// the staged temp before the atomic rename — otherwise a 0o600 target is
+	// published as 0o644. POSIX-only assertion (Windows ignores POSIX modes).
+	test.skipIf(process.platform === "win32")(
+		"preserves a restrictive 0o600 target mode through the atomic publish",
+		async () => {
+			await fsPromisesActuals.writeFile!(currentTestFilePath, JSON.stringify({ before: true }))
+			fsSyncActual.chmodSync(currentTestFilePath, 0o600)
+
+			await safeWriteJson(currentTestFilePath, { after: true })
+
+			expect(fsSyncActual.statSync(currentTestFilePath).mode & 0o777).toBe(0o600)
+			expect(await readFileContent(currentTestFilePath)).toEqual({ after: true })
+		},
+	)
 })

--- a/src/utils/safeWriteJson.ts
+++ b/src/utils/safeWriteJson.ts
@@ -4,6 +4,8 @@ import * as path from "path"
 import * as lockfile from "proper-lockfile"
 import { JsonStreamStringify } from "json-stream-stringify"
 
+import { resolvePublishTarget, safeWriteText, type SafeWriteTextOptions } from "../services/file-safety/safeWriteText"
+
 /**
  * Options for safeWriteJson function
  */
@@ -31,7 +33,7 @@ export interface SafeWriteJsonOptions {
  * Safely writes JSON data to a file.
  * - Creates parent directories if they don't exist
  * - Uses 'proper-lockfile' for inter-process advisory locking to prevent concurrent writes to the same path.
- * - Writes to a temporary file first.
+ * - Writes to a temporary file first via JsonStreamStringify streaming.
  * - If the target file exists, it's backed up before being replaced.
  * - Attempts to roll back and clean up in case of errors.
  * - Supports pretty-printing with indentation while maintaining streaming efficiency.
@@ -41,7 +43,6 @@ export interface SafeWriteJsonOptions {
  * @param {SafeWriteJsonOptions} options - Optional configuration for JSON formatting.
  * @returns {Promise<void>}
  */
-
 async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJsonOptions): Promise<void> {
 	const absoluteFilePath = path.resolve(filePath)
 	let releaseLock = async () => {} // Initialized to a no-op
@@ -51,10 +52,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 
 	// Ensure directory structure exists with improved reliability
 	try {
-		// Create directory with recursive option
 		await fs.mkdir(dirPath, { recursive: true })
-
-		// Verify directory exists after creation attempt
 		await fs.access(dirPath)
 	} catch (dirError: any) {
 		console.error(`Failed to create or access directory for ${absoluteFilePath}:`, dirError)
@@ -84,13 +82,11 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		// The releaseLock remains a no-op, so the finally block in the main file operations
 		// try-catch-finally won't try to release an unacquired lock if this path is taken.
 		console.error(`Failed to acquire lock for ${absoluteFilePath}:`, lockError)
-		// Propagate the lock acquisition error
 		throw lockError
 	}
 
-	// Variables to hold the actual paths of temp files if they are created.
+	// Variables to hold the actual path of the temp file if it is created.
 	let actualTempNewFilePath: string | null = null
-	let actualTempBackupFilePath: string | null = null
 
 	try {
 		// If a merge callback was provided, read the current file under the lock
@@ -110,79 +106,43 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 			data = options.merge(existing, data)
 		}
 
-		// Step 1: Write data to a new temporary file.
+		// Step 1: Write data to a new temporary file via JSON streaming.
+		// Stage it beside the *resolved* target (the symlink referent when the path is
+		// a symlink): safeWriteText commits by renaming onto that referent, and a
+		// rename across filesystems would fail with EXDEV.
+		const resolvedTargetPath = await resolvePublishTarget(absoluteFilePath)
 		actualTempNewFilePath = path.join(
-			path.dirname(absoluteFilePath),
-			`.${path.basename(absoluteFilePath)}.new_${Date.now()}_${Math.random().toString(36).substring(2)}.tmp`,
+			path.dirname(resolvedTargetPath),
+			".new_" + Date.now() + "_" + Math.random().toString(36).substring(2) + ".tmp",
 		)
 
 		await _streamDataToFile(actualTempNewFilePath, data, options?.prettyPrint)
 
-		// Step 2: Check if the target file exists. If so, rename it to a backup path.
-		try {
-			// Check for target file existence
-			await fs.access(absoluteFilePath)
-			// Target exists, create a backup path and rename.
-			actualTempBackupFilePath = path.join(
-				path.dirname(absoluteFilePath),
-				`.${path.basename(absoluteFilePath)}.bak_${Date.now()}_${Math.random().toString(36).substring(2)}.tmp`,
-			)
-			await fs.rename(absoluteFilePath, actualTempBackupFilePath)
-		} catch (accessError: any) {
-			// Explicitly type accessError
-			if (accessError.code !== "ENOENT") {
-				// An error other than "file not found" occurred during access check.
-				throw accessError
-			}
-			// Target file does not exist, so no backup is made. actualTempBackupFilePath remains null.
+		// Step 2: Delegate backup + commit + rollback to safeWriteText with the
+		// pre-written temp path. backup:true keeps the old safeWriteJson
+		// semantics (target -> backup before commit, rollback on failure) and
+		// keeps the target in place until safeWriteText captures its Windows
+		// DACL (safeWriteText dumps the DACL before its own backup rename and
+		// restores it onto the directory after the commit rename).
+		const textOptions: SafeWriteTextOptions = {
+			tempPath: actualTempNewFilePath,
+			backup: true,
 		}
 
-		// Step 3: Rename the new temporary file to the target file path.
-		// This is the main "commit" step.
-		await fs.rename(actualTempNewFilePath, absoluteFilePath)
+		await safeWriteText(absoluteFilePath, "", textOptions)
 
-		// If we reach here, the new file is successfully in place.
-		// The original actualTempNewFilePath is now the main file, so we shouldn't try to clean it up as "temp".
-		// Mark as "used" or "committed"
+		// If we reach here, the new file is successfully in place and any
+		// backup has already been handled by safeWriteText.
 		actualTempNewFilePath = null
-
-		// Step 4: If a backup was created, attempt to delete it.
-		if (actualTempBackupFilePath) {
-			try {
-				await fs.unlink(actualTempBackupFilePath)
-				// Mark backup as handled
-				actualTempBackupFilePath = null
-			} catch (unlinkBackupError) {
-				// Log this error, but do not re-throw. The main operation was successful.
-				// actualTempBackupFilePath remains set, indicating an orphaned backup.
-				console.error(
-					`Successfully wrote ${absoluteFilePath}, but failed to clean up backup ${actualTempBackupFilePath}:`,
-					unlinkBackupError,
-				)
-			}
-		}
 	} catch (originalError) {
 		console.error(`Operation failed for ${absoluteFilePath}: [Original Error Caught]`, originalError)
 
 		const newFileToCleanupWithinCatch = actualTempNewFilePath
-		const backupFileToRollbackOrCleanupWithinCatch = actualTempBackupFilePath
 
-		// Attempt rollback if a backup was made
-		if (backupFileToRollbackOrCleanupWithinCatch) {
-			try {
-				await fs.rename(backupFileToRollbackOrCleanupWithinCatch, absoluteFilePath)
-				// Mark as handled, prevent later unlink of this path
-				actualTempBackupFilePath = null
-			} catch (rollbackError) {
-				// actualTempBackupFilePath (outer scope) remains pointing to backupFileToRollbackOrCleanupWithinCatch
-				console.error(
-					`[Catch] Failed to restore backup ${backupFileToRollbackOrCleanupWithinCatch} to ${absoluteFilePath}:`,
-					rollbackError,
-				)
-			}
-		}
-
-		// Cleanup the .new file if it exists
+		// A failed safeWriteText already rolled the backup (if any) back to
+		// the target path. Clean up the .new file if it still exists
+		// (safeWriteText also cleans up its tempPath on failure; this is a
+		// safety net in case its cleanup missed it).
 		if (newFileToCleanupWithinCatch) {
 			try {
 				await fs.unlink(newFileToCleanupWithinCatch)
@@ -194,26 +154,12 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 			}
 		}
 
-		// Cleanup the .bak file if it still needs to be (i.e., wasn't successfully restored)
-		if (actualTempBackupFilePath) {
-			try {
-				await fs.unlink(actualTempBackupFilePath)
-			} catch (cleanupError) {
-				console.error(
-					`[Catch] Failed to clean up temporary backup file ${actualTempBackupFilePath}:`,
-					cleanupError,
-				)
-			}
-		}
 		throw originalError // This MUST be the error that rejects the promise.
 	} finally {
 		// Release the lock in the main finally block.
 		try {
-			// releaseLock will be the actual unlock function if lock was acquired,
-			// or the initial no-op if acquisition failed.
 			await releaseLock()
 		} catch (unlockError) {
-			// Do not re-throw here, as the originalError from the try/catch (if any) is more important.
 			console.error(`Failed to release lock for ${absoluteFilePath}:`, unlockError)
 		}
 	}


### PR DESCRIPTION
> Tracking issue: [#1396](https://github.com/Zoo-Code-Org/Zoo-Code/issues/1396)

## Summary

L1 of the file-write safety series (plan: [easonLiangWorldedtech/Zoo-Code#33](https://github.com/easonLiangWorldedtech/Zoo-Code/issues/33)), part of epic #1375. `DiffViewProvider.saveDirectly` — the funnel every write tool uses on the chat-diff (PREVENT_FOCUS_DISRUPTION) path — currently blocks the save result on the LSP settle: it waits `writeDelayMs`, re-runs `vscode.languages.getDiagnostics()`, and only then returns. This PR makes the save resolve immediately and moves the diagnostics into an asynchronous post-save tail, so post-save latency drops by the LSP-settle time while the diagnostic information is still delivered — just later.

## Changes

- `src/integrations/editor/DiffViewProvider.ts`
  - `saveDirectly` now resolves without awaiting diagnostics: the write + document-open steps run as before, then it returns `{ newProblemsMessage: undefined, userEdits: undefined, finalContent: content }` and clears `this.newProblemsMessage`, so the tool-result JSON no longer carries a `problems` field computed before the LSP settled.
  - New private tail method `emitPostSaveDiagnostics`: when diagnostics are enabled it keeps the existing `writeDelayMs` delay (moved into the tail), recomputes with the same `getNewDiagnostics` + `diagnosticsToProblemsString` call (Error severity, same `includeDiagnosticMessages` / `maxDiagnosticMessages` from task state), and — when new problems exist — emits them through the existing ClineSay type `error` as a single self-contained string: `New problems detected after saving file: <relPath>` + the problems text. Rationale: only Error-severity diagnostics reach this point and `error` is the closest existing say type with no task-failure semantics; no new message type is introduced and `packages/types` is untouched.
  - `diagnosticsEnabled: false` skips the tail entirely (no delay, no say), exactly as before. The tail is abort/crash-safe: any throw (e.g. task abort rejecting `say`) is caught and logged via `console.warn` — never an unhandled rejection (no floating promises).
- `src/integrations/editor/__tests__/DiffViewProvider.spec.ts` — the `saveDirectly` blocks now assert the async contract with fake timers: the save resolves before any diagnostics say; advancing timers + flushing yields exactly one `say("error", …)` with the settled problems payload when new Error diagnostics exist; `diagnosticsEnabled: false` and clean saves never say; the say type is exactly `"error"`. Existing `saveDirectly` routing assertions (safeWriteText signature, write-delay pass-through) stay green.

## Notes

- Informational follow-up event only — no toggle, per plan: a setting would either re-introduce the blocking path or drop the information.
- The tool-result `problems` field is intentionally dropped from the save response; the same information now arrives via the post-save event.
- Stacking: this branch is built on #1395 (S3 atomic publish), whose head branch lives on the fork, so the PR targets `main` and its diff includes the S3 commit. Merge only after #1395 lands (then this becomes a fast-forward); it will be rebased onto the final #1395 head before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved file saving with atomic writes to help prevent partial or corrupted files.
  * Added safer backup, rollback, cleanup, and symlink handling during file updates.
  * Preserved file permissions during supported file operations.

* **Bug Fixes**
  * New diagnostics are reported asynchronously after saving, without blocking the save operation.
  * Improved recovery when writing or replacing files fails.
  * Prevented unchanged or disabled diagnostics from generating unnecessary error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

**Review-gate re-trigger (2026-08-30):** empty commit cb1360613 (no code change) re-runs CI and CodeRabbit current-head review under the org new PR review gate; the code head remains 991ab6935.
