### PR TITLE
feat(tools): wire guarded writes into the diff-view save paths (S4b, #1375)

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -103,6 +103,7 @@ import { ToolRepetitionDetector } from "../tools/ToolRepetitionDetector"
 import { restoreTodoListForTask } from "../tools/UpdateTodoListTool"
 import { FileContextTracker } from "../context-tracking/FileContextTracker"
 import { RooIgnoreController } from "../ignore/RooIgnoreController"
+import { ObservationRegistry } from "./observationRegistry"
 import { RooProtectedController } from "../protect/RooProtectedController"
 import { type AssistantMessageContent, presentAssistantMessage } from "../assistant-message"
 import { NativeToolCallParser } from "../assistant-message/NativeToolCallParser"
@@ -181,6 +182,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	readonly parentTask: Task | undefined = undefined
 	readonly taskNumber: number
 	readonly workspacePath: string
+	readonly observationRegistry = new ObservationRegistry()
 
 	/**
 	 * The mode associated with this task. Persisted across sessions

--- a/src/core/task/__tests__/observationRegistry.spec.ts
+++ b/src/core/task/__tests__/observationRegistry.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest"
+
+import { ObservationRegistry } from "../observationRegistry"
+
+describe("ObservationRegistry", () => {
+	it("observe → get returns the recorded version and observedAt", () => {
+		const reg = new ObservationRegistry()
+		reg.observe("/a/b/c.ts", "1:2:300:4000000000:5000000000")
+
+		const obs = reg.get("/a/b/c.ts")
+		expect(obs).toBeDefined()
+		expect(obs!.version).toBe("1:2:300:4000000000:5000000000")
+		expect(typeof obs!.observedAt).toBe("number")
+	})
+
+	it("re-observe replaces the entry with a fresh observedAt", () => {
+		vi.useFakeTimers()
+		const reg = new ObservationRegistry()
+		reg.observe("/a/b/c.ts", "v1")
+		const first = reg.get("/a/b/c.ts")!
+		expect(first.version).toBe("v1")
+
+		vi.advanceTimersByTime(50)
+		reg.observe("/a/b/c.ts", "v2")
+		const second = reg.get("/a/b/c.ts")!
+		expect(second.version).toBe("v2")
+		expect(second.observedAt).toBeGreaterThan(first.observedAt)
+
+		vi.useRealTimers()
+	})
+
+	it("has returns true for observed paths, false otherwise", () => {
+		const reg = new ObservationRegistry()
+		reg.observe("/x.ts", "t1")
+		expect(reg.has("/x.ts")).toBe(true)
+		expect(reg.has("/y.ts")).toBe(false)
+	})
+
+	it("size reflects the number of observed entries", () => {
+		const reg = new ObservationRegistry()
+		expect(reg.size).toBe(0)
+		reg.observe("/a.ts", "t1")
+		reg.observe("/b.ts", "t2")
+		expect(reg.size).toBe(2)
+	})
+
+	it("clear removes all entries and resets size to 0", () => {
+		const reg = new ObservationRegistry()
+		reg.observe("/a.ts", "t1")
+		reg.observe("/b.ts", "t2")
+		reg.clear()
+		expect(reg.size).toBe(0)
+		expect(reg.get("/a.ts")).toBeUndefined()
+		expect(reg.has("/b.ts")).toBe(false)
+	})
+
+	it("get on empty registry returns undefined", () => {
+		const reg = new ObservationRegistry()
+		expect(reg.get("/any.ts")).toBeUndefined()
+	})
+
+	it("separate instances are independent — observing in one does not appear in the other", () => {
+		const regA = new ObservationRegistry()
+		const regB = new ObservationRegistry()
+		regA.observe("/shared.ts", "v1")
+		expect(regA.get("/shared.ts")).toBeDefined()
+		expect(regB.get("/shared.ts")).toBeUndefined()
+		regB.observe("/shared.ts", "v2")
+		expect(regA.get("/shared.ts")!.version).toBe("v1")
+		expect(regB.get("/shared.ts")!.version).toBe("v2")
+	})
+})

--- a/src/core/task/observationRegistry.ts
+++ b/src/core/task/observationRegistry.ts
@@ -1,0 +1,47 @@
+/**
+ * Per-task file observation registry (upstream epic #1375, phase A2).
+ *
+ * Each Task owns its own instance so parent and subtask observations are
+ * independent. The S4 guarded-write will compare these versions against the
+ * token recomputed pre-write to detect stale reads or file replacement.
+ *
+ * Pure in-memory — zero I/O, no dependencies. No behavior change in this PR:
+ * observations are recorded but not consulted.
+ */
+
+export interface FileObservation {
+	/** Version token derived from on-disk fs.stat (bigint mode). */
+	version: string
+	/** Millisecond timestamp when the observation was recorded. */
+	observedAt: number
+}
+
+export class ObservationRegistry {
+	private readonly entries = new Map<string, FileObservation>()
+
+	/**
+	 * Record an observation for a file at its absolute path.
+	 *
+	 * Re-observing replaces the entry with a fresh observedAt timestamp and
+	 * the new version token.
+	 */
+	observe(absolutePath: string, version: string): void {
+		this.entries.set(absolutePath, { version, observedAt: Date.now() })
+	}
+
+	get(absolutePath: string): FileObservation | undefined {
+		return this.entries.get(absolutePath)
+	}
+
+	has(absolutePath: string): boolean {
+		return this.entries.has(absolutePath)
+	}
+
+	clear(): void {
+		this.entries.clear()
+	}
+
+	get size(): number {
+		return this.entries.size
+	}
+}

--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -173,7 +173,8 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 					return
 				}
 
-				// Save directly without showing diff view or opening the file
+				// Save directly without showing diff view or opening the file. The diff is
+				// applied to an existing file, so edit-guard semantics require a prior read.
 				task.diffViewProvider.editType = "modify"
 				task.diffViewProvider.originalContent = originalContent
 				await task.diffViewProvider.saveDirectly(
@@ -182,6 +183,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 					false,
 					diagnosticsEnabled,
 					writeDelayMs,
+					"edit",
 				)
 			} else {
 				// Original behavior with diff view

--- a/src/core/tools/ApplyPatchTool.ts
+++ b/src/core/tools/ApplyPatchTool.ts
@@ -11,6 +11,7 @@ import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { fileExistsAtPath } from "../../utils/fs"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { sanitizeUnifiedDiff, computeDiffStats } from "../diff/stats"
+import { versionTokenOfStat } from "../../utils/versionToken"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
 import { parsePatch, ParseError, processAllHunks } from "./apply-patch"
@@ -85,10 +86,25 @@ export class ApplyPatchTool extends BaseTool<"apply_patch"> {
 				return
 			}
 
-			// Process each hunk
+			// Process each hunk. The read doubles as the S2 observation for the
+			// guarded publish (ReadFileTool contract: stat before and after the
+			// read, observe only when the on-disk version is unchanged between the
+			// two stats). Without it, the in-place modify publish is an unobserved
+			// write and the composed chat-diff default rejects it ("File already
+			// exists ... and was not read before this write") even though this tool
+			// just read the exact content the patch was applied to.
 			const readFile = async (filePath: string): Promise<string> => {
 				const absolutePath = path.resolve(task.cwd, filePath)
-				return await fs.readFile(absolutePath, "utf8")
+				const preReadStats = await fs.stat(absolutePath, { bigint: true }).catch(() => undefined)
+				const content: string = await fs.readFile(absolutePath, "utf8")
+				const postReadStats = await fs.stat(absolutePath, { bigint: true }).catch(() => undefined)
+				if (preReadStats && postReadStats) {
+					const preReadToken = versionTokenOfStat(preReadStats)
+					if (preReadToken === versionTokenOfStat(postReadStats)) {
+						task.observationRegistry.observe(absolutePath, preReadToken)
+					}
+				}
+				return content
 			}
 
 			let changes: ApplyPatchFileChange[]

--- a/src/core/tools/ApplyPatchTool.ts
+++ b/src/core/tools/ApplyPatchTool.ts
@@ -214,7 +214,16 @@ export class ApplyPatchTool extends BaseTool<"apply_patch"> {
 
 		// Save the changes
 		if (isPreventFocusDisruptionEnabled) {
-			await task.diffViewProvider.saveDirectly(relPath, newContent, true, diagnosticsEnabled, writeDelayMs)
+			// Guarded publish: the patch supplies the complete new content, so create-guard
+			// semantics apply (an unobserved existing target is rejected, not overwritten).
+			await task.diffViewProvider.saveDirectly(
+				relPath,
+				newContent,
+				true,
+				diagnosticsEnabled,
+				writeDelayMs,
+				"create",
+			)
 		} else {
 			await task.diffViewProvider.saveChanges(diagnosticsEnabled, writeDelayMs)
 		}
@@ -408,12 +417,14 @@ export class ApplyPatchTool extends BaseTool<"apply_patch"> {
 
 			// Save new content to the new path
 			if (isPreventFocusDisruptionEnabled) {
+				// The move destination is published with the complete new content.
 				await task.diffViewProvider.saveDirectly(
 					change.movePath,
 					newContent,
 					false,
 					diagnosticsEnabled,
 					writeDelayMs,
+					"create",
 				)
 			} else {
 				// Write to new path and delete old file
@@ -433,7 +444,16 @@ export class ApplyPatchTool extends BaseTool<"apply_patch"> {
 		} else {
 			// Save changes to the same file
 			if (isPreventFocusDisruptionEnabled) {
-				await task.diffViewProvider.saveDirectly(relPath, newContent, false, diagnosticsEnabled, writeDelayMs)
+				// Guarded publish: the patched file content is complete, so create-guard
+				// semantics apply (stale observed versions are rejected with a re-read hint).
+				await task.diffViewProvider.saveDirectly(
+					relPath,
+					newContent,
+					false,
+					diagnosticsEnabled,
+					writeDelayMs,
+					"create",
+				)
 			} else {
 				await task.diffViewProvider.saveChanges(diagnosticsEnabled, writeDelayMs)
 			}

--- a/src/core/tools/EditFileTool.ts
+++ b/src/core/tools/EditFileTool.ts
@@ -436,13 +436,16 @@ export class EditFileTool extends BaseTool<"edit_file"> {
 
 			// Save the changes
 			if (isPreventFocusDisruptionEnabled) {
-				// Direct file write without diff view or opening the file
+				// Direct file write without diff view or opening the file. In-place edits
+				// use edit-guard semantics (a prior read is required); new-file creation
+				// keeps create-guard semantics.
 				await task.diffViewProvider.saveDirectly(
 					relPath,
 					newContent,
 					isNewFile,
 					diagnosticsEnabled,
 					writeDelayMs,
+					isNewFile ? "create" : "edit",
 				)
 			} else {
 				// Call saveChanges to update the DiffViewProvider properties

--- a/src/core/tools/EditTool.ts
+++ b/src/core/tools/EditTool.ts
@@ -211,8 +211,16 @@ export class EditTool extends BaseTool<"edit"> {
 
 			// Save the changes
 			if (isPreventFocusDisruptionEnabled) {
-				// Direct file write without diff view or opening the file
-				await task.diffViewProvider.saveDirectly(relPath, newContent, false, diagnosticsEnabled, writeDelayMs)
+				// Direct file write without diff view or opening the file. This tool only
+				// edits existing files, so edit-guard semantics require a prior read.
+				await task.diffViewProvider.saveDirectly(
+					relPath,
+					newContent,
+					false,
+					diagnosticsEnabled,
+					writeDelayMs,
+					"edit",
+				)
 			} else {
 				// Call saveChanges to update the DiffViewProvider properties
 				await task.diffViewProvider.saveChanges(diagnosticsEnabled, writeDelayMs)

--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -16,6 +16,7 @@ import type { ReadFileParams, ReadFileMode, ReadFileToolParams, FileEntry, LineR
 import { isLegacyReadFileParams, type ClineSayTool } from "@roo-code/types"
 
 import { Task } from "../task/Task"
+import { computeVersionToken } from "../../utils/versionToken"
 import { formatResponse } from "../prompts/responses"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
@@ -219,6 +220,11 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 					const result = this.processTextFile(fileContent, entry)
 
 					await task.fileContextTracker.trackFileContext(relPath, "read_tool" as RecordSource)
+
+					// A2 (plan #33 / epic #1375): record the observed on-disk version for the future write guard.
+					// A stat failure leaves the target unobserved and never fails the read.
+					const version = await computeVersionToken(fullPath).catch(() => undefined)
+					if (version) task.observationRegistry.observe(fullPath, version)
 
 					updateFileResult(relPath, {
 						nativeContent: `File: ${relPath}\n${result}`,
@@ -799,6 +805,12 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 
 				// Track file in context
 				await task.fileContextTracker.trackFileContext(relPath, "read_tool")
+
+				// A2 (plan #33 / epic #1375): mirror the native path — record the observed
+				// on-disk version so legacy-format reads also feed the future write guard.
+				// A stat failure leaves the target unobserved and never fails the read.
+				const version = await computeVersionToken(fullPath).catch(() => undefined)
+				if (version) task.observationRegistry.observe(fullPath, version)
 			} catch (error) {
 				const errorMsg = error instanceof Error ? error.message : String(error)
 				results.push(`File: ${relPath}\nError: ${errorMsg}`)

--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -16,7 +16,7 @@ import type { ReadFileParams, ReadFileMode, ReadFileToolParams, FileEntry, LineR
 import { isLegacyReadFileParams, type ClineSayTool } from "@roo-code/types"
 
 import { Task } from "../task/Task"
-import { computeVersionToken } from "../../utils/versionToken"
+import { versionTokenOfStat } from "../../utils/versionToken"
 import { formatResponse } from "../prompts/responses"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
@@ -215,6 +215,9 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 					// Read text file content with lossy UTF-8 conversion
 					// Reading as Buffer first allows graceful handling of non-UTF8 bytes
 					// (they become U+FFFD replacement characters instead of throwing)
+					// A2 (epic #1375): capture the on-disk token before the read so a mutation
+					// landing mid-read is detected by the post-read stat below.
+					const preReadStats = await fs.stat(fullPath, { bigint: true }).catch(() => undefined)
 					const buffer = await fs.readFile(fullPath)
 					const fileContent = buffer.toString("utf-8")
 					const result = this.processTextFile(fileContent, entry)
@@ -222,9 +225,18 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 					await task.fileContextTracker.trackFileContext(relPath, "read_tool" as RecordSource)
 
 					// A2 (plan #33 / epic #1375): record the observed on-disk version for the future write guard.
-					// A stat failure leaves the target unobserved and never fails the read.
-					const version = await computeVersionToken(fullPath).catch(() => undefined)
-					if (version) task.observationRegistry.observe(fullPath, version)
+					// The token is captured before AND after the read; the target is observed only
+					// when both match — a mutation between the two stats means the content the model
+					// received is not the on-disk state, and observing it would let a later write
+					// match a token the model never saw. A stat failure leaves the target
+					// unobserved and never fails the read.
+					const postReadStats = await fs.stat(fullPath, { bigint: true }).catch(() => undefined)
+					if (preReadStats && postReadStats) {
+						const preReadToken = versionTokenOfStat(preReadStats)
+						if (preReadToken === versionTokenOfStat(postReadStats)) {
+							task.observationRegistry.observe(fullPath, preReadToken)
+						}
+					}
 
 					updateFileResult(relPath, {
 						nativeContent: `File: ${relPath}\n${result}`,
@@ -774,6 +786,9 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 				}
 
 				// Read text file
+				// A2 (epic #1375): capture the on-disk token before the read so a mutation
+				// landing mid-read is detected by the post-read stat below.
+				const preReadStats = await fs.stat(fullPath, { bigint: true }).catch(() => undefined)
 				const rawContent = await fs.readFile(fullPath, "utf8")
 
 				// Handle line ranges if specified
@@ -808,9 +823,16 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 
 				// A2 (plan #33 / epic #1375): mirror the native path — record the observed
 				// on-disk version so legacy-format reads also feed the future write guard.
-				// A stat failure leaves the target unobserved and never fails the read.
-				const version = await computeVersionToken(fullPath).catch(() => undefined)
-				if (version) task.observationRegistry.observe(fullPath, version)
+				// Observe only when the pre-read and post-read tokens match (a mutation between
+				// them means the returned content is not the on-disk state). A stat failure
+				// leaves the target unobserved and never fails the read.
+				const postReadStats = await fs.stat(fullPath, { bigint: true }).catch(() => undefined)
+				if (preReadStats && postReadStats) {
+					const preReadToken = versionTokenOfStat(preReadStats)
+					if (preReadToken === versionTokenOfStat(postReadStats)) {
+						task.observationRegistry.observe(fullPath, preReadToken)
+					}
+				}
 			} catch (error) {
 				const errorMsg = error instanceof Error ? error.message : String(error)
 				results.push(`File: ${relPath}\nError: ${errorMsg}`)

--- a/src/core/tools/SearchReplaceTool.ts
+++ b/src/core/tools/SearchReplaceTool.ts
@@ -207,8 +207,16 @@ export class SearchReplaceTool extends BaseTool<"search_replace"> {
 
 			// Save the changes
 			if (isPreventFocusDisruptionEnabled) {
-				// Direct file write without diff view or opening the file
-				await task.diffViewProvider.saveDirectly(relPath, newContent, false, diagnosticsEnabled, writeDelayMs)
+				// Direct file write without diff view or opening the file. This tool only
+				// edits existing files, so edit-guard semantics require a prior read.
+				await task.diffViewProvider.saveDirectly(
+					relPath,
+					newContent,
+					false,
+					diagnosticsEnabled,
+					writeDelayMs,
+					"edit",
+				)
 			} else {
 				// Call saveChanges to update the DiffViewProvider properties
 				await task.diffViewProvider.saveChanges(diagnosticsEnabled, writeDelayMs)

--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -133,7 +133,16 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 					return
 				}
 
-				await task.diffViewProvider.saveDirectly(relPath, newContent, false, diagnosticsEnabled, writeDelayMs)
+				// Guarded publish: this write carries the complete file content, so it uses
+				// create-guard semantics (unobserved targets may only be created when absent).
+				await task.diffViewProvider.saveDirectly(
+					relPath,
+					newContent,
+					false,
+					diagnosticsEnabled,
+					writeDelayMs,
+					"create",
+				)
 			} else {
 				if (!task.diffViewProvider.isEditing) {
 					const partialMessage = JSON.stringify(sharedMessageProps)

--- a/src/core/tools/__tests__/applyDiffTool.guardedWrite.spec.ts
+++ b/src/core/tools/__tests__/applyDiffTool.guardedWrite.spec.ts
@@ -1,0 +1,157 @@
+// npx vitest run core/tools/__tests__/applyDiffTool.guardedWrite.spec.ts
+
+import type { MockedFunction } from "vitest"
+
+import { fileExistsAtPath } from "../../../utils/fs"
+import type { Task } from "../../task/Task"
+import { ApplyDiffTool } from "../ApplyDiffTool"
+
+vi.mock("fs/promises", () => ({
+	default: {
+		readFile: vi.fn().mockResolvedValue("original file content\n"),
+	},
+}))
+
+vi.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock("../../prompts/responses", () => ({
+	formatResponse: {
+		toolError: vi.fn((msg: string) => `Error: ${msg}`),
+		rooIgnoreError: vi.fn((filePath: string) => `Access denied: ${filePath}`),
+		createPrettyPatch: vi.fn(() => "mock-diff"),
+	},
+}))
+
+vi.mock("../../diff/stats", () => ({
+	sanitizeUnifiedDiff: vi.fn((diff: string) => diff),
+	computeDiffStats: vi.fn(() => ({ additions: 1, deletions: 1 })),
+}))
+
+describe("ApplyDiffTool.execute - guarded write (S4b, epic #1375)", () => {
+	const mockedFileExistsAtPath = fileExistsAtPath as MockedFunction<typeof fileExistsAtPath>
+
+	let tool: ApplyDiffTool
+	let mockTask: Pick<
+		Task,
+		| "cwd"
+		| "consecutiveMistakeCount"
+		| "consecutiveMistakeCountForApplyDiff"
+		| "recordToolError"
+		| "rooIgnoreController"
+		| "rooProtectedController"
+		| "say"
+		| "processQueuedMessages"
+		| "didEditFile"
+		| "api"
+		| "diffStrategy"
+		| "diffViewProvider"
+		| "providerRef"
+		| "fileContextTracker"
+	>
+	let mockSaveDirectly: MockedFunction<(...args: unknown[]) => Promise<unknown>>
+	let mockAskApproval: MockedFunction<(...args: unknown[]) => Promise<boolean>>
+	let mockHandleError: MockedFunction<(...args: unknown[]) => Promise<void>>
+	let mockPushToolResult: MockedFunction<(...args: unknown[]) => void>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockedFileExistsAtPath.mockResolvedValue(true)
+
+		mockSaveDirectly = vi.fn().mockResolvedValue({
+			newProblemsMessage: "",
+			userEdits: undefined,
+			finalContent: "new content",
+		})
+
+		// Structural stubs for the guarded-write path: the real DiffViewProvider is
+		// out of scope here, so vi.fn() doubles stand in for the members the tool
+		// touches (the saveDirectly double also records the writeKind plumbing).
+		const diffViewProviderStub = {
+			editType: undefined as "create" | "modify" | undefined,
+			originalContent: undefined as string | undefined,
+			saveDirectly: mockSaveDirectly,
+			pushToolWriteResult: vi.fn().mockResolvedValue("Saved file"),
+			reset: vi.fn().mockResolvedValue(undefined),
+		}
+		mockTask = {
+			cwd: "/workspace/project",
+			consecutiveMistakeCount: 0,
+			consecutiveMistakeCountForApplyDiff: new Map(),
+			recordToolError: vi.fn(),
+			rooIgnoreController: {
+				validateAccess: vi.fn().mockReturnValue(true),
+			} as unknown as Task["rooIgnoreController"],
+			rooProtectedController: {
+				isWriteProtected: vi.fn().mockReturnValue(false),
+			} as unknown as Task["rooProtectedController"],
+			say: vi.fn().mockResolvedValue(undefined),
+			processQueuedMessages: vi.fn(),
+			didEditFile: false,
+			api: {
+				getModel: () => ({ id: "claude-sonnet-4-5" }),
+			} as unknown as Task["api"],
+			diffStrategy: {
+				applyDiff: vi.fn().mockResolvedValue({ success: true, content: "modified file content\n" }),
+			} as unknown as Task["diffStrategy"],
+			diffViewProvider: diffViewProviderStub as unknown as Task["diffViewProvider"],
+			providerRef: {
+				deref: vi.fn().mockReturnValue({
+					getState: vi.fn().mockResolvedValue({
+						diagnosticsEnabled: true,
+						writeDelayMs: 1000,
+						// Exercise the focus-disruption (saveDirectly) save path.
+						experiments: { preventFocusDisruption: true },
+					}),
+				}),
+			} as unknown as Task["providerRef"],
+			fileContextTracker: {
+				trackFileContext: vi.fn().mockResolvedValue(undefined),
+			} as unknown as Task["fileContextTracker"],
+		}
+
+		mockAskApproval = vi.fn().mockResolvedValue(true)
+		mockHandleError = vi.fn().mockResolvedValue(undefined)
+		mockPushToolResult = vi.fn()
+
+		tool = new ApplyDiffTool()
+	})
+
+	it("publishes through the guarded saveDirectly with edit kind", async () => {
+		await tool.execute({ path: "src/thing.ts", diff: "unified diff" }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockSaveDirectly).toHaveBeenCalledWith(
+			"src/thing.ts",
+			"modified file content\n",
+			false,
+			true,
+			1000,
+			"edit",
+		)
+		expect(mockPushToolResult).toHaveBeenCalledWith("Saved file")
+		expect(mockTask.didEditFile).toBe(true)
+		expect(mockHandleError).not.toHaveBeenCalled()
+	})
+
+	it("surfaces the unobserved edit remediation as a tool error", async () => {
+		const guardError = new Error("File not read yet -- read the file, then retry.")
+		mockSaveDirectly.mockRejectedValue(guardError)
+
+		await tool.execute({ path: "src/thing.ts", diff: "unified diff" }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockHandleError).toHaveBeenCalledWith("applying diff", guardError)
+		expect(vi.mocked(mockTask.diffViewProvider.reset)).toHaveBeenCalled()
+		expect(mockTask.didEditFile).toBe(false)
+		expect(mockPushToolResult).not.toHaveBeenCalledWith("Saved file")
+	})
+})

--- a/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
+++ b/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
@@ -94,3 +94,201 @@ describe("ApplyPatchTool.execute - delete file success path", () => {
 		expect(mockTask.recordToolError).not.toHaveBeenCalled()
 	})
 })
+
+describe("ApplyPatchTool.execute - guarded write (S4b, epic #1375)", () => {
+	const mockedFileExistsAtPath = fileExistsAtPath as MockedFunction<typeof fileExistsAtPath>
+
+	let tool: ApplyPatchTool
+	let mockTask: Pick<
+		Task,
+		| "cwd"
+		| "consecutiveMistakeCount"
+		| "recordToolError"
+		| "rooIgnoreController"
+		| "rooProtectedController"
+		| "say"
+		| "processQueuedMessages"
+		| "didEditFile"
+		| "diffViewProvider"
+		| "providerRef"
+		| "fileContextTracker"
+	>
+	let mockSaveDirectly: MockedFunction<(...args: unknown[]) => Promise<unknown>>
+	let mockAskApproval: MockedFunction<(...args: unknown[]) => Promise<boolean>>
+	let mockHandleError: MockedFunction<(...args: unknown[]) => Promise<void>>
+	let mockPushToolResult: MockedFunction<(...args: unknown[]) => void>
+
+	const updatePatch = `*** Begin Patch
+*** Update File: src/thing.ts
+@@
+-original file content
++modified file content
+*** End Patch`
+
+	const addPatch = `*** Begin Patch
+*** Add File: src/new.ts
++new line one
++new line two
+*** End Patch`
+
+	const movePatch = `*** Begin Patch
+*** Update File: src/old.ts
+*** Move to: src/new.ts
+@@
+-original file content
++modified file content
+*** End Patch`
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockedFileExistsAtPath.mockResolvedValue(true)
+
+		mockSaveDirectly = vi.fn().mockResolvedValue({
+			newProblemsMessage: "",
+			userEdits: undefined,
+			finalContent: "new content",
+		})
+
+		// Structural stubs for the guarded-write path: the real DiffViewProvider is
+		// out of scope here, so vi.fn() doubles stand in for the members the tool
+		// touches (the saveDirectly double also records the writeKind plumbing).
+		const diffViewProviderStub = {
+			editType: undefined as "create" | "modify" | undefined,
+			originalContent: undefined as string | undefined,
+			saveDirectly: mockSaveDirectly,
+			pushToolWriteResult: vi.fn().mockResolvedValue("Saved file"),
+			reset: vi.fn().mockResolvedValue(undefined),
+		}
+		mockTask = {
+			cwd: "/workspace/project",
+			consecutiveMistakeCount: 0,
+			recordToolError: vi.fn(),
+			rooIgnoreController: {
+				validateAccess: vi.fn().mockReturnValue(true),
+			} as unknown as Task["rooIgnoreController"],
+			rooProtectedController: {
+				isWriteProtected: vi.fn().mockReturnValue(false),
+			} as unknown as Task["rooProtectedController"],
+			say: vi.fn().mockResolvedValue(undefined),
+			processQueuedMessages: vi.fn(),
+			didEditFile: false,
+			diffViewProvider: diffViewProviderStub as unknown as Task["diffViewProvider"],
+			providerRef: {
+				deref: vi.fn().mockReturnValue({
+					getState: vi.fn().mockResolvedValue({
+						diagnosticsEnabled: true,
+						writeDelayMs: 1000,
+						// Exercise the focus-disruption (saveDirectly) save path.
+						experiments: { preventFocusDisruption: true },
+					}),
+				}),
+			} as unknown as Task["providerRef"],
+			fileContextTracker: {
+				trackFileContext: vi.fn().mockResolvedValue(undefined),
+			} as unknown as Task["fileContextTracker"],
+		}
+
+		mockAskApproval = vi.fn().mockResolvedValue(true)
+		mockHandleError = vi.fn().mockResolvedValue(undefined)
+		mockPushToolResult = vi.fn()
+
+		tool = new ApplyPatchTool()
+	})
+
+	it("update: publishes through the guarded saveDirectly with create kind", async () => {
+		await tool.execute({ patch: updatePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockSaveDirectly).toHaveBeenCalledWith(
+			"src/thing.ts",
+			"modified file content\n",
+			false,
+			true,
+			1000,
+			"create",
+		)
+		expect(mockPushToolResult).toHaveBeenCalledWith("Saved file")
+		expect(mockTask.didEditFile).toBe(true)
+		expect(mockHandleError).not.toHaveBeenCalled()
+	})
+
+	it("add: publishes the new file through the guarded saveDirectly with create kind", async () => {
+		mockedFileExistsAtPath.mockResolvedValueOnce(false)
+
+		await tool.execute({ patch: addPatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockSaveDirectly).toHaveBeenCalledWith(
+			"src/new.ts",
+			"new line one\nnew line two\n",
+			true,
+			true,
+			1000,
+			"create",
+		)
+		expect(mockPushToolResult).toHaveBeenCalledWith("Saved file")
+		expect(mockTask.didEditFile).toBe(true)
+		expect(mockHandleError).not.toHaveBeenCalled()
+	})
+
+	it("move: publishes the destination through the guarded saveDirectly with create kind", async () => {
+		await tool.execute({ patch: movePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockSaveDirectly).toHaveBeenCalledWith(
+			"src/new.ts",
+			"modified file content\n",
+			false,
+			true,
+			1000,
+			"create",
+		)
+		expect(mockTask.didEditFile).toBe(true)
+		expect(mockHandleError).not.toHaveBeenCalled()
+	})
+
+	it("update: surfaces the unobserved-existing remediation as a tool error", async () => {
+		const guardError = new Error(
+			"File already exists at /workspace/project/src/thing.ts and was not read before this write -- read the file first, then retry.",
+		)
+		mockSaveDirectly.mockRejectedValue(guardError)
+
+		await tool.execute({ patch: updatePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockHandleError).toHaveBeenCalledWith("apply patch", guardError)
+		expect(vi.mocked(mockTask.diffViewProvider.reset)).toHaveBeenCalled()
+		expect(mockTask.didEditFile).toBe(false)
+		expect(mockPushToolResult).not.toHaveBeenCalledWith("Saved file")
+	})
+
+	it("update: surfaces the stale-version remediation as a tool error", async () => {
+		const guardError = new Error(
+			"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+		)
+		mockSaveDirectly.mockRejectedValue(guardError)
+
+		await tool.execute({ patch: updatePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockHandleError).toHaveBeenCalledWith("apply patch", guardError)
+		expect(vi.mocked(mockTask.diffViewProvider.reset)).toHaveBeenCalled()
+		expect(mockTask.didEditFile).toBe(false)
+	})
+})

--- a/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
+++ b/src/core/tools/__tests__/applyPatchTool.execute.spec.ts
@@ -4,12 +4,36 @@ import type { MockedFunction } from "vitest"
 
 import { fileExistsAtPath } from "../../../utils/fs"
 import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
+import path from "path"
+import * as fsPromises from "fs/promises"
 import type { Task } from "../../task/Task"
+import { ObservationRegistry } from "../../task/observationRegistry"
 import { ApplyPatchTool } from "../ApplyPatchTool"
+
+// The vi.mock factory exposes the fs/promises functions under a `default`
+// property (matching the SUT's default import), which the static module type
+// does not declare; cast once at this boundary rather than at each call site.
+const mockedFsPromises = vi.mocked(
+	fsPromises as unknown as {
+		default: {
+			stat: ReturnType<typeof vi.fn>
+			unlink: MockedFunction<typeof fsPromises.unlink>
+		}
+	},
+)
 
 vi.mock("fs/promises", () => ({
 	default: {
 		readFile: vi.fn().mockResolvedValue("original file content\n"),
+		// Stable on-disk version for the S2 self-read observation (the hunk
+		// read now stats before and after; equal tokens record the observe).
+		stat: vi.fn().mockResolvedValue({
+			dev: 7n,
+			ino: 4242n,
+			size: 1234n,
+			mtimeNs: 1_700_000_000_123_456_789n,
+			ctimeNs: 1_700_000_000_789_999_999n,
+		}),
 		unlink: vi.fn().mockResolvedValue(undefined),
 	},
 }))
@@ -38,6 +62,7 @@ describe("ApplyPatchTool.execute - delete file success path", () => {
 		| "say"
 		| "processQueuedMessages"
 		| "didEditFile"
+		| "observationRegistry"
 	>
 	let mockAskApproval: MockedFunction<(...args: unknown[]) => Promise<boolean>>
 	let mockHandleError: MockedFunction<(...args: unknown[]) => Promise<void>>
@@ -52,6 +77,7 @@ describe("ApplyPatchTool.execute - delete file success path", () => {
 		mockTask = {
 			cwd: "/workspace/project",
 			consecutiveMistakeCount: 0,
+			observationRegistry: new ObservationRegistry(),
 			recordToolUsage: vi.fn(),
 			recordToolError: vi.fn(),
 			rooIgnoreController: {
@@ -112,6 +138,7 @@ describe("ApplyPatchTool.execute - guarded write (S4b, epic #1375)", () => {
 		| "diffViewProvider"
 		| "providerRef"
 		| "fileContextTracker"
+		| "observationRegistry"
 	>
 	let mockSaveDirectly: MockedFunction<(...args: unknown[]) => Promise<unknown>>
 	let mockAskApproval: MockedFunction<(...args: unknown[]) => Promise<boolean>>
@@ -163,6 +190,7 @@ describe("ApplyPatchTool.execute - guarded write (S4b, epic #1375)", () => {
 		mockTask = {
 			cwd: "/workspace/project",
 			consecutiveMistakeCount: 0,
+			observationRegistry: new ObservationRegistry(),
 			recordToolError: vi.fn(),
 			rooIgnoreController: {
 				validateAccess: vi.fn().mockReturnValue(true),
@@ -214,6 +242,43 @@ describe("ApplyPatchTool.execute - guarded write (S4b, epic #1375)", () => {
 		expect(mockPushToolResult).toHaveBeenCalledWith("Saved file")
 		expect(mockTask.didEditFile).toBe(true)
 		expect(mockHandleError).not.toHaveBeenCalled()
+	})
+
+	it("update: observes the hunk read so the guarded publish is not unobserved", async () => {
+		await tool.execute({ patch: updatePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		// The hunk read doubles as the S2 observation (ReadFileTool contract):
+		// stable pre/post stats record the version token, so the in-place modify
+		// publish is not rejected as an unobserved write.
+		const observed = mockTask.observationRegistry.get(path.resolve("/workspace/project", "src/thing.ts"))
+		expect(observed?.version).toBe("7:4242:1234:1700000000123456789:1700000000789999999")
+	})
+
+	it("update: does not observe when the pre- and post-read tokens disagree", async () => {
+		// The file changed mid-read: pre/post stats differ, so no observation is
+		// recorded and the guarded publish surfaces the unobserved-existing
+		// remediation instead of publishing against a stale version.
+		const statMock = mockedFsPromises.default.stat
+		statMock.mockResolvedValueOnce({ dev: 7n, ino: 4242n, size: 1234n, mtimeNs: 1n, ctimeNs: 2n })
+		statMock.mockResolvedValueOnce({ dev: 7n, ino: 4242n, size: 9999n, mtimeNs: 3n, ctimeNs: 4n })
+
+		const guardError = new Error(
+			"File already exists at /workspace/project/src/thing.ts and was not read before this write -- read the file first, then retry.",
+		)
+		mockSaveDirectly.mockRejectedValue(guardError)
+
+		await tool.execute({ patch: updatePatch }, mockTask as Task, {
+			askApproval: mockAskApproval,
+			handleError: mockHandleError,
+			pushToolResult: mockPushToolResult,
+		})
+
+		expect(mockTask.observationRegistry.has(path.resolve("/workspace/project", "src/thing.ts"))).toBe(false)
+		expect(mockHandleError).toHaveBeenCalled()
 	})
 
 	it("add: publishes the new file through the guarded saveDirectly with create kind", async () => {

--- a/src/core/tools/__tests__/editFileTool.spec.ts
+++ b/src/core/tools/__tests__/editFileTool.spec.ts
@@ -168,6 +168,7 @@ describe("editFileTool", () => {
 			fileContent?: string
 			isPartial?: boolean
 			accessAllowed?: boolean
+			experiments?: Record<string, boolean>
 		} = {},
 	): Promise<ToolResponse | undefined> {
 		const fileExists = options.fileExists ?? true
@@ -178,6 +179,13 @@ describe("editFileTool", () => {
 		mockedFileExistsAtPath.mockResolvedValue(fileExists)
 		mockedFsReadFile.mockResolvedValue(fileContent)
 		mockTask.rooIgnoreController.validateAccess.mockReturnValue(accessAllowed)
+		mockTask.providerRef.deref.mockReturnValue({
+			getState: vi.fn().mockResolvedValue({
+				diagnosticsEnabled: true,
+				writeDelayMs: 1000,
+				experiments: options.experiments ?? {},
+			}),
+		})
 
 		const nativeArgs: Record<string, unknown> = {
 			file_path: testFilePath,
@@ -684,6 +692,93 @@ describe("editFileTool", () => {
 			await executeEditFileTool()
 
 			expect(mockTask.fileContextTracker.trackFileContext).toHaveBeenCalledWith(testFilePath, "roo_edited")
+		})
+	})
+
+	describe("guarded write (S4b, epic #1375)", () => {
+		const focusDisruption = { preventFocusDisruption: true }
+
+		it("publishes an existing-file edit through saveDirectly with edit kind", async () => {
+			const result = await executeEditFileTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileExists: true, fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockTask.diffViewProvider.saveDirectly).toHaveBeenCalledWith(
+				testFilePath,
+				"Line 1\nModified Line 2\nLine 3",
+				false,
+				true,
+				1000,
+				"edit",
+			)
+			expect(mockTask.diffViewProvider.saveChanges).not.toHaveBeenCalled()
+			expect(mockTask.didEditFile).toBe(true)
+			expect(result).toContain("Tool result message")
+			expect(mockHandleError).not.toHaveBeenCalled()
+		})
+
+		it("publishes new-file creation through saveDirectly with create kind", async () => {
+			await executeEditFileTool(
+				{ old_string: "", new_string: "New file content" },
+				{ fileExists: false, experiments: focusDisruption },
+			)
+
+			expect(mockTask.diffViewProvider.saveDirectly).toHaveBeenCalledWith(
+				testFilePath,
+				"New file content",
+				true,
+				true,
+				1000,
+				"create",
+			)
+			expect(mockTask.didEditFile).toBe(true)
+			expect(mockHandleError).not.toHaveBeenCalled()
+		})
+
+		it("surfaces the unobserved edit remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error("File not read yet -- read the file, then retry.")
+			mockTask.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeEditFileTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileExists: true, fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockHandleError).toHaveBeenCalledWith("edit_file", guardError)
+			expect(result).toBeUndefined()
+			expect(mockTask.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockTask.didToolFailInCurrentTurn).toBe(true)
+			expect(mockTask.didEditFile).toBe(false)
+		})
+
+		it("surfaces the stale-version remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+			mockTask.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeEditFileTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileExists: true, fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockHandleError).toHaveBeenCalledWith("edit_file", guardError)
+			expect(result).toBeUndefined()
+			expect(mockTask.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockTask.didEditFile).toBe(false)
+		})
+
+		it("still fails a literal mismatch with the existing message before the guard runs", async () => {
+			const result = await executeEditFileTool(
+				{ old_string: "NonExistent", new_string: "Whatever" },
+				{ fileExists: true, fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(result).toContain("No match found")
+			expect(result).toContain("<error_details>")
+			expect(mockTask.diffViewProvider.saveDirectly).not.toHaveBeenCalled()
+			expect(mockHandleError).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/core/tools/__tests__/editTool.spec.ts
+++ b/src/core/tools/__tests__/editTool.spec.ts
@@ -169,6 +169,7 @@ describe("editTool", () => {
 			fileContent?: string
 			isPartial?: boolean
 			accessAllowed?: boolean
+			experiments?: Record<string, boolean>
 		} = {},
 	): Promise<ToolResponse | undefined> {
 		const fileExists = options.fileExists ?? true
@@ -179,6 +180,13 @@ describe("editTool", () => {
 		mockedFileExistsAtPath.mockResolvedValue(fileExists)
 		mockedFsReadFile.mockResolvedValue(fileContent)
 		mockTask.rooIgnoreController.validateAccess.mockReturnValue(accessAllowed)
+		mockTask.providerRef.deref.mockReturnValue({
+			getState: vi.fn().mockResolvedValue({
+				diagnosticsEnabled: true,
+				writeDelayMs: 1000,
+				experiments: options.experiments ?? {},
+			}),
+		})
 
 		const defaultParams = {
 			file_path: testFilePath,
@@ -422,6 +430,44 @@ describe("editTool", () => {
 			await executeEditTool()
 
 			expect(mockTask.fileContextTracker.trackFileContext).toHaveBeenCalledWith(testFilePath, "roo_edited")
+		})
+	})
+
+	describe("guarded write (S4b, epic #1375)", () => {
+		const focusDisruption = { preventFocusDisruption: true }
+
+		it("publishes through saveDirectly with edit kind", async () => {
+			const result = await executeEditTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockTask.diffViewProvider.saveDirectly).toHaveBeenCalledWith(
+				testFilePath,
+				"Line 1\nModified Line 2\nLine 3",
+				false,
+				true,
+				1000,
+				"edit",
+			)
+			expect(mockTask.didEditFile).toBe(true)
+			expect(result).toBe("Tool result message")
+			expect(mockHandleError).not.toHaveBeenCalled()
+		})
+
+		it("surfaces the unobserved edit remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error("File not read yet -- read the file, then retry.")
+			mockTask.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeEditTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockHandleError).toHaveBeenCalledWith("edit", guardError)
+			expect(result).toBeUndefined()
+			expect(mockTask.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockTask.didEditFile).toBe(false)
 		})
 	})
 })

--- a/src/core/tools/__tests__/guardedWrite.spec.ts
+++ b/src/core/tools/__tests__/guardedWrite.spec.ts
@@ -1,0 +1,454 @@
+/**
+ * Tests for the guarded-write compare-and-swap core (upstream epic #1375,
+ * phase A4a).
+ *
+ * Covers guard selection through the S2 observation registry, version-token
+ * CAS, remediation messages, and the per-absolute-path FIFO chain: FIFO
+ * ordering, exactly-one winner under concurrency, no wedge after a rejected
+ * link, and independence across paths.
+ */
+
+import * as fs from "fs/promises"
+import * as path from "path"
+
+import { describe, expect, it, beforeEach, vi } from "vitest"
+
+import { createIfAbsent, guardedWrite, replaceIfVersion, resetChain } from "../guardedWrite"
+import { safeWriteText } from "../../../services/file-safety/safeWriteText"
+import { computeVersionToken } from "../../../utils/versionToken"
+import { ObservationRegistry } from "../../task/observationRegistry"
+import type { Task } from "../../task/Task"
+
+// -- Mocks -------------------------------------------------------------------
+
+vi.mock("fs/promises", () => ({
+	access: vi.fn(),
+	stat: vi.fn(),
+}))
+
+vi.mock("../../../utils/versionToken", () => ({
+	computeVersionToken: vi.fn(),
+}))
+
+vi.mock("../../../services/file-safety/safeWriteText", () => ({
+	safeWriteText: vi.fn(),
+}))
+
+const mockedFsAccess = vi.mocked(fs.access)
+const mockedComputeVersionToken = vi.mocked(computeVersionToken)
+const mockedSafeWriteText = vi.mocked(safeWriteText)
+
+// -- Fixtures ----------------------------------------------------------------
+
+const WORKSPACE = "/test/workspace"
+
+/** Resolve a fixture path the same way guardedWrite resolves task.cwd-relative paths. */
+const abs = (relPath: string): string => path.resolve(WORKSPACE, relPath)
+
+interface MockTaskOptions {
+	cwd?: string
+	observationRegistry?: ObservationRegistry
+}
+
+/**
+ * Minimal structural Task: guardedWrite only reads task.cwd and
+ * task.observationRegistry. The real Task constructor needs the full provider
+ * machinery, so a single documented double cast stands in for the class.
+ */
+function createMockTask(options: MockTaskOptions = {}): Task {
+	const task = {
+		cwd: options.cwd ?? WORKSPACE,
+		observationRegistry: options.observationRegistry ?? new ObservationRegistry(),
+	}
+	return task as unknown as Task
+}
+
+// -- Tests -------------------------------------------------------------------
+
+describe("guardedWrite (S4a, epic #1375)", () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+		resetChain()
+	})
+
+	describe("unobserved create", () => {
+		it("succeeds when the file is absent and publishes via safeWriteText", async () => {
+			mockedFsAccess.mockRejectedValue({ code: "ENOENT" })
+			const task = createMockTask()
+
+			await guardedWrite(task, "new-file.txt", "hello", "create")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("new-file.txt"), "hello")
+		})
+
+		it("fails with the read-first remediation when the file exists - nothing published", async () => {
+			mockedFsAccess.mockResolvedValue(undefined)
+			const task = createMockTask()
+
+			await expect(guardedWrite(task, "existing.txt", "hello", "create")).rejects.toThrow(
+				"File already exists at " +
+					abs("existing.txt") +
+					" and was not read before this write -- read the file first, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+
+		it("rethrows I/O errors that are not ENOENT verbatim (no guard verdict on access failure)", async () => {
+			const failures = [{ code: "EACCES" }, null, "volume offline", new Error("EIO-ish failure")]
+			for (const failure of failures) {
+				mockedFsAccess.mockRejectedValueOnce(failure)
+				await expect(createIfAbsent(abs("io-error.txt"), "x")).rejects.toBe(failure)
+			}
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("deleted-after-read target", () => {
+		it("normalizes an ENOENT from the version token into the re-read remediation", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("vanished.txt"), "v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			// The file was deleted after the read: the token computation fails
+			// with a raw ENOENT, which the guard must convert into the standard
+			// re-read-then-retry contract.
+			mockedComputeVersionToken.mockRejectedValue({ code: "ENOENT" })
+
+			await expect(guardedWrite(task, "vanished.txt", "next", "update")).rejects.toThrow(
+				"File was deleted after it was read",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+
+		it("rethrows non-ENOENT token failures verbatim from replaceIfVersion", async () => {
+			const failure = { code: "EACCES" }
+			mockedComputeVersionToken.mockRejectedValueOnce(failure)
+
+			await expect(replaceIfVersion(abs("locked.txt"), "v1", "next")).rejects.toBe(failure)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+	describe("unobserved update", () => {
+		it("succeeds when the file is absent (same create guard)", async () => {
+			mockedFsAccess.mockRejectedValue({ code: "ENOENT" })
+			const task = createMockTask()
+
+			await guardedWrite(task, "new-file.txt", "hello", "update")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("new-file.txt"), "hello")
+		})
+
+		it("fails with the read-first remediation when the file exists - nothing published", async () => {
+			mockedFsAccess.mockResolvedValue(undefined)
+			const task = createMockTask()
+
+			await expect(guardedWrite(task, "existing.txt", "hello", "update")).rejects.toThrow(
+				"File already exists at " +
+					abs("existing.txt") +
+					" and was not read before this write -- read the file first, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("observed create", () => {
+		it("recreates a file that vanished after the read", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("gone.txt"), "v1")
+			mockedFsAccess.mockRejectedValue({ code: "ENOENT" })
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "gone.txt", "back", "create")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("gone.txt"), "back")
+		})
+
+		it("goes through the version guard when the file still exists", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("kept.txt"), "v1")
+			mockedFsAccess.mockResolvedValue(undefined)
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "kept.txt", "rewritten", "create")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("kept.txt"), "rewritten")
+		})
+
+		it("fails with the stale remediation suffix when the version moved", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("kept.txt"), "v1")
+			mockedFsAccess.mockResolvedValue(undefined)
+			mockedComputeVersionToken.mockResolvedValue("v2")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await expect(guardedWrite(task, "kept.txt", "rewritten", "create")).rejects.toThrow(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+
+		it("defers to the version guard when the access check is denied (not ENOENT)", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("locked.txt"), "v1")
+			mockedFsAccess.mockRejectedValue({ code: "EACCES" })
+			mockedComputeVersionToken.mockResolvedValue("v2")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await expect(guardedWrite(task, "locked.txt", "rewritten", "create")).rejects.toThrow(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("observed update (version CAS)", () => {
+		it("publishes when the on-disk version matches the observation", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("doc.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "doc.txt", "new content", "update")
+
+			expect(mockedComputeVersionToken).toHaveBeenCalledWith(abs("doc.txt"))
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("doc.txt"), "new content")
+		})
+
+		it("fails with the stale remediation suffix when the version moved - nothing published", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("doc.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v2")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await expect(guardedWrite(task, "doc.txt", "new content", "update")).rejects.toThrow(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("edit", () => {
+		it("fails read-first when the file was never observed - nothing published, no I/O", async () => {
+			const task = createMockTask()
+
+			await expect(guardedWrite(task, "any.txt", "patched", "edit")).rejects.toThrow(
+				"File not read yet -- read the file, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+			expect(mockedComputeVersionToken).not.toHaveBeenCalled()
+			expect(mockedFsAccess).not.toHaveBeenCalled()
+		})
+
+		it("publishes when the version matches the observation", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("doc.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "doc.txt", "patched", "edit")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("doc.txt"), "patched")
+		})
+
+		it("fails with the stale remediation suffix when the version moved", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("doc.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v3")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await expect(guardedWrite(task, "doc.txt", "patched", "edit")).rejects.toThrow(
+				"Stale version -- the file changed since you read it (expected v1, current v3); re-read the file, then retry.",
+			)
+			expect(mockedSafeWriteText).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("concurrency: per-path FIFO chain", () => {
+		it("two concurrent updates on one path - exactly one publishes, the other fails stale", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("shared.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			// The first publish changes the on-disk state (new token).
+			mockedSafeWriteText.mockImplementation(async () => {
+				mockedComputeVersionToken.mockResolvedValue("v2")
+			})
+
+			const p1 = guardedWrite(task, "shared.txt", "first", "update")
+			const p2 = guardedWrite(task, "shared.txt", "second", "update")
+			const [r1, r2] = await Promise.allSettled([p1, p2])
+
+			if (r1.status !== "fulfilled" || r2.status !== "rejected") {
+				throw new Error("expected exactly one publish, got " + r1.status + " / " + r2.status)
+			}
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(r2.reason.message).toBe(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+		})
+
+		it("observed-absent then two concurrent creates - the second fails stale", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("absent.txt"), "v1") // read before, file later vanished
+			mockedFsAccess.mockRejectedValue({ code: "ENOENT" })
+			const task = createMockTask({ observationRegistry: reg })
+
+			let publishes = 0
+			mockedSafeWriteText.mockImplementation(async () => {
+				publishes += 1
+				if (publishes === 1) {
+					// After the first publish the file exists again under a new token.
+					mockedFsAccess.mockResolvedValue(undefined)
+					mockedComputeVersionToken.mockResolvedValue("v2")
+				}
+			})
+
+			const p1 = guardedWrite(task, "absent.txt", "first", "create")
+			const p2 = guardedWrite(task, "absent.txt", "second", "create")
+			const [r1, r2] = await Promise.allSettled([p1, p2])
+
+			if (r1.status !== "fulfilled" || r2.status !== "rejected") {
+				throw new Error("expected exactly one publish, got " + r1.status + " / " + r2.status)
+			}
+			expect(publishes).toBe(1)
+			expect(r2.reason.message).toContain("Stale version")
+			expect(r2.reason.message).toContain("re-read the file, then retry.")
+		})
+
+		it("the chain settles after a rejection - a later matching write still runs", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("settle.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v2") // already stale at v1
+			const task = createMockTask({ observationRegistry: reg })
+
+			const p1 = guardedWrite(task, "settle.txt", "first", "update")
+			await expect(p1).rejects.toThrow("Stale version")
+
+			// No resetChain: the rejected link must not wedge the chain. The
+			// caller re-reads the file (observation refreshed to v2) and retries.
+			reg.observe(abs("settle.txt"), "v2")
+			const p2 = guardedWrite(task, "settle.txt", "second", "update")
+			await expect(p2).resolves.toBeUndefined()
+
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("settle.txt"), "second")
+		})
+
+		it("evicts settled chain entries - a later write still serializes in order", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("evict.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			// A first write settles; its chain entry is evicted with it.
+			const p1 = guardedWrite(task, "evict.txt", "first", "update")
+			await expect(p1).resolves.toBeUndefined()
+
+			// Two rapid writes submitted after the eviction must still run one
+			// at a time in submission order (the eviction must not drop the
+			// chain for in-flight or just-enqueued links).
+			const order: string[] = []
+			mockedSafeWriteText.mockImplementation(async (_path: string, content: string) => {
+				order.push(content)
+			})
+			const p2 = guardedWrite(task, "evict.txt", "second", "update")
+			const p3 = guardedWrite(task, "evict.txt", "third", "update")
+			await Promise.all([p2, p3])
+
+			expect(order).toEqual(["second", "third"])
+			// Three publishes in total: the settled first write plus the two
+			// serialized rapid writes.
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(3)
+		})
+
+		it("writes on different paths are independent (no cross-path serialization)", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("a.txt"), "v1")
+			reg.observe(abs("b.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			const p1 = guardedWrite(task, "a.txt", "a", "update")
+			const p2 = guardedWrite(task, "b.txt", "b", "update")
+			await Promise.all([p1, p2])
+
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	describe("path resolution", () => {
+		it("resolves a relative path against task.cwd", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("sub/dir.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "sub/dir.txt", "content", "update")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(abs("sub/dir.txt"), "content")
+		})
+
+		it("normalizes an already-absolute input (trailing separator) to the observation key", async () => {
+			const reg = new ObservationRegistry()
+			const canonical = abs("sub/dir.txt")
+			// ReadFileTool observes under path.resolve(task.cwd, relPath) — the
+			// canonical spelling. A write addressed with a trailing separator used
+			// to bypass the observation (isAbsolute passthrough) and fail
+			// "File already exists" / "File not read yet" for a file that was read.
+			reg.observe(canonical, "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, canonical + "/", "content", "update")
+
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(mockedSafeWriteText).toHaveBeenCalledWith(canonical, "content")
+		})
+
+		it("serializes two spellings of one file through a single chain key", async () => {
+			const reg = new ObservationRegistry()
+			const canonical = abs("shared2.txt")
+			reg.observe(canonical, "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			// The first publish changes the on-disk state (new token).
+			mockedSafeWriteText.mockImplementation(async () => {
+				mockedComputeVersionToken.mockResolvedValue("v2")
+			})
+
+			// Plain spelling vs the trailing-separator spelling: with one chain key
+			// they are strictly ordered (first matches v1, second sees v2).
+			const p1 = guardedWrite(task, canonical, "first", "update")
+			const p2 = guardedWrite(task, canonical + "/", "second", "update")
+			const [r1, r2] = await Promise.allSettled([p1, p2])
+
+			if (r1.status !== "fulfilled" || r2.status !== "rejected") {
+				throw new Error("expected exactly one publish, got " + r1.status + " / " + r2.status)
+			}
+			expect(mockedSafeWriteText).toHaveBeenCalledTimes(1)
+			expect(r2.reason.message).toBe(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+		})
+	})
+
+	describe("resetChain", () => {
+		it("detaches pending links so later writes start a fresh chain", async () => {
+			const reg = new ObservationRegistry()
+			reg.observe(abs("x.txt"), "v1")
+			mockedComputeVersionToken.mockResolvedValue("v1")
+			const task = createMockTask({ observationRegistry: reg })
+
+			await guardedWrite(task, "x.txt", "a", "update")
+			resetChain()
+			await guardedWrite(task, "x.txt", "b", "update")
+
+			expect(mockedSafeWriteText).toHaveBeenLastCalledWith(abs("x.txt"), "b")
+		})
+	})
+})

--- a/src/core/tools/__tests__/readFileTool.spec.ts
+++ b/src/core/tools/__tests__/readFileTool.spec.ts
@@ -13,10 +13,16 @@
  */
 
 import path from "path"
+import type { Stats } from "fs"
+
+import type { LegacyReadFileParams } from "@roo-code/types"
 
 import { isBinaryFile } from "isbinaryfile"
 
 import { readFileTool, ReadFileTool } from "../ReadFileTool"
+import type { Task } from "../../task/Task"
+import { ObservationRegistry } from "../../task/observationRegistry"
+import { computeVersionToken } from "../../../utils/versionToken"
 import { formatResponse } from "../../prompts/responses"
 import {
 	validateImageForProcessing,
@@ -136,6 +142,7 @@ interface MockTaskOptions {
 	rooIgnoreAllowed?: boolean
 	maxImageFileSize?: number
 	maxTotalImageSize?: number
+	observationRegistry?: ObservationRegistry
 }
 
 function createMockTask(options: MockTaskOptions = {}) {
@@ -143,6 +150,9 @@ function createMockTask(options: MockTaskOptions = {}) {
 
 	return {
 		cwd: "/test/workspace",
+		// Mirror Task: every task always owns an observation registry (A2, #1375).
+		// Tests asserting on observations pass their own instance via options.
+		observationRegistry: options.observationRegistry ?? new ObservationRegistry(),
 		api: {
 			getModel: vi.fn().mockReturnValue({
 				info: { supportsImages },
@@ -1488,6 +1498,109 @@ describe("ReadFileTool", () => {
 			await readFileTool.execute({ path: "src/" }, mockTask as any, callbacks)
 
 			expect(mockTask.didToolFailInCurrentTurn).toBe(true)
+		})
+
+		describe("observation registry", () => {
+			it("records an observation on successful read of an existing file", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				// Override the beforeEach default stat mock with proper BigIntStats.
+				mockedFsStat.mockResolvedValue({
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+					// Cast: the mock only implements the members the tool and versionToken read.
+				} as unknown as Stats)
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				// Spy on observe to capture the exact key used (Windows path.resolve may use backslashes).
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute({ path: "existing.ts" }, mockTask as unknown as Task, callbacks)
+
+				// Verify the tool called observe exactly once with a valid token.
+				expect(observeSpy).toHaveBeenCalledTimes(1)
+				const [calledPath, calledVersion] = observeSpy.mock.calls[0]
+				expect(calledPath).toContain("existing.ts")
+				expect(calledVersion).toMatch(/^\d+:\d+:\d+:\d+:\d+$/)
+
+				// Verify get() returns the same data using the spy-captured key.
+				const obs = reg.get(calledPath)
+				expect(obs).toBeDefined()
+				expect(obs!.version).toBe(calledVersion)
+			})
+
+			it("a failed read (absent path) leaves the registry size 0 and does not throw", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				mockedFsReadFile.mockRejectedValue(new Error("ENOENT"))
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute({ path: "missing.ts" }, mockTask as unknown as Task, callbacks)
+
+				// observationRegistry is guaranteed present because we passed it in createMockTask.
+				const reg = mockTask.observationRegistry
+				expect(reg).toBeDefined()
+				expect(reg!.size).toBe(0)
+			})
+
+			it("records an observation for legacy-format reads of existing files", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				mockedFsStat.mockResolvedValue({
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+					// Cast: the mock only implements the members the tool and versionToken read.
+				} as unknown as Stats)
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				// Typed legacy (pre-refactor) params: the multi-file format with the
+				// _legacyFormat discriminant (see LegacyReadFileParams).
+				const legacyParams: LegacyReadFileParams = {
+					files: [{ path: "legacy.ts" }],
+					_legacyFormat: true,
+				}
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute(legacyParams, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).toHaveBeenCalledTimes(1)
+				const [calledPath, calledVersion] = observeSpy.mock.calls[0]
+				expect(calledPath).toContain("legacy.ts")
+				expect(calledVersion).toMatch(/^\d+:\d+:\d+:\d+:\d+$/)
+			})
+
+			it("two separate Task-owned registries are independent", async () => {
+				const regA = new ObservationRegistry()
+				const regB = new ObservationRegistry()
+				regA.observe("/shared.ts", "v1")
+				expect(regA.get("/shared.ts")!.version).toBe("v1")
+				expect(regB.get("/shared.ts")).toBeUndefined()
+				regB.observe("/shared.ts", "v2")
+				expect(regA.get("/shared.ts")!.version).toBe("v1")
+				expect(regB.get("/shared.ts")!.version).toBe("v2")
+			})
 		})
 	})
 })

--- a/src/core/tools/__tests__/readFileTool.spec.ts
+++ b/src/core/tools/__tests__/readFileTool.spec.ts
@@ -197,7 +197,18 @@ describe("ReadFileTool", () => {
 		vi.clearAllMocks()
 
 		// Default mock implementations
-		mockedFsStat.mockResolvedValue({ isDirectory: () => false } as any)
+		// The stat default carries BigIntStats fields (A2, epic #1375): reads now
+		// token-ize the pre/post stats, so the default must look like a real bigint stat.
+		// Tests overriding it do so per-call with mockResolvedValue(Once).
+		mockedFsStat.mockResolvedValue({
+			isDirectory: () => false,
+			dev: BigInt(1),
+			ino: BigInt(2),
+			size: BigInt(300),
+			mtimeNs: BigInt(4_000_000_000n),
+			ctimeNs: BigInt(5_000_000_000n),
+			// Cast: the mock only implements the members the tool and versionToken read.
+		} as unknown as Stats)
 		mockedIsBinaryFile.mockResolvedValue(false)
 		mockedFsReadFile.mockResolvedValue(Buffer.from("test content"))
 		mockedReadWithSlice.mockReturnValue({
@@ -1591,6 +1602,204 @@ describe("ReadFileTool", () => {
 				expect(calledVersion).toMatch(/^\d+:\d+:\d+:\d+:\d+$/)
 			})
 
+			it("does not observe when the file mutates between the pre-read and post-read stats", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				const preStats = {
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+				}
+				// A mutation lands mid-read: the post-read stat differs.
+				const postStats = { ...preStats, size: BigInt(301) }
+
+				// Call order: directory check, pre-read stat, post-read stat.
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockResolvedValueOnce(preStats as unknown as Stats)
+					.mockResolvedValueOnce(postStats as unknown as Stats)
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute({ path: "mutated.ts" }, mockTask as unknown as Task, callbacks)
+
+				// The read itself succeeded, but the target stays unobserved: the content the
+				// model received is not the on-disk state, so observing it would let a later
+				// write match a token the model never saw.
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+			})
+
+			it("leaves the target unobserved without failing the read when the pre-read stat fails", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				// Directory check OK; the pre-read stat fails (caught, target unobserved).
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockRejectedValueOnce(new Error("EACCES"))
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute({ path: "stat-fail.ts" }, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				// The read still succeeds — a stat failure never fails the read.
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+				expect(callbacks.pushToolResult).toHaveBeenCalled()
+			})
+
+			it("leaves the target unobserved without failing the read when the post-read stat fails", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				const okStats = {
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+				}
+				// Directory check and pre-read stat OK; the post-read stat fails.
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockResolvedValueOnce(okStats as unknown as Stats)
+					.mockRejectedValueOnce(new Error("EACCES"))
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute({ path: "post-stat-fail.ts" }, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+				expect(callbacks.pushToolResult).toHaveBeenCalled()
+			})
+
+			it("legacy format: does not observe when the file mutates between the pre-read and post-read stats", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				const preStats = {
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+				}
+				// Call order: directory check, pre-read stat, post-read stat (mutated).
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockResolvedValueOnce(preStats as unknown as Stats)
+					.mockResolvedValueOnce({ ...preStats, size: BigInt(301) } as unknown as Stats)
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				const legacyParams: LegacyReadFileParams = {
+					files: [{ path: "legacy-mutated.ts" }],
+					_legacyFormat: true,
+				}
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute(legacyParams, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+			})
+
+			it("legacy format: leaves the target unobserved when a stat fails without failing the read", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				// Directory check OK; the pre-read stat fails (caught, target unobserved).
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockRejectedValueOnce(new Error("EACCES"))
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				const legacyParams: LegacyReadFileParams = {
+					files: [{ path: "legacy-stat-fail.ts" }],
+					_legacyFormat: true,
+				}
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute(legacyParams, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+				expect(callbacks.pushToolResult).toHaveBeenCalled()
+			})
+			it("legacy format: leaves the target unobserved when the post-read stat fails", async () => {
+				const mockTask = createMockTask({
+					observationRegistry: new ObservationRegistry(),
+				})
+				const callbacks = createMockCallbacks()
+
+				const okStats = {
+					isDirectory: () => false,
+					dev: BigInt(1),
+					ino: BigInt(2),
+					size: BigInt(300),
+					mtimeNs: BigInt(4_000_000_000n),
+					ctimeNs: BigInt(5_000_000_000n),
+				}
+				// Directory check and pre-read stat OK; the post-read stat fails.
+				mockedFsStat
+					.mockResolvedValueOnce({ isDirectory: () => false } as unknown as Stats)
+					.mockResolvedValueOnce(okStats as unknown as Stats)
+					.mockRejectedValueOnce(new Error("EACCES"))
+				mockedIsBinaryFile.mockResolvedValue(false)
+
+				const reg = mockTask.observationRegistry!
+				const observeSpy = vi.spyOn(reg, "observe")
+
+				const legacyParams: LegacyReadFileParams = {
+					files: [{ path: "legacy-post-stat-fail.ts" }],
+					_legacyFormat: true,
+				}
+
+				// Cast: the mock task only implements the members ReadFileTool.execute touches.
+				await readFileTool.execute(legacyParams, mockTask as unknown as Task, callbacks)
+
+				expect(observeSpy).not.toHaveBeenCalled()
+				expect(reg.size).toBe(0)
+				expect(mockTask.didToolFailInCurrentTurn).toBe(false)
+				expect(callbacks.pushToolResult).toHaveBeenCalled()
+			})
 			it("two separate Task-owned registries are independent", async () => {
 				const regA = new ObservationRegistry()
 				const regB = new ObservationRegistry()

--- a/src/core/tools/__tests__/searchReplaceTool.spec.ts
+++ b/src/core/tools/__tests__/searchReplaceTool.spec.ts
@@ -166,6 +166,7 @@ describe("searchReplaceTool", () => {
 			fileContent?: string
 			isPartial?: boolean
 			accessAllowed?: boolean
+			experiments?: Record<string, boolean>
 		} = {},
 	): Promise<ToolResponse | undefined> {
 		const fileExists = options.fileExists ?? true
@@ -176,6 +177,13 @@ describe("searchReplaceTool", () => {
 		mockedFileExistsAtPath.mockResolvedValue(fileExists)
 		mockedFsReadFile.mockResolvedValue(fileContent)
 		mockCline.rooIgnoreController.validateAccess.mockReturnValue(accessAllowed)
+		mockCline.providerRef.deref.mockReturnValue({
+			getState: vi.fn().mockResolvedValue({
+				diagnosticsEnabled: true,
+				writeDelayMs: 1000,
+				experiments: options.experiments ?? {},
+			}),
+		})
 
 		const nativeArgs: Record<string, unknown> = {
 			file_path: testFilePath,
@@ -437,6 +445,44 @@ describe("searchReplaceTool", () => {
 
 			expect(mockCline.consecutiveMistakeCount).toBe(0)
 			expect(mockAskApproval).toHaveBeenCalled()
+		})
+	})
+
+	describe("guarded write (S4b, epic #1375)", () => {
+		const focusDisruption = { preventFocusDisruption: true }
+
+		it("publishes through saveDirectly with edit kind", async () => {
+			const result = await executeSearchReplaceTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockCline.diffViewProvider.saveDirectly).toHaveBeenCalledWith(
+				testFilePath,
+				"Line 1\nModified Line 2\nLine 3",
+				false,
+				true,
+				1000,
+				"edit",
+			)
+			expect(mockCline.didEditFile).toBe(true)
+			expect(result).toBe("Tool result message")
+			expect(mockHandleError).not.toHaveBeenCalled()
+		})
+
+		it("surfaces the unobserved edit remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error("File not read yet -- read the file, then retry.")
+			mockCline.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeSearchReplaceTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileContent: "Line 1\nLine 2\nLine 3", experiments: focusDisruption },
+			)
+
+			expect(mockHandleError).toHaveBeenCalledWith("search and replace", guardError)
+			expect(result).toBeUndefined()
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockCline.didEditFile).toBe(false)
 		})
 	})
 })

--- a/src/core/tools/__tests__/writeToFileTool.spec.ts
+++ b/src/core/tools/__tests__/writeToFileTool.spec.ts
@@ -26,6 +26,13 @@ vi.mock("delay", () => ({
 	default: vi.fn(),
 }))
 
+// The focus-disruption save path reads the original file content via fs.readFile.
+vi.mock("fs/promises", () => ({
+	default: {
+		readFile: vi.fn().mockResolvedValue("original content"),
+	},
+}))
+
 vi.mock("../../../utils/fs", () => ({
 	fileExistsAtPath: vi.fn().mockResolvedValue(false),
 	createDirectoriesForFile: vi.fn().mockResolvedValue([]),
@@ -156,6 +163,11 @@ describe("writeToFileTool", () => {
 				userEdits: null,
 				finalContent: "final content",
 			}),
+			saveDirectly: vi.fn().mockResolvedValue({
+				newProblemsMessage: "",
+				userEdits: undefined,
+				finalContent: "final content",
+			}),
 			scrollToFirstDiff: vi.fn(),
 			updateDiagnosticSettings: vi.fn(),
 			pushToolWriteResult: vi.fn().mockImplementation(async function (
@@ -187,6 +199,7 @@ describe("writeToFileTool", () => {
 		mockCline.say = vi.fn().mockResolvedValue(undefined)
 		mockCline.ask = vi.fn().mockResolvedValue(undefined)
 		mockCline.recordToolError = vi.fn()
+		mockCline.processQueuedMessages = vi.fn()
 		mockCline.sayAndCreateMissingParamError = vi.fn().mockResolvedValue("Missing param error")
 
 		mockAskApproval = vi.fn().mockResolvedValue(true)
@@ -204,6 +217,7 @@ describe("writeToFileTool", () => {
 			fileExists?: boolean
 			isPartial?: boolean
 			accessAllowed?: boolean
+			experiments?: Record<string, boolean>
 		} = {},
 	): Promise<ToolResponse | undefined> {
 		// Configure mocks based on test scenario
@@ -213,6 +227,13 @@ describe("writeToFileTool", () => {
 
 		mockedFileExistsAtPath.mockResolvedValue(fileExists)
 		mockCline.rooIgnoreController.validateAccess.mockReturnValue(accessAllowed)
+		mockCline.providerRef.deref.mockReturnValue({
+			getState: vi.fn().mockResolvedValue({
+				diagnosticsEnabled: true,
+				writeDelayMs: 1000,
+				experiments: options.experiments ?? {},
+			}),
+		})
 
 		// Create a tool use object
 		const toolUse: ToolUse = {
@@ -447,6 +468,58 @@ describe("writeToFileTool", () => {
 				"user_feedback_diff",
 				expect.stringContaining("editedExistingFile"),
 			)
+		})
+	})
+
+	describe("guarded write (S4b, epic #1375)", () => {
+		const focusDisruption = { preventFocusDisruption: true }
+
+		it("publishes through saveDirectly with create kind when the write is approved", async () => {
+			const result = await executeWriteFileTool({}, { fileExists: true, experiments: focusDisruption })
+
+			expect(mockCline.diffViewProvider.saveDirectly).toHaveBeenCalledWith(
+				testFilePath,
+				testContent,
+				false,
+				true,
+				1000,
+				"create",
+			)
+			expect(mockCline.diffViewProvider.saveChanges).not.toHaveBeenCalled()
+			expect(mockCline.fileContextTracker.trackFileContext).toHaveBeenCalledWith(testFilePath, "roo_edited")
+			expect(mockCline.didEditFile).toBe(true)
+			expect(mockCline.consecutiveMistakeCount).toBe(0)
+			expect(result).toBe("Tool result message")
+			expect(mockHandleError).not.toHaveBeenCalled()
+		})
+
+		it("surfaces the unobserved-existing remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error(
+				`File already exists at ${absoluteFilePath} and was not read before this write -- read the file first, then retry.`,
+			)
+			mockCline.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeWriteFileTool({}, { fileExists: true, experiments: focusDisruption })
+
+			expect(mockHandleError).toHaveBeenCalledWith("writing file", guardError)
+			expect(result).toBeUndefined()
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockCline.diffViewProvider.saveChanges).not.toHaveBeenCalled()
+			expect(mockCline.didEditFile).toBe(false)
+		})
+
+		it("surfaces the stale-version remediation as a tool error and publishes nothing", async () => {
+			const guardError = new Error(
+				"Stale version -- the file changed since you read it (expected v1, current v2); re-read the file, then retry.",
+			)
+			mockCline.diffViewProvider.saveDirectly.mockRejectedValue(guardError)
+
+			const result = await executeWriteFileTool({}, { fileExists: true, experiments: focusDisruption })
+
+			expect(mockHandleError).toHaveBeenCalledWith("writing file", guardError)
+			expect(result).toBeUndefined()
+			expect(mockCline.diffViewProvider.reset).toHaveBeenCalled()
+			expect(mockCline.didEditFile).toBe(false)
 		})
 	})
 

--- a/src/core/tools/guardedWrite.ts
+++ b/src/core/tools/guardedWrite.ts
@@ -1,0 +1,260 @@
+/**
+ * Guarded-write compare-and-swap core (upstream epic #1375, phase A4a).
+ *
+ * Wraps the S3 safeWriteText publish primitive behind version-token guards so
+ * that every write is deterministic:
+ *
+ * - an unobserved target may only be created when it is absent
+ *   (createIfAbsent);
+ * - an observed target is published only when the on-disk version token still
+ *   matches the token recorded at read time (replaceIfVersion);
+ * - an edit-style write requires a prior observation (unobservedEditGuard).
+ *
+ * A per-absolute-path FIFO chain of tail promises orders concurrent
+ * in-process writes to the same path: the first matching write wins, the rest
+ * fail stale. Observations come from the task's S2 ObservationRegistry.
+ */
+
+import * as fs from "fs/promises"
+import * as path from "path"
+
+import { safeWriteText } from "../../services/file-safety/safeWriteText"
+import { computeVersionToken } from "../../utils/versionToken"
+import type { Task } from "../task/Task"
+
+// -- Types ------------------------------------------------------------------
+
+/** Write kind that drives guard selection. */
+export type GuardedWriteKind = "create" | "update" | "edit"
+
+/** Internal error thrown when a guard rejects a write. */
+class GuardRejectedError extends Error {
+	constructor(
+		message: string,
+		readonly path: string,
+	) {
+		super(message)
+		this.name = "GuardRejectedError"
+	}
+}
+
+// -- Per-path tail-promise chain --------------------------------------------
+
+/**
+ * Per-absolute-path FIFO chain of pending guarded writes (tail promise per
+ * path). Every write enqueues onto the current tail for its path, so
+ * concurrent writes to the same path run one at a time in submission order.
+ *
+ * The chain never leaks a rejection through itself: each link settles, a
+ * rejected link is skipped by the next writer (a failed write must not block
+ * later writes to the same path), and every caller receives its own link
+ * promise to handle.
+ *
+ * Settled entries are evicted (below), so a long-lived extension does not
+ * accumulate a map entry per distinct written path.
+ */
+const pendingChains = new Map<string, Promise<void>>()
+
+/**
+ * Enqueue a write operation on the per-path FIFO chain.
+ *
+ * Returns the promise for this link; it always settles. A prior link that
+ * rejected is skipped, not propagated. The map entry for this link is
+ * deleted once it settles — but only while it is still the current tail for
+ * the path, so a replacement enqueued in the meantime keeps ownership.
+ */
+function enqueue(pathKey: string, fn: () => Promise<void>): Promise<void> {
+	const prev = pendingChains.get(pathKey) ?? Promise.resolve()
+	const next = prev.then(fn, fn)
+	pendingChains.set(pathKey, next)
+	void next.then(
+		() => {
+			if (pendingChains.get(pathKey) === next) {
+				pendingChains.delete(pathKey)
+			}
+		},
+		() => {
+			if (pendingChains.get(pathKey) === next) {
+				pendingChains.delete(pathKey)
+			}
+		},
+	)
+	return next
+}
+
+// -- Guard primitives --------------------------------------------------------
+
+/**
+ * Extract a Node errno code (e.g. "ENOENT") from a thrown value, or
+ * undefined when the value carries none.
+ */
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? (error as { code?: string }).code
+		: undefined
+}
+
+/** True when the path is absent on disk (fs.access reports ENOENT). */
+async function fileIsAbsent(absolutePath: string): Promise<boolean> {
+	try {
+		await fs.access(absolutePath)
+		return false
+	} catch (error: unknown) {
+		return errorCode(error) === "ENOENT"
+	}
+}
+
+/**
+ * Publish content only if the target file does not exist.
+ *
+ * Rejects with a loud remediation error when the file already exists: the
+ * write was issued for a file that was never read, so the caller must read
+ * the file first, then retry.
+ */
+export async function createIfAbsent(absolutePath: string, content: string): Promise<void> {
+	try {
+		await fs.access(absolutePath)
+	} catch (error: unknown) {
+		if (errorCode(error) !== "ENOENT") {
+			// A real I/O failure (EACCES, EIO, ...) -- not a guard verdict.
+			throw error
+		}
+		await safeWriteText(absolutePath, content)
+		return
+	}
+
+	throw new GuardRejectedError(
+		"File already exists at " +
+			absolutePath +
+			" and was not read before this write -- read the file first, then retry.",
+		absolutePath,
+	)
+}
+
+/**
+ * Publish content only if the current on-disk version token equals
+ * expectedVersion (the token observed at read time).
+ *
+ * On a match the content is published via the S3 safeWriteText primitive; on
+ * a mismatch the write is rejected stale with a re-read-then-retry
+ * remediation suffix.
+ */
+export async function replaceIfVersion(absolutePath: string, expectedVersion: string, content: string): Promise<void> {
+	let currentVersion: string
+	try {
+		currentVersion = await computeVersionToken(absolutePath)
+	} catch (error: unknown) {
+		if (errorCode(error) === "ENOENT") {
+			// The observed file was deleted after the read: the version recorded
+			// at read time no longer exists on disk. Normalize the raw ENOENT
+			// into the guard's re-read-then-retry contract so the caller gets a
+			// remediation it can act on, not a raw errno.
+			throw new GuardRejectedError(
+				"File was deleted after it was read -- the version recorded at read time (" +
+					expectedVersion +
+					") no longer exists; re-read the file, then retry.",
+				absolutePath,
+			)
+		}
+		// A real I/O failure (EACCES, EIO, ...) -- not a guard verdict.
+		throw error
+	}
+
+	if (currentVersion === expectedVersion) {
+		await safeWriteText(absolutePath, content)
+		return
+	}
+
+	throw new GuardRejectedError(
+		"Stale version -- the file changed since you read it (expected " +
+			expectedVersion +
+			", current " +
+			currentVersion +
+			"); re-read the file, then retry.",
+		absolutePath,
+	)
+}
+
+/**
+ * Unobserved-edit guard: an edit-style write without a prior observation is
+ * rejected before any I/O. The literal-match / patch logic stays with the
+ * tools in S4b; this guard only verifies that a read happened first.
+ *
+ * Returns Promise<never> because the rejection is total: this function
+ * never resolves.
+ */
+export async function unobservedEditGuard(absolutePath: string): Promise<never> {
+	throw new GuardRejectedError("File not read yet -- read the file, then retry.", absolutePath)
+}
+
+// -- Public API --------------------------------------------------------------
+
+/**
+ * Resolve a relative or absolute path against task.cwd.
+ *
+ * path.resolve also normalizes an already-absolute input (collapsing "." / ".."
+ * segments and trailing separators), so the key always matches the
+ * ObservationRegistry key recorded at read time (ReadFileTool observes under
+ * path.resolve(task.cwd, relPath)) and two spellings of one file share one
+ * FIFO chain.
+ */
+function resolveAbsolutePath(task: Task, relPathOrAbsolute: string): string {
+	return path.resolve(task.cwd, relPathOrAbsolute)
+}
+
+/**
+ * Guarded write entry point.
+ *
+ * 1. Resolves the absolute path against task.cwd.
+ * 2. Consults the task's S2 observation registry to pick the guard:
+ *    - unobserved + create/update: createIfAbsent (rejects if it exists);
+ *    - observed + create on a file that vanished after the read: recreate;
+ *    - observed otherwise: replaceIfVersion (CAS on the S1 version token);
+ *    - unobserved + edit: unobservedEditGuard.
+ * 3. Runs the chosen guard on the per-path FIFO chain so concurrent writes to
+ *    the same path are deterministically ordered.
+ */
+export async function guardedWrite(
+	task: Task,
+	relPathOrAbsolute: string,
+	content: string,
+	kind: GuardedWriteKind = "update",
+): Promise<void> {
+	const absolutePath = resolveAbsolutePath(task, relPathOrAbsolute)
+
+	return enqueue(absolutePath, async () => {
+		const obs = task.observationRegistry.get(absolutePath)
+
+		if (obs === undefined) {
+			// Edit-style writes require a prior read: no observation, no write.
+			if (kind === "edit") {
+				await unobservedEditGuard(absolutePath)
+			}
+			// Never read: only an absent target may be created. (The edit guard
+			// above rejects before reaching this line.)
+			await createIfAbsent(absolutePath, content)
+			return
+		}
+
+		if (kind === "edit") {
+			await replaceIfVersion(absolutePath, obs.version, content)
+			return
+		}
+
+		// kind is "create" or "update": a "create" on a file that vanished
+		// after the read recreates it; otherwise the version recorded at read
+		// time must still match the on-disk token.
+		if (kind === "create" && (await fileIsAbsent(absolutePath))) {
+			await createIfAbsent(absolutePath, content)
+		} else {
+			await replaceIfVersion(absolutePath, obs.version, content)
+		}
+	})
+}
+
+/**
+ * Reset the per-path tail-promise chains (test hook).
+ */
+export function resetChain(): void {
+	pendingChains.clear()
+}

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -1721,7 +1721,7 @@
 	},
 	"utils/safeWriteJson.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 4
+			"count": 3
 		}
 	},
 	"utils/tts.ts": {

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -976,7 +976,7 @@
 	},
 	"core/tools/__tests__/readFileTool.spec.ts": {
 		"@typescript-eslint/no-explicit-any": {
-			"count": 98
+			"count": 97
 		}
 	},
 	"core/tools/__tests__/runSlashCommandTool.spec.ts": {

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -18,7 +18,7 @@ import { arePathsEqual, getReadablePath } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
 import { Task } from "../../core/task/Task"
-import { safeWriteText } from "../../services/file-safety/safeWriteText"
+import { guardedWrite, type GuardedWriteKind } from "../../core/tools/guardedWrite"
 
 import { DecorationController } from "./DecorationController"
 
@@ -1137,6 +1137,10 @@ export class DiffViewProvider {
 	 * @param relPath - Relative path to the file
 	 * @param content - Content to write to the file
 	 * @param openFile - Whether to show the file in editor (false = open in memory only for diagnostics)
+	 * @param writeKind - Guarded-write kind that selects the S4a guard for this publish.
+	 *   Defaults to "create" because this method always publishes a complete file
+	 *   content: an unobserved target may only be created when absent, and an
+	 *   observed target must still carry the version token recorded at read time.
 	 * @returns Result of the save operation including any new problems detected
 	 */
 	async saveDirectly(
@@ -1145,6 +1149,7 @@ export class DiffViewProvider {
 		openFile: boolean = true,
 		diagnosticsEnabled: boolean = true,
 		writeDelayMs: number = DEFAULT_WRITE_DELAY_MS,
+		writeKind: GuardedWriteKind = "create",
 	): Promise<{
 		newProblemsMessage: string | undefined
 		userEdits: string | undefined
@@ -1155,9 +1160,19 @@ export class DiffViewProvider {
 		// Get diagnostics before editing the file
 		this.preDiagnostics = vscode.languages.getDiagnostics()
 
-		// Write the content directly to the file
+		// Publish through the S4 guarded-write API (epic #1375): an unobserved
+		// write to an existing file and a stale observed version are rejected
+		// with a re-read-then-retry remediation instead of overwriting the file.
+		// Concurrent in-process writes to the same path are already ordered by
+		// the guard's per-path FIFO chain, so no additional locking is added here.
+		const task = this.taskRef.deref()
+		if (!task) {
+			// Fail closed: without the owning task the observation registry is
+			// unreachable and the write cannot be guarded.
+			throw new Error("Cannot guard the write: the owning task is no longer available")
+		}
 		await createDirectoriesForFile(absolutePath)
-		await safeWriteText(absolutePath, content)
+		await guardedWrite(task, relPath, content, writeKind)
 
 		// Open the document to ensure diagnostics are loaded
 		// When openFile is false (PREVENT_FOCUS_DISRUPTION enabled), we only open in memory

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -18,6 +18,7 @@ import { arePathsEqual, getReadablePath } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
 import { Task } from "../../core/task/Task"
+import { safeWriteText } from "../../services/file-safety/safeWriteText"
 
 import { DecorationController } from "./DecorationController"
 
@@ -1156,7 +1157,7 @@ export class DiffViewProvider {
 
 		// Write the content directly to the file
 		await createDirectoriesForFile(absolutePath)
-		await fs.writeFile(absolutePath, content, "utf-8")
+		await safeWriteText(absolutePath, content)
 
 		// Open the document to ensure diagnostics are loaded
 		// When openFile is false (PREVENT_FOCUS_DISRUPTION enabled), we only open in memory

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -15,6 +15,14 @@ vi.mock("fs/promises", () => ({
 	readFile: vi.fn().mockResolvedValue("file content"),
 	writeFile: vi.fn().mockResolvedValue(undefined),
 	access: vi.fn().mockResolvedValue(undefined),
+	mkdir: vi.fn().mockResolvedValue(undefined),
+	rename: vi.fn().mockResolvedValue(undefined),
+	unlink: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock safeWriteText (used by saveDirectly)
+vi.mock("../../../services/file-safety/safeWriteText", () => ({
+	safeWriteText: vi.fn().mockResolvedValue(undefined),
 }))
 
 // Mock utils
@@ -26,6 +34,8 @@ vi.mock("../../../utils/fs", () => ({
 vi.mock("path", () => ({
 	resolve: vi.fn((cwd, relPath) => `${cwd}/${relPath}`),
 	basename: vi.fn((path) => path.split("/").pop()),
+	dirname: vi.fn((path) => path.split("/").slice(0, -1).join("/") || "/"),
+	join: (...args: string[]) => args.join("/"),
 }))
 
 // Mock vscode
@@ -791,9 +801,9 @@ describe("DiffViewProvider", () => {
 
 			const result = await diffViewProvider.saveDirectly("test.ts", "new content", true, true, 2000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify file was opened without focus
 			expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
@@ -814,9 +824,9 @@ describe("DiffViewProvider", () => {
 		it("should not open file when openWithoutFocus is false", async () => {
 			await diffViewProvider.saveDirectly("test.ts", "new content", false, true, 1000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify file was NOT opened
 			expect(vscode.window.showTextDocument).not.toHaveBeenCalled()
@@ -829,9 +839,9 @@ describe("DiffViewProvider", () => {
 
 			await diffViewProvider.saveDirectly("test.ts", "new content", true, false, 1000)
 
-			// Verify file was written
-			const fs = await import("fs/promises")
-			expect(fs.writeFile).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content", "utf-8")
+			// Verify file was written via safeWriteText
+			const { safeWriteText } = await import("../../../services/file-safety/safeWriteText")
+			expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
 
 			// Verify delay was NOT called
 			expect(mockDelay).not.toHaveBeenCalled()

--- a/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.spec.ts
@@ -5,6 +5,13 @@ import delay from "delay"
 
 import { makeRange, makeTextDocument, makeTextEditor, makeUri } from "../../../test-utils/vscode"
 
+import * as fs from "fs/promises"
+
+import { computeVersionToken } from "../../../utils/versionToken"
+import { safeWriteText } from "../../../services/file-safety/safeWriteText"
+import { ObservationRegistry } from "../../../core/task/observationRegistry"
+import type { Task } from "../../../core/task/Task"
+
 // Mock delay
 vi.mock("delay", () => ({
 	default: vi.fn().mockResolvedValue(undefined),
@@ -25,6 +32,12 @@ vi.mock("../../../services/file-safety/safeWriteText", () => ({
 	safeWriteText: vi.fn().mockResolvedValue(undefined),
 }))
 
+// Mock the S1 version token (used by the S4 guarded write); the real
+// computeVersionToken needs fs.stat, which is not part of the fs/promises mock above.
+vi.mock("../../../utils/versionToken", () => ({
+	computeVersionToken: vi.fn(),
+}))
+
 // Mock utils
 vi.mock("../../../utils/fs", () => ({
 	createDirectoriesForFile: vi.fn().mockResolvedValue([]),
@@ -33,6 +46,7 @@ vi.mock("../../../utils/fs", () => ({
 // Mock path
 vi.mock("path", () => ({
 	resolve: vi.fn((cwd, relPath) => `${cwd}/${relPath}`),
+	isAbsolute: vi.fn((p: string) => p.startsWith("/")),
 	basename: vi.fn((path) => path.split("/").pop()),
 	dirname: vi.fn((path) => path.split("/").slice(0, -1).join("/") || "/"),
 	join: (...args: string[]) => args.join("/"),
@@ -159,8 +173,11 @@ describe("DiffViewProvider", () => {
 			return mockWorkspaceEdit as any
 		})
 
-		// Create a mock Task instance
+		// Create a mock Task instance. The guarded write (S4b) consults the task's
+		// S2 observation registry, so the mock carries a real (in-memory) instance.
 		mockTask = {
+			cwd: mockCwd,
+			observationRegistry: new ObservationRegistry(),
 			providerRef: {
 				deref: vi.fn().mockReturnValue({
 					getState: vi.fn().mockResolvedValue({
@@ -793,6 +810,13 @@ describe("DiffViewProvider", () => {
 			// Mock vscode functions
 			vi.mocked(vscode.window.showTextDocument).mockResolvedValue({} as any)
 			vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([])
+
+			// Baseline for the single-writer flow these tests encode: the file was read
+			// before the write, so the observation registry holds the version token the
+			// guarded write recomputes and compares, and the target exists on disk.
+			mockTask.observationRegistry.observe(`${mockCwd}/test.ts`, "v1")
+			vi.mocked(computeVersionToken).mockResolvedValue("v1")
+			vi.mocked(fs.access).mockResolvedValue(undefined)
 		})
 
 		it("should write content directly to file without opening diff view", async () => {
@@ -867,6 +891,68 @@ describe("DiffViewProvider", () => {
 			expect((diffViewProvider as any).userEdits).toBeUndefined()
 			expect((diffViewProvider as any).relPath).toBe("test.ts")
 			expect((diffViewProvider as any).newContent).toBe("new content")
+		})
+
+		describe("guarded write (S4b, epic #1375)", () => {
+			const enoent = () => Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+
+			it("rejects an unobserved write to an existing file with the read-first remediation", async () => {
+				mockTask.observationRegistry.clear()
+
+				await expect(diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0)).rejects.toThrow(
+					"File already exists at /mock/cwd/test.ts and was not read before this write -- read the file first, then retry.",
+				)
+				expect(safeWriteText).not.toHaveBeenCalled()
+			})
+
+			it("creates an unobserved file when the target is absent", async () => {
+				mockTask.observationRegistry.clear()
+				vi.mocked(fs.access).mockRejectedValue(enoent())
+
+				await diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0)
+
+				expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
+			})
+
+			it("rejects an observed write whose version token is stale", async () => {
+				// The file changed on disk after the read that recorded "v1".
+				vi.mocked(computeVersionToken).mockResolvedValue("v2")
+
+				const result = diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0)
+
+				await expect(result).rejects.toThrow("Stale version")
+				await expect(result).rejects.toThrow("re-read the file, then retry.")
+				expect(safeWriteText).not.toHaveBeenCalled()
+			})
+
+			it("rejects an unobserved edit-kind write before any I/O", async () => {
+				mockTask.observationRegistry.clear()
+
+				await expect(
+					diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0, "edit"),
+				).rejects.toThrow("File not read yet -- read the file, then retry.")
+				expect(safeWriteText).not.toHaveBeenCalled()
+				expect(fs.access).not.toHaveBeenCalled()
+			})
+
+			it("recreates an observed file that vanished after the read", async () => {
+				vi.mocked(fs.access).mockRejectedValue(enoent())
+
+				await diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0)
+
+				expect(safeWriteText).toHaveBeenCalledWith(`${mockCwd}/test.ts`, "new content")
+			})
+
+			it("fails closed when the owning task has been collected", async () => {
+				// A real WeakRef cannot be forced to deref to undefined deterministically
+				// (GC timing), so a structural stub stands in for the collected reference.
+				diffViewProvider["taskRef"] = { deref: () => undefined } as unknown as WeakRef<Task>
+
+				await expect(diffViewProvider.saveDirectly("test.ts", "new content", true, false, 0)).rejects.toThrow(
+					"Cannot guard the write: the owning task is no longer available",
+				)
+				expect(safeWriteText).not.toHaveBeenCalled()
+			})
 		})
 	})
 

--- a/src/services/file-safety/__tests__/safeWriteText.spec.ts
+++ b/src/services/file-safety/__tests__/safeWriteText.spec.ts
@@ -1,0 +1,614 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import { execFile } from "child_process"
+import type { ChildProcess } from "child_process"
+import * as path from "path"
+
+import { safeWriteText, type SafeWriteTextOptions } from "../safeWriteText"
+
+// Full mock for fs/promises — all methods are vi.fn() stubs
+vi.mock("fs/promises", () => ({
+	mkdir: vi.fn(),
+	access: vi.fn(),
+	rename: vi.fn(),
+	unlink: vi.fn(),
+	realpath: vi.fn(),
+}))
+
+// Full mock for fs — all sync methods are vi.fn() stubs. Stats is a bare
+// class stub so tests can build minimal Stats stand-ins via its prototype.
+vi.mock("fs", () => ({
+	openSync: vi.fn(),
+	writeSync: vi.fn(),
+	closeSync: vi.fn(),
+	mkdirSync: vi.fn(),
+	fsyncSync: vi.fn(),
+	chmodSync: vi.fn(),
+	fchmodSync: vi.fn(),
+	statSync: vi.fn(),
+	Stats: class Stats {},
+}))
+
+// Mock child_process.execFile (callback-based — must invoke callback to resolve)
+vi.mock("child_process", () => ({
+	execFile: vi.fn((cmd, args, opts, cb) => {
+		if (typeof cb === "function") cb(null)
+	}),
+}))
+
+// Minimal stand-in for the ChildProcess that callback-form execFile returns.
+const fakeChild = { kill: () => true } as unknown as ChildProcess
+
+// Helper that mirrors safeWriteText's path resolution exactly
+function _resolvedTarget(filePath: string): string {
+	return path.resolve(filePath)
+}
+function _dirPath(filePath: string): string {
+	return path.dirname(_resolvedTarget(filePath))
+}
+function _stagingDir(dir: string): string {
+	return path.join(dir, ".file-safety-staging")
+}
+
+// Minimal Stats stand-in: the SUT only reads `.mode` from it.
+function _stats(mode: number): fsSync.Stats {
+	const s = Object.create(fsSync.Stats.prototype) as fsSync.Stats
+	Object.assign(s, { mode })
+	return s
+}
+
+// ── Test 1: staging file created then cleaned after success ────────────────
+
+describe("safeWriteText", () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+		// After resetAllMocks, vi.fn() returns undefined — restore promise defaults.
+		vi.mocked(fs.mkdir).mockResolvedValue(undefined)
+		vi.mocked(fs.access).mockResolvedValue(undefined)
+		vi.mocked(fs.rename).mockResolvedValue(undefined)
+		vi.mocked(fs.unlink).mockResolvedValue(undefined)
+		// Existing-target default: a regular 0o644 file.
+		vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o644))
+		// Default sync-write behaviour: report that all requested bytes were
+		// written. The Buffer overload passes (fd, buffer, offset, length),
+		// so the fourth argument is the requested length.
+		vi.mocked(fsSync.writeSync).mockImplementation((...args: unknown[]) =>
+			typeof args[3] === "number" ? args[3] : 0,
+		)
+	})
+
+	describe("staging and cleanup", () => {
+		it("creates a temp file in the staging dir, fsyncs it, renames to target, and cleans up on success", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1) // fd=1
+			vi.mocked(fsSync.closeSync).mockReturnValue(undefined)
+
+			await safeWriteText(targetPath, "hello world", { platform: "linux" })
+
+			// staging dir was created with private permissions — use
+			// stringContaining to handle Windows path resolution
+			expect(fsSync.mkdirSync).toHaveBeenCalledWith(expect.stringContaining(".file-safety-staging"), {
+				recursive: true,
+				mode: 0o700,
+			})
+			// a pre-existing staging dir is repaired to private permissions too
+			expect(fsSync.chmodSync).toHaveBeenCalledWith(expect.stringContaining(".file-safety-staging"), 0o700)
+
+			// temp file was opened for writing with the existing target's mode
+			// (default 0o644 from the statSync default mock)
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o644)
+
+			// content was written as a buffer (partial-write loop, full write)
+			expect(fsSync.writeSync).toHaveBeenCalledWith(1, Buffer.from("hello world", "utf8"), 0, 11)
+
+			// fsync (sync form) was called on the fd
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+
+			// file was closed
+			expect(fsSync.closeSync).toHaveBeenCalledWith(1)
+
+			// atomic rename happened — realpath mock returns targetPath, so that's the dest
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// no unlink of temp (it's now the committed file; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 2: fsync ordering ───────────────────────────────────────────────
+
+	describe("fsync ordering", () => {
+		it("calls fsync on the fd before close, and rename after close", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// Verify call order: openSync(temp) → writeSync → fsyncSync(temp)
+			// → closeSync(temp) → rename. On POSIX the parent directory is then
+			// opened and fsynced after the commit rename, so openSync/fsyncSync/
+			// closeSync each have a second (directory) call.
+			expect(vi.mocked(fsSync.openSync).mock.calls.length).toBe(2)
+			expect(vi.mocked(fsSync.writeSync).mock.calls.length).toBe(1)
+			expect(vi.mocked(fsSync.fsyncSync).mock.calls.length).toBe(2)
+			expect(vi.mocked(fsSync.closeSync).mock.calls.length).toBe(2)
+
+			// the temp file was fully closed before the commit rename
+			expect(vi.mocked(fsSync.closeSync).mock.calls[0][0]).toBe(1)
+			expect(fs.rename).toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 3: simulated failure between write and rename leaves target intact ──
+
+	describe("crash/torn-write safety", () => {
+		it("simulated failure between fsync and rename leaves the target byte-identical and no temp left behind", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fs.rename).mockRejectedValue(new Error("ENOSPC"))
+
+			await expect(safeWriteText(targetPath, "new data", { platform: "linux" })).rejects.toThrow("ENOSPC")
+
+			// rename was attempted (the failure point)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// temp file was cleaned up on failure
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+
+			// backup was NOT created (backup:false by default), so target is untouched
+			// The only rename call was temp→target, not a rollback rename
+			expect(fs.rename).toHaveBeenCalledTimes(1)
+		})
+
+		it("a post-commit backup cleanup failure is non-fatal: the target stays committed and no temp is left behind", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// The post-commit backup unlink (SUT step 6) fails — the write must
+			// still succeed; an orphaned backup is the documented acceptable
+			// outcome, so the failure is swallowed instead of rolling back.
+			vi.mocked(fs.unlink).mockRejectedValueOnce(new Error("EPERM"))
+
+			await safeWriteText(targetPath, "data", { backup: true, platform: "linux" })
+
+			// the commit rename (temp -> target) still happened
+			expect(fs.rename).toHaveBeenNthCalledWith(2, expect.stringContaining("safeWriteText_"), targetPath)
+
+			// the failing cleanup was the post-commit backup unlink
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText.bak_"))
+
+			// no rollback rename: the committed target is not restored from the backup
+			expect(fs.rename).toHaveBeenCalledTimes(2)
+
+			// the staging temp was already committed by the rename; nothing
+			// temp-shaped is unlinked afterwards
+			expect(fs.unlink).not.toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+		})
+	})
+
+	// ── Test 4: backup:true keeps old safeWriteJson semantics incl. rollback ──
+
+	describe("backup:true", () => {
+		it("renames target -> backup before commit, deletes backup on success", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "new data", { backup: true })
+
+			// target was accessed (exists check)
+			expect(fs.access).toHaveBeenCalledWith(targetPath)
+
+			// first rename: target -> backup
+			expect(fs.rename).toHaveBeenNthCalledWith(1, targetPath, expect.stringContaining("safeWriteText.bak_"))
+
+			// second rename: temp -> target (realpath mock returns targetPath)
+			expect(fs.rename).toHaveBeenNthCalledWith(2, expect.stringContaining("safeWriteText_"), targetPath)
+
+			// backup was deleted on success
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText.bak_"))
+		})
+
+		it("rollback: on failure after rename target->backup, restores backup to target", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// first rename (target->backup) succeeds, second fails
+			let callCount = 0
+			vi.mocked(fs.rename).mockImplementation(async () => {
+				callCount++
+				if (callCount === 1) return // target -> backup
+				throw new Error("ENOSPC") // temp -> target fails
+			})
+
+			await expect(safeWriteText(targetPath, "new data", { backup: true })).rejects.toThrow("ENOSPC")
+
+			// rollback rename is the 3rd call (after target->backup and temp->target failure)
+			expect(fs.rename).toHaveBeenNthCalledWith(3, expect.stringContaining("safeWriteText.bak_"), targetPath)
+
+			// temp was cleaned up on failure
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"))
+		})
+
+		it("backup:true when target does not exist: no backup created, just commit", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// fs.access resolves for dirPath check, but rejects for target check (backup path)
+			vi.mocked(fs.access).mockImplementation(async (p) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw { code: "ENOENT" }
+			})
+
+			await safeWriteText(targetPath, "new data", { backup: true, platform: "linux" })
+
+			// no backup rename (target didn't exist)
+			expect(fs.access).toHaveBeenCalledWith(targetPath)
+
+			// only one rename: temp -> target
+			expect(fs.rename).toHaveBeenCalledTimes(1)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+
+			// no unlink (no backup to delete; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 5: win32 DACL path ──────────────────────────────────────────────
+
+	describe("win32 DACL", () => {
+		it.skipIf(process.platform !== "win32")(
+			"copies target DACL onto staging file via icacls before rename on Windows",
+			async () => {
+				const targetPath = "/tmp/test-dir/target.txt"
+				vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+				await safeWriteText(targetPath, "data", { platform: "win32" })
+
+				// icacls dump + restore were called (execFile is callback-based mock)
+				expect(execFile).toHaveBeenCalledTimes(2)
+			},
+		)
+
+		it("non-win32: DACL path is unreachable when platform is not win32", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// icacls was NOT called on non-win32
+			expect(execFile).not.toHaveBeenCalled()
+		})
+
+		it("win32 DACL failure falls back to plain rename (never fails the write)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// icacls dump fails — the callback-based mock must invoke cb with an error.
+			vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+				if (typeof cb === "function") cb(new Error("icacls error"), "", "")
+				return fakeChild
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// write succeeded despite icacls failure (fallback to plain rename)
+			expect(fs.rename).toHaveBeenCalled()
+		})
+
+		it("win32 DACL save args are [targetPath, /save, dumpPath, /T] before backup rename", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { backup: true, platform: "win32" })
+
+			// icacls was called twice (save + restore)
+			expect(execFile).toHaveBeenCalledTimes(2)
+
+			// First call: save DACL from target before backup rename
+			const firstCall = vi.mocked(execFile).mock.calls[0]
+			expect(firstCall[0]).toBe("icacls")
+			expect(firstCall[1]).toEqual([targetPath, "/save", expect.stringContaining(".acl.tmp"), "/T"])
+
+			// Second call: restore DACL onto directory after commit rename
+			const secondCall = vi.mocked(execFile).mock.calls[1]
+			expect(secondCall[0]).toBe("icacls")
+			expect(secondCall[1]).toEqual([
+				expect.stringContaining("/tmp/test-dir"),
+				"/restore",
+				expect.stringContaining(".acl.tmp"),
+			])
+
+			// dump file was unlinked after restore
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining(".acl.tmp"))
+		})
+
+		it("win32 DACL: dump is unlinked even when restore fails", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			// icacls save succeeds, restore fails
+			let callCount = 0
+			vi.mocked(execFile).mockImplementation((_cmd, _args, _opts, cb) => {
+				callCount++
+				if (typeof cb === "function") {
+					cb(callCount === 1 ? null : new Error("icacls restore error"), "", "")
+				}
+				return fakeChild
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// write succeeded despite restore failure (best-effort)
+			expect(fs.rename).toHaveBeenCalled()
+
+			// dump file was still unlinked in finally
+			expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining(".acl.tmp"))
+		})
+
+		it("win32 DACL: when target does not exist, no save/restore/dump", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			// fs.access rejects for targetPath (ENOENT), but resolves for dirPath
+			vi.mocked(fs.access).mockImplementation(async (p) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw { code: "ENOENT" }
+				return undefined
+			})
+
+			await safeWriteText(targetPath, "data", { platform: "win32" })
+
+			// icacls was NOT called (target absent → skip DACL entirely)
+			expect(execFile).not.toHaveBeenCalled()
+
+			// no dump file created or unlinked
+			expect(fs.unlink).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── Test 6: pre-written temp path (tempPath option) ──────────────────────
+
+	describe("pre-written temp path", () => {
+		it("uses the provided tempPath, fsyncs it, and renames to target", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			// platform:linux skips DACL entirely so this test focuses on tempPath only
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// openSync was called on the custom temp path (r+ mode for fsync)
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+
+			// fsync was called
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+
+			// rename happened — realpath mock returns targetPath
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+
+			// no unlink of custom temp (caller's concern; DACL skipped via platform:linux)
+			expect(fs.unlink).not.toHaveBeenCalled()
+
+			// a caller-supplied tempPath must not create the staging directory
+			expect(fsSync.mkdirSync).not.toHaveBeenCalled()
+		})
+
+		it("applies the existing target's mode to a caller-supplied tempPath before publishing", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o600))
+			vi.mocked(fsSync.openSync).mockReturnValue(2)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// the caller-staged temp is fchmod'd to the restrictive target mode so
+			// the atomic rename cannot widen a 0o600 target (CWE-732 regression)
+			expect(fsSync.fchmodSync).toHaveBeenCalledWith(2, 0o600)
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+
+		it("keeps the temp's default mode when the target does not exist yet (ENOENT)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			const enoent = Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+			vi.mocked(fsSync.statSync).mockImplementation(() => {
+				throw enoent
+			})
+			vi.mocked(fsSync.openSync).mockReturnValue(2)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// no existing target, so nothing to preserve and no fchmod on the temp
+			expect(fsSync.fchmodSync).not.toHaveBeenCalled()
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+
+		it("opens the temp before applying a read-only target's mode (0o444 does not block the open)", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o444))
+			vi.mocked(fsSync.openSync).mockReturnValue(3)
+
+			const customTempPath = "/tmp/custom-temp.tmp"
+
+			await safeWriteText(targetPath, "", { tempPath: customTempPath, platform: "linux" })
+
+			// a 0o444 target must not make openSync(tempPath, "r+") fail: the mode
+			// is applied with fchmodSync on the already-open fd, after the open
+			expect(fsSync.openSync).toHaveBeenCalledWith(customTempPath, "r+")
+			expect(fsSync.fchmodSync).toHaveBeenCalledWith(3, 0o444)
+			const openIdx = vi.mocked(fsSync.openSync).mock.invocationCallOrder[0]
+			const fchmodIdx = vi.mocked(fsSync.fchmodSync).mock.invocationCallOrder[0]
+			expect(openIdx).toBeLessThan(fchmodIdx)
+			expect(fs.rename).toHaveBeenCalledWith(customTempPath, targetPath)
+		})
+	})
+
+	// ── Test 7: symlink handling (Finding 4 regression test) ─────────────────
+
+	describe("symlink handling", () => {
+		it("a write through a symlink commits onto the resolved referent, never the link path", async () => {
+			const linkPath = "/tmp/links/link.txt"
+			const referentPath = "/tmp/targets/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(referentPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(linkPath, "new-content", { platform: "linux" })
+
+			// The commit rename must target the realpath result (the referent), never the link itself —
+			// that is what guarantees a write through a symlink replaces the referent's content
+			// and preserves the link.
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), referentPath)
+			expect(fs.rename).not.toHaveBeenCalledWith(expect.anything(), linkPath)
+		})
+
+		it("when realpath reports ENOENT (target absent), uses the given path as-is", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// rename still happened with the fallback path (path.resolve on /tmp → C:\tmp)
+			const resolvedFallback = _resolvedTarget(targetPath)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), resolvedFallback)
+		})
+	})
+
+	// ── Test 8: review fixes (permissions, partial writes, resolution, durability) ──
+
+	describe("review fixes", () => {
+		it("preserves the target's restrictive mode and tolerates a failed staging-dir permission repair", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fsSync.statSync).mockReturnValue(_stats(0o600))
+			// a pre-existing staging dir may fail its best-effort permission repair
+			vi.mocked(fsSync.chmodSync).mockImplementationOnce(() => {
+				throw new Error("EACCES")
+			})
+
+			await safeWriteText(targetPath, "secret", { platform: "linux" })
+
+			// the staging file inherits the target's 0o600 mode and the write commits
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o600)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("falls back to the 0o644 default when the target does not exist yet", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			vi.mocked(fsSync.statSync).mockImplementation(() => {
+				throw Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+			})
+
+			await safeWriteText(targetPath, "fresh", { platform: "linux" })
+
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), "w", 0o644)
+		})
+
+		it("loops on short writes until the full content is durable before fsync", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const content = "0123456789" // 10 bytes
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			const buffer = Buffer.from(content, "utf8")
+			// first write (offset 0) reports 4 bytes (short write); the loop continues
+			vi.mocked(fsSync.writeSync).mockImplementation((...args: unknown[]) =>
+				args[2] === 0 ? 4 : typeof args[3] === "number" ? args[3] : 0,
+			)
+
+			await safeWriteText(targetPath, content, { platform: "linux" })
+
+			// [0,10) reports 4 bytes, then [4,10) writes the remaining 6
+			expect(fsSync.writeSync).toHaveBeenCalledTimes(2)
+			expect(fsSync.writeSync).toHaveBeenNthCalledWith(1, 1, buffer, 0, 10)
+			expect(fsSync.writeSync).toHaveBeenNthCalledWith(2, 1, buffer, 4, 6)
+			expect(fsSync.fsyncSync).toHaveBeenCalledWith(1)
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("fsyncs the parent directory after the commit rename on POSIX", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			// temp fd=1 then parent-dir fd=2 - distinct fds prove the ordering
+			vi.mocked(fsSync.openSync).mockReturnValueOnce(1).mockReturnValue(2)
+
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			// the directory fsync (fd 2) happens only after the file fsync (fd 1);
+			// the dir path assertion is path-agnostic (stringContaining) because
+			// path.dirname renders the same input differently on Windows
+			expect(fsSync.openSync).toHaveBeenCalledWith(expect.stringContaining("test-dir"), "r")
+			expect(fsSync.fsyncSync).toHaveBeenNthCalledWith(1, 1)
+			expect(fsSync.fsyncSync).toHaveBeenNthCalledWith(2, 2)
+			expect(fsSync.closeSync).toHaveBeenCalledWith(2)
+		})
+
+		it("treats a failed parent-directory fsync as best-effort", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync)
+				.mockReturnValueOnce(1)
+				.mockImplementationOnce(() => {
+					throw new Error("EBADF")
+				})
+
+			// the content rename already committed; a missing directory fsync is not fatal
+			await safeWriteText(targetPath, "data", { platform: "linux" })
+
+			expect(fs.rename).toHaveBeenCalledWith(expect.stringContaining("safeWriteText_"), targetPath)
+		})
+
+		it("propagates realpath errors (EACCES and code-less) instead of the fallback path", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const eacces = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+			vi.mocked(fs.realpath).mockRejectedValueOnce(eacces)
+			await expect(safeWriteText(targetPath, "data", { platform: "linux" })).rejects.toBe(eacces)
+			expect(fs.rename).not.toHaveBeenCalled()
+
+			const plain = new Error("resolution failed")
+			vi.mocked(fs.realpath).mockRejectedValueOnce(plain)
+			await expect(safeWriteText(targetPath, "data", { platform: "linux" })).rejects.toBe(plain)
+			expect(fs.rename).not.toHaveBeenCalled()
+		})
+
+		it("backup:true propagates access errors (EACCES and code-less) instead of skipping the backup", async () => {
+			const targetPath = "/tmp/test-dir/target.txt"
+			const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" })
+			const plain = new Error("access failed")
+			vi.mocked(fs.realpath).mockResolvedValue(targetPath)
+			vi.mocked(fsSync.openSync).mockReturnValue(1)
+			// each write accesses dirPath then target; only the target access rejects
+			const rejectTarget = (error: Error) => async (p: unknown) => {
+				if (typeof p === "string" && p.endsWith("target.txt")) throw error
+			}
+			vi.mocked(fs.access)
+				.mockImplementationOnce(rejectTarget(eacces))
+				.mockImplementationOnce(rejectTarget(eacces))
+				.mockImplementationOnce(rejectTarget(plain))
+				.mockImplementationOnce(rejectTarget(plain))
+
+			await expect(safeWriteText(targetPath, "data", { backup: true, platform: "linux" })).rejects.toEqual(
+				expect.objectContaining({ code: "EACCES" }),
+			)
+			await expect(safeWriteText(targetPath, "data", { backup: true, platform: "linux" })).rejects.toThrow(
+				"access failed",
+			)
+			expect(fs.rename).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/services/file-safety/safeWriteText.ts
+++ b/src/services/file-safety/safeWriteText.ts
@@ -1,0 +1,307 @@
+import * as fs from "fs/promises"
+import * as fsSync from "fs"
+import * as path from "path"
+import { execFile } from "child_process"
+
+/**
+ * Options for safeWriteText atomic text publish primitive.
+ */
+export interface SafeWriteTextOptions {
+	/**
+	 * When true, preserve the old-file semantics: rename target -> backup first,
+	 * after commit rename delete the backup; on failure roll the backup back to
+	 * the target path.  When false (default) the atomic rename simply replaces
+	 * the target -- crash-safe window is zero.
+	 */
+	backup?: boolean
+
+	/**
+	 * Platform override for testing.  When omitted the real process.platform
+	 * value is used.  Set to "win32" or "linux" / "darwin" from tests so that
+	 * both branches are reachable without needing a real Windows runner.
+	 */
+	platform?: string
+
+	/**
+	 * Custom execFile runner for testing (e.g. vi.fn).  When omitted the real
+	 * child_process.execFile is used.
+	 */
+	execFileRunner?: typeof execFile
+
+	/**
+	 * Pre-written temp path to use for the commit phase.  When provided,
+	 * safeWriteText skips creating its own staging file and uses this path
+	 * instead (it still fsyncs before rename).  Useful when a caller has
+	 * already written data to a temp file via a custom stream.
+	 */
+	tempPath?: string
+}
+
+// -- helpers ---------------------------------------------------------------
+
+/** Generate a unique temp file name in the given directory. */
+function _tempName(dir: string, prefix: string): string {
+	return path.join(dir, "." + prefix + "_" + Date.now() + "_" + Math.random().toString(36).substring(2) + ".tmp")
+}
+
+/** Create a private staging sub-directory inside *dir* so that multiple
+ * concurrent writes never collide on their temp names. */
+function _stagingDir(dir: string): string {
+	const sd = path.join(dir, ".file-safety-staging")
+	// mode:0o700 protects a freshly created staging dir; the best-effort chmod
+	// repairs a pre-existing one (mkdirSync with recursive:true never chmods an
+	// existing directory), so staged temp files are never group/world readable.
+	fsSync.mkdirSync(sd, { recursive: true, mode: 0o700 })
+	try {
+		fsSync.chmodSync(sd, 0o700)
+	} catch {
+		// best-effort: chmod denied or unavailable; a fresh dir was still
+		// created with the requested mode
+	}
+	return sd
+}
+
+/**
+ * fsync a file descriptor so its data is durable before the atomic rename.
+ * Uses the sync form because this repo's @types/node does not declare
+ * fs.promises.fsync; the staging file is small, so the blocking window is bounded.
+ */
+function _fsyncFile(fd: number): void {
+	fsSync.fsyncSync(fd)
+}
+
+/** Save the DACL of *srcPath* to a dump file on Windows.
+ * Returns true when the dump was written successfully; false otherwise.
+ * Never throws — callers treat failure as "skip DACL handling". */
+async function _saveDaclWindows(srcPath: string, dumpPath: string, execFileRunner?: typeof execFile): Promise<boolean> {
+	const runner = execFileRunner ?? execFile
+	try {
+		await new Promise<void>((resolve, reject) => {
+			runner("icacls", [srcPath, "/save", dumpPath, "/T"], { windowsHide: true }, (err) =>
+				err ? reject(err) : resolve(),
+			)
+		})
+		return true
+	} catch {
+		return false
+	}
+}
+
+/** Restore a DACL dump onto *dirPath* on Windows.
+ * Best-effort: content is already committed, so failure is non-fatal. */
+async function _restoreDaclWindows(dirPath: string, dumpPath: string, execFileRunner?: typeof execFile): Promise<void> {
+	const runner = execFileRunner ?? execFile
+	try {
+		await new Promise<void>((resolve, reject) => {
+			runner("icacls", [dirPath, "/restore", dumpPath], { windowsHide: true }, (err) =>
+				err ? reject(err) : resolve(),
+			)
+		})
+	} catch {
+		// best-effort; content already committed
+	}
+}
+
+// -- public API ------------------------------------------------------------
+
+/**
+ * Atomic text publish primitive.
+ *
+ * 1. Write content to a temp file in a private per-write staging subdir
+ *    (same volume -> atomic rename guaranteed).
+ * 2. fsync the temp file, then close it.
+ * 3. win32 only: if target exists save its DACL dump BEFORE backup rename.
+ * 4. Optionally rename target -> backup (when backup:true).
+ * 5. Atomic rename temp -> target.
+ * 6. win32 only: restore DACL onto the directory AFTER commit rename.
+ * 7. On success: delete backup (if any) and unlink DACL dump.
+ * 8. On failure: rollback backup to target path; clean up temp + dump.
+ */
+
+/**
+ * Resolve the publish target: the symlink referent when the given path is an
+ * existing symlink, the path itself otherwise. Only ENOENT (target absent yet)
+ * may fall back to the given path; any other resolution error (EACCES, EIO, ...)
+ * propagates so a broken or unreadable symlink is never written through its
+ * link path. Callers that stage a temp file themselves must stage it beside
+ * the resolved path: the commit is a rename onto the referent, and a rename
+ * across filesystems fails with EXDEV.
+ */
+export async function resolvePublishTarget(absoluteFilePath: string): Promise<string> {
+	return fs.realpath(absoluteFilePath).catch((error: unknown) => {
+		const code =
+			typeof error === "object" && error !== null && "code" in error
+				? (error as { code?: string }).code
+				: undefined
+		if (code !== "ENOENT") throw error
+		return absoluteFilePath
+	})
+}
+
+export async function safeWriteText(filePath: string, content: string, options?: SafeWriteTextOptions): Promise<void> {
+	const absoluteFilePath = path.resolve(filePath)
+
+	// Resolve the symlink referent (see resolvePublishTarget).
+	const targetPath = await resolvePublishTarget(absoluteFilePath)
+	const dirPath = path.dirname(targetPath)
+
+	// Ensure parent directory exists (mirrors safeWriteJson behaviour).
+	await fs.mkdir(dirPath, { recursive: true })
+	await fs.access(dirPath)
+
+	// Create the staging directory only when we generate the temp file there;
+	// callers supplying their own tempPath (e.g. safeWriteJson) must not be left
+	// with an empty .file-safety-staging directory behind.
+	const tempPath = options?.tempPath ?? _tempName(_stagingDir(dirPath), "safeWriteText")
+
+	let backupPath: string | null = null
+	let releaseBackupOnSuccess = false
+	let daclDumpPath: string | null = null // tracked for cleanup in finally
+
+	try {
+		// -- Step 1: write content to staging temp file -------------------
+		if (!options?.tempPath) {
+			// Preserve the existing target's permissions: the staging file must
+			// not be published wider than the file it replaces (a 0o600 target
+			// must not become 0o644 through the atomic rename).
+			let targetMode = 0o644 // default for a fresh target
+			try {
+				targetMode = fsSync.statSync(targetPath).mode & 0o777
+			} catch {
+				// target does not exist yet - keep the default
+			}
+			const fd = fsSync.openSync(tempPath, "w", targetMode)
+			try {
+				// Loop until every byte is written: writeSync can report a short
+				// (partial) write, and publishing a truncated staging file would
+				// commit corrupt content.
+				const buffer = Buffer.from(content, "utf8")
+				let offset = 0
+				while (offset < buffer.length) {
+					offset += fsSync.writeSync(fd, buffer, offset, buffer.length - offset)
+				}
+				_fsyncFile(fd)
+			} finally {
+				fsSync.closeSync(fd)
+			}
+		} else {
+			// Preserve the existing target's mode (CWE-732): the caller-staged
+			// temp carries its own creation mode, and publishing it as-is would
+			// widen a restrictive target (e.g. 0o600 -> 0o644) through rename.
+			// The mode is applied with fchmodSync on the open fd (AFTER openSync):
+			// chmodSync on the path before the open would make a read-only target
+			// (0o400/0o444) fail openSync(tempPath, "r+") with EACCES.
+			let targetMode: number | null = null
+			try {
+				targetMode = fsSync.statSync(targetPath).mode & 0o777
+			} catch {
+				// target does not exist yet - keep the temp's default mode
+			}
+			const fd = fsSync.openSync(tempPath, "r+")
+			try {
+				if (targetMode !== null) {
+					fsSync.fchmodSync(fd, targetMode)
+				}
+				_fsyncFile(fd)
+			} finally {
+				fsSync.closeSync(fd)
+			}
+		}
+
+		// -- Step 2 (win32): save DACL BEFORE backup rename ---------------
+		const platform = options?.platform ?? process.platform
+		if (platform === "win32") {
+			try {
+				await fs.access(targetPath) // target exists?
+				daclDumpPath = targetPath + ".acl.tmp"
+				const saved = await _saveDaclWindows(targetPath, daclDumpPath, options?.execFileRunner)
+				if (!saved) {
+					daclDumpPath = null // skip DACL handling entirely
+				}
+			} catch {
+				// target does not exist or access failed — no DACL handling
+				daclDumpPath = null
+			}
+		}
+
+		try {
+			// -- Step 3 (backup:true): rename target -> backup --------------
+			if (options?.backup) {
+				try {
+					await fs.access(targetPath)
+					backupPath = _tempName(dirPath, "safeWriteText.bak")
+					await fs.rename(targetPath, backupPath)
+					releaseBackupOnSuccess = true
+				} catch (err: unknown) {
+					const code =
+						typeof err === "object" && err !== null && "code" in err
+							? (err as { code?: string }).code
+							: undefined
+					if (code !== "ENOENT") throw err
+				}
+			}
+
+			// -- Step 4: atomic rename temp -> target ---------------------
+			await fs.rename(tempPath, targetPath)
+
+			// -- Step 4b (POSIX): fsync the parent directory so the directory entry
+			// changed by the commit rename is durable, not just the file content.
+			if (platform !== "win32") {
+				try {
+					const dirFd = fsSync.openSync(dirPath, "r")
+					try {
+						_fsyncFile(dirFd)
+					} finally {
+						fsSync.closeSync(dirFd)
+					}
+				} catch {
+					// best-effort: the content rename already committed
+				}
+			}
+
+			// -- Step 5 (win32): restore DACL AFTER commit rename ---------
+			if (platform === "win32" && daclDumpPath !== null) {
+				const restoredDir = path.dirname(targetPath)
+				await _restoreDaclWindows(restoredDir, daclDumpPath, options?.execFileRunner)
+			}
+
+			// -- Step 6 (backup:true): delete backup on success -----------
+			if (releaseBackupOnSuccess && backupPath) {
+				try {
+					await fs.unlink(backupPath)
+				} catch {
+					// non-fatal — orphaned backup is acceptable
+				}
+			}
+		} finally {
+			// Unlink DACL dump regardless of success/failure in this span.
+			if (daclDumpPath !== null) {
+				await fs.unlink(daclDumpPath).catch(() => {})
+			}
+		}
+
+		// tempPath is now the committed file; no cleanup needed.
+	} catch (originalError: unknown) {
+		// -- Rollback / cleanup on failure ----------------------------------
+		if (backupPath && releaseBackupOnSuccess) {
+			try {
+				await fs.rename(backupPath, targetPath)
+			} catch {
+				// rollback failed — do not mask original error
+			}
+		}
+
+		// Always clean up the staging temp file on failure.
+		try {
+			await fs.unlink(tempPath).catch(() => {})
+		} catch {
+			// cleanup failure is non-fatal
+		}
+
+		if (daclDumpPath !== null) {
+			await fs.unlink(daclDumpPath).catch(() => {})
+		}
+
+		throw originalError
+	}
+}

--- a/src/utils/__tests__/safeWriteJson.test.ts
+++ b/src/utils/__tests__/safeWriteJson.test.ts
@@ -4,6 +4,7 @@ import * as path from "path"
 import * as os from "os"
 
 import { safeWriteJson } from "../safeWriteJson"
+import * as lockfile from "proper-lockfile"
 
 // Capture actual implementations before the vi.mock factory runs,
 // so they are never wrapped by vi.fn() — avoids infinite recursion when
@@ -577,6 +578,82 @@ describe("safeWriteJson", () => {
 
 		// the content was committed onto the referent
 		expect(await readFileContent(referentPath)).toEqual({ after: true })
+	})
+
+	// proper-lockfile with realpath:false keys the lock by the given path, so a
+	// symlink alias and its referent must coordinate through ONE lock on the
+	// resolved referent — otherwise a concurrent merge through both aliases
+	// reads the same JSON and overwrites one update. (Real symlinks are
+	// unavailable in this CI lane, so the resolution is simulated by mocking
+	// fs.realpath, the same way as the staging test above.)
+	test("acquires the lock on the resolved referent, not the caller alias", async () => {
+		vi.resetModules() // fresh module instances so the doMock below is picked up
+
+		const referentDir = path.join(tempDir, "lock-referent")
+		const linkDir = path.join(tempDir, "lock-link")
+		await fs.mkdir(referentDir, { recursive: true })
+		await fs.mkdir(linkDir, { recursive: true })
+		// caller-visible path (the link) vs the resolved referent path
+		const callerPath = path.join(linkDir, "locked.json")
+		const referentPath = path.join(referentDir, "locked.json")
+		await fsPromisesActuals.writeFile!(referentPath, JSON.stringify({ seed: 1 }))
+
+		vi.spyOn(fs, "realpath").mockResolvedValue(referentPath)
+
+		// Wrap the real lock in a capturing mock, and drive the two rare error paths
+		// (the onCompromised callback and a failing release) so they stay covered
+		// without real lockfile staleness. The callback rethrows by design, so
+		// the mock swallows that throw and lets the real lock proceed.
+		const realLockfile = await vi.importActual<typeof import("proper-lockfile")>("proper-lockfile")
+		const lockMockFn = vi.fn(
+			async (
+				file: Parameters<typeof realLockfile.lock>[0],
+				options?: Parameters<typeof realLockfile.lock>[1],
+			) => {
+				try {
+					options?.onCompromised?.(new Error("lock compromised (test)"))
+				} catch {
+					// onCompromised rethrows by design; swallow so the real lock proceeds.
+				}
+				const release = await realLockfile.lock(file, options)
+				return async () => {
+					await release()
+					throw new Error("release failed (test)")
+				}
+			},
+		)
+		const lockMock = lockMockFn as unknown as typeof realLockfile.lock
+		vi.doMock("proper-lockfile", () => ({
+			...realLockfile,
+			lock: lockMock,
+		}))
+
+		// Re-import safeWriteJson so it picks up the mocked proper-lockfile.
+		const { safeWriteJson: mockedSafeWriteJson } = await import("../safeWriteJson")
+
+		const mergeFn = vi.fn((existing: unknown, incoming: unknown) => ({
+			...(existing as Record<string, unknown>),
+			...(incoming as Record<string, unknown>),
+		}))
+
+		// Capture the compromise + release-failure logs.
+		const consoleErrorSpy = vi.spyOn(console, "error")
+		await mockedSafeWriteJson(callerPath, { added: true }, { merge: mergeFn })
+
+		// The lock was keyed by the resolved referent — every alias shares it.
+		expect(lockMock).toHaveBeenCalledTimes(1)
+		expect(String(lockMockFn.mock.calls[0][0])).toBe(referentPath)
+		// The merge read the referent's content through that single lock.
+		expect(mergeFn).toHaveBeenCalledWith({ seed: 1 }, { added: true })
+		expect(await readFileContent(referentPath)).toEqual({ seed: 1, added: true })
+		// The compromise callback and the failed release were logged, not thrown.
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("was compromised"), expect.any(Error))
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Failed to release lock"),
+			expect.any(Error),
+		)
+
+		vi.unmock("proper-lockfile") // Ensure the mock is removed after this test
 	})
 
 	// CWE-732 regression: safeWriteJson stages the temp itself and passes it

--- a/src/utils/__tests__/safeWriteJson.test.ts
+++ b/src/utils/__tests__/safeWriteJson.test.ts
@@ -312,9 +312,8 @@ describe("safeWriteJson", () => {
 		expect(content).toEqual(newData)
 	})
 
-	// Test for console error suppression during backup deletion
-	test("should suppress console.error when backup deletion fails", async () => {
-		const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {}) // Suppress console.error
+	// Test for best-effort backup deletion (the backup lifecycle now lives in safeWriteText)
+	test("does not fail the write when backup deletion fails (orphaned backup is acceptable)", async () => {
 		const initialData = { message: "Initial" }
 		const newData = { message: "New" }
 
@@ -322,18 +321,23 @@ describe("safeWriteJson", () => {
 
 		// fs.unlink is already vi.fn() — use vi.mocked to avoid double-wrapping via vi.spyOn
 		vi.mocked(fs.unlink).mockImplementation(async (filePath: any) => {
-			if (filePath.toString().includes(".bak_")) {
+			if (filePath.toString().includes("safeWriteText.bak_")) {
 				throw new Error("Backup deletion failed")
 			}
 			return fsPromisesActuals.unlink!(filePath)
 		})
 
+		// The write must still succeed: backup cleanup is best-effort inside
+		// safeWriteText and never masks the committed content.
 		await safeWriteJson(currentTestFilePath, newData)
 
-		// Verify console.error was called with the expected message
-		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Successfully wrote"), expect.any(Error))
+		const content = await readFileContent(currentTestFilePath)
+		expect(content).toEqual(newData)
 
-		consoleErrorSpy.mockRestore()
+		// The orphaned backup is still on disk because its deletion failed.
+		const entries = await fs.readdir(tempDir)
+		expect(entries.some((entry) => entry.includes("safeWriteText.bak_"))).toBe(true)
+
 		vi.mocked(fs.unlink).mockRestore()
 	})
 
@@ -434,9 +438,9 @@ describe("safeWriteJson", () => {
 		expect(vi.mocked(fs.access)).toHaveBeenCalled()
 	})
 
-	// Test for rollback failure scenario
-	test("should log error and re-throw original if rollback fails", async () => {
-		const initialData = { message: "Initial, should be lost if rollback fails" }
+	// Test for rollback failure scenario (the rollback rename now lives in safeWriteText)
+	test("re-throws the original error when the rollback rename fails, leaving an orphaned backup", async () => {
+		const initialData = { message: "Initial, orphaned when rollback fails" }
 		const newData = { message: "New content" }
 
 		await fsPromisesActuals.writeFile!(currentTestFilePath, JSON.stringify(initialData))
@@ -451,20 +455,20 @@ describe("safeWriteJson", () => {
 				// Second call: tempNewFilePath -> filePath (fail)
 				throw new Error("Primary rename failed")
 			} else if (renameCallCount === 3) {
-				// Third call: tempBackupFilePath -> filePath (rollback, also fail)
+				// Third call: backup -> filePath (rollback, also fail)
 				throw new Error("Rollback rename failed")
 			}
 			return fsPromisesActuals.rename!(oldPath, newPath)
 		})
 
-		// Should throw the original error, not the rollback error
+		// The original error must propagate, not the rollback error
 		await expect(safeWriteJson(currentTestFilePath, newData)).rejects.toThrow("Primary rename failed")
 
-		// Verify console.error was called for the rollback failure
-		expect(consoleErrorSpy).toHaveBeenCalledWith(
-			expect.stringContaining("Failed to restore backup"),
-			expect.objectContaining({ message: "Rollback rename failed" }),
-		)
+		// The rollback failed inside safeWriteText, so the target is gone and
+		// the backup is orphaned on disk.
+		expect(await fileExists(currentTestFilePath)).toBe(false)
+		const entries = await fs.readdir(tempDir)
+		expect(entries.some((entry) => entry.includes("safeWriteText.bak_"))).toBe(true)
 
 		consoleErrorSpy.mockRestore()
 	})
@@ -542,4 +546,53 @@ describe("safeWriteJson", () => {
 		const content = await readFileContent(currentTestFilePath)
 		expect(content).toEqual({ c: 3 })
 	})
+
+	// The commit rename targets the symlink referent. The staged temp file must
+	// therefore be created beside the RESOLVED target — staging beside the link
+	// would make the commit rename fail with EXDEV when the referent is on
+	// another filesystem. (Real symlinks are unavailable in this CI lane, so the
+	// resolution is simulated by mocking fs.realpath the same way.)
+	test("stages the temp file beside the symlink referent and commits onto it", async () => {
+		const referentDir = path.join(tempDir, "referent")
+		const linkDir = path.join(tempDir, "link")
+		await fs.mkdir(referentDir, { recursive: true })
+		await fs.mkdir(linkDir, { recursive: true })
+		// caller-visible path (the link) vs the resolved referent path
+		const callerPath = path.join(linkDir, "test-file.json")
+		const referentPath = path.join(referentDir, "test-file.json")
+		// Seed the RESOLVED referent with real content (via the actual fs) so the
+		// write exercises replacement of an EXISTING referent: the lock is
+		// acquired on the caller path (realpath:false, which may be absent) while
+		// the backup + commit happen on the referent.
+		await fsPromisesActuals.writeFile!(referentPath, JSON.stringify({ seed: true }))
+
+		vi.spyOn(fs, "realpath").mockResolvedValue(referentPath)
+
+		await safeWriteJson(callerPath, { after: true })
+
+		// the temp file was created next to the resolved referent, NOT beside the link
+		const tempPaths = vi.mocked(fsSyncActual.createWriteStream).mock.calls.map((call) => String(call[0]))
+		expect(tempPaths.some((p) => p.startsWith(referentDir + path.sep) && p.includes(".new_"))).toBe(true)
+		expect(tempPaths.some((p) => p.startsWith(linkDir + path.sep))).toBe(false)
+
+		// the content was committed onto the referent
+		expect(await readFileContent(referentPath)).toEqual({ after: true })
+	})
+
+	// CWE-732 regression: safeWriteJson stages the temp itself and passes it
+	// via tempPath, so safeWriteText must apply the existing target's mode to
+	// the staged temp before the atomic rename — otherwise a 0o600 target is
+	// published as 0o644. POSIX-only assertion (Windows ignores POSIX modes).
+	test.skipIf(process.platform === "win32")(
+		"preserves a restrictive 0o600 target mode through the atomic publish",
+		async () => {
+			await fsPromisesActuals.writeFile!(currentTestFilePath, JSON.stringify({ before: true }))
+			fsSyncActual.chmodSync(currentTestFilePath, 0o600)
+
+			await safeWriteJson(currentTestFilePath, { after: true })
+
+			expect(fsSyncActual.statSync(currentTestFilePath).mode & 0o777).toBe(0o600)
+			expect(await readFileContent(currentTestFilePath)).toEqual({ after: true })
+		},
+	)
 })

--- a/src/utils/__tests__/versionToken.spec.ts
+++ b/src/utils/__tests__/versionToken.spec.ts
@@ -1,0 +1,103 @@
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import type { Stats } from "fs"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { computeVersionToken, versionTokenOfStat } from "../versionToken"
+
+// Stats is a class-backed interface without a public constructor, so a plain-object
+// test double is the only practical way to pin the token format without real files.
+// Last-resort double assertion (test-local, per AGENTS.md).
+function makeStats(overrides: Partial<Stats> = {}): Stats {
+	const base: Partial<Stats> = {
+		dev: 7,
+		ino: 4242,
+		size: 1234,
+		atimeMs: 1_700_000_000_000,
+		mtimeMs: 1_700_000_000_123.456,
+		ctimeMs: 1_700_000_000_789.999,
+		birthtimeMs: 1_700_000_000_000,
+	}
+	return { ...base, ...overrides } as unknown as Stats
+}
+
+describe("versionTokenOfStat (A1, epic #1375)", () => {
+	it("is deterministic for an identical stat", () => {
+		expect(versionTokenOfStat(makeStats())).toBe(versionTokenOfStat(makeStats()))
+	})
+
+	it("matches the documented dev:ino:size:mtimeNs:ctimeNs format", () => {
+		const expected = [
+			"7",
+			"4242",
+			"1234",
+			Math.round(1_700_000_000_123.456 * 1e6).toString(),
+			Math.round(1_700_000_000_789.999 * 1e6).toString(),
+		].join(":")
+		expect(versionTokenOfStat(makeStats())).toBe(expected)
+	})
+
+	it("distinguishes size changes at identical timestamps", () => {
+		expect(versionTokenOfStat(makeStats({ size: 1235 }))).not.toBe(versionTokenOfStat(makeStats()))
+	})
+
+	it("distinguishes mtime changes at identical size", () => {
+		expect(versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_124 }))).not.toBe(versionTokenOfStat(makeStats()))
+	})
+
+	it("distinguishes a replaced file (dev/ino change) with identical content state", () => {
+		const replaced = makeStats({ dev: 8, ino: 999 })
+		expect(versionTokenOfStat(replaced)).not.toBe(versionTokenOfStat(makeStats()))
+	})
+
+	it("preserves sub-ms mtime resolution in the ns field", () => {
+		const wholeMs = versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_123 }))
+		const halfMsLater = versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_123.5 }))
+		expect(halfMsLater).not.toBe(wholeMs)
+		// 0.5 ms = 500_000 ns. The float-derived ns field is quantized (~256 ns at
+		// this epoch), so allow a bounded drift instead of asserting an exact value.
+		const diff = Number(halfMsLater.split(":")[3]) - Number(wholeMs.split(":")[3])
+		expect(Math.abs(diff - 500_000)).toBeLessThanOrEqual(512)
+	})
+
+	it("handles sizes beyond 32 bits without precision loss", () => {
+		const size = 5_000_000_000 // > 2^32
+		const token = versionTokenOfStat(makeStats({ size }))
+		expect(token).toContain(`:4242:${size}:`)
+	})
+})
+
+describe("computeVersionToken (A1, epic #1375)", () => {
+	let tmpDir: string
+	let file: string
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "version-token-"))
+		file = path.join(tmpDir, "seed.txt")
+		await fs.writeFile(file, "seed content", "utf8")
+	})
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true })
+	})
+
+	it("derives the token from the on-disk state (single stat)", async () => {
+		const token = await computeVersionToken(file)
+		expect(token).toBe(versionTokenOfStat(await fs.stat(file)))
+	})
+
+	it("changes when the file content changes", async () => {
+		const before = await computeVersionToken(file)
+		// Different size + a new mtime — both must move the token.
+		await fs.writeFile(file, "seed content, extended", "utf8")
+		await new Promise((resolve) => setTimeout(resolve, 5))
+		expect(await computeVersionToken(file)).not.toBe(before)
+	})
+
+	it("rejects with ENOENT for an absent file", async () => {
+		await expect(computeVersionToken(path.join(tmpDir, "absent.txt"))).rejects.toMatchObject({
+			code: "ENOENT",
+		})
+	})
+})

--- a/src/utils/__tests__/versionToken.spec.ts
+++ b/src/utils/__tests__/versionToken.spec.ts
@@ -1,25 +1,33 @@
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
-import type { Stats } from "fs"
+import type { BigIntStats } from "fs"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import { computeVersionToken, versionTokenOfStat } from "../versionToken"
 
-// Stats is a class-backed interface without a public constructor, so a plain-object
-// test double is the only practical way to pin the token format without real files.
-// Last-resort double assertion (test-local, per AGENTS.md).
-function makeStats(overrides: Partial<Stats> = {}): Stats {
-	const base: Partial<Stats> = {
-		dev: 7,
-		ino: 4242,
-		size: 1234,
-		atimeMs: 1_700_000_000_000,
-		mtimeMs: 1_700_000_000_123.456,
-		ctimeMs: 1_700_000_000_789.999,
-		birthtimeMs: 1_700_000_000_000,
+// BigIntStats is a class-backed interface without a public constructor, so a
+// plain-object test double is the only practical way to pin the token format
+// without real files. Last-resort double assertion (test-local, per AGENTS.md).
+function makeStats(overrides: Partial<BigIntStats> = {}): BigIntStats {
+	// This repo's @types/node models every StatsBase field (including the *Ms
+	// fields) as the parameter type T, so all values here are bigint literals;
+	// the token only reads the *Ns fields. Single-step downcast from Partial to
+	// the full type (BigIntStats has no public constructor).
+	const base: Partial<BigIntStats> = {
+		dev: 7n,
+		ino: 4242n,
+		size: 1234n,
+		atimeMs: 1_700_000_000_000n,
+		mtimeMs: 1_700_000_000_123n,
+		ctimeMs: 1_700_000_000_789n,
+		birthtimeMs: 1_700_000_000_000n,
+		atimeNs: 1_700_000_000_000_000_000n,
+		mtimeNs: 1_700_000_000_123_456_789n,
+		ctimeNs: 1_700_000_000_789_999_999n,
+		birthtimeNs: 1_700_000_000_000_000_000n,
 	}
-	return { ...base, ...overrides } as unknown as Stats
+	return { ...base, ...overrides } as BigIntStats
 }
 
 describe("versionTokenOfStat (A1, epic #1375)", () => {
@@ -27,44 +35,38 @@ describe("versionTokenOfStat (A1, epic #1375)", () => {
 		expect(versionTokenOfStat(makeStats())).toBe(versionTokenOfStat(makeStats()))
 	})
 
-	it("matches the documented dev:ino:size:mtimeNs:ctimeNs format", () => {
-		const expected = [
-			"7",
-			"4242",
-			"1234",
-			Math.round(1_700_000_000_123.456 * 1e6).toString(),
-			Math.round(1_700_000_000_789.999 * 1e6).toString(),
-		].join(":")
-		expect(versionTokenOfStat(makeStats())).toBe(expected)
+	it("matches the documented dev:ino:size:mtimeNs:ctimeNs format with exact decimal fields", () => {
+		expect(versionTokenOfStat(makeStats())).toBe("7:4242:1234:1700000000123456789:1700000000789999999")
 	})
 
 	it("distinguishes size changes at identical timestamps", () => {
-		expect(versionTokenOfStat(makeStats({ size: 1235 }))).not.toBe(versionTokenOfStat(makeStats()))
+		expect(versionTokenOfStat(makeStats({ size: 1235n }))).not.toBe(versionTokenOfStat(makeStats()))
 	})
 
-	it("distinguishes mtime changes at identical size", () => {
-		expect(versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_124 }))).not.toBe(versionTokenOfStat(makeStats()))
+	it("distinguishes a one-nanosecond mtime change", () => {
+		expect(versionTokenOfStat(makeStats({ mtimeNs: 1_700_000_000_123_456_790n }))).not.toBe(
+			versionTokenOfStat(makeStats()),
+		)
 	})
 
 	it("distinguishes a replaced file (dev/ino change) with identical content state", () => {
-		const replaced = makeStats({ dev: 8, ino: 999 })
+		const replaced = makeStats({ dev: 8n, ino: 999n })
 		expect(versionTokenOfStat(replaced)).not.toBe(versionTokenOfStat(makeStats()))
 	})
 
-	it("preserves sub-ms mtime resolution in the ns field", () => {
-		const wholeMs = versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_123 }))
-		const halfMsLater = versionTokenOfStat(makeStats({ mtimeMs: 1_700_000_000_123.5 }))
-		expect(halfMsLater).not.toBe(wholeMs)
-		// 0.5 ms = 500_000 ns. The float-derived ns field is quantized (~256 ns at
-		// this epoch), so allow a bounded drift instead of asserting an exact value.
-		const diff = Number(halfMsLater.split(":")[3]) - Number(wholeMs.split(":")[3])
-		expect(Math.abs(diff - 500_000)).toBeLessThanOrEqual(512)
+	it("renders nanosecond resolution exactly (no float quantization)", () => {
+		const base = versionTokenOfStat(makeStats())
+		const plusOneMicrosecond = versionTokenOfStat(makeStats({ mtimeNs: 1_700_000_000_123_457_789n }))
+		// 1_000 ns apart — the BigInt derivation must keep the delta exact.
+		const baseNs = BigInt(base.split(":")[3])
+		const microNs = BigInt(plusOneMicrosecond.split(":")[3])
+		expect(microNs - baseNs).toBe(1_000n)
 	})
 
-	it("handles sizes beyond 32 bits without precision loss", () => {
-		const size = 5_000_000_000 // > 2^32
+	it("handles sizes beyond Number.MAX_SAFE_INTEGER without precision loss", () => {
+		const size = 10_000_000_000_000_001n // 10^16 + 1 > 2^53
 		const token = versionTokenOfStat(makeStats({ size }))
-		expect(token).toContain(`:4242:${size}:`)
+		expect(token).toBe(`7:4242:${size}:1700000000123456789:1700000000789999999`)
 	})
 })
 
@@ -82,9 +84,9 @@ describe("computeVersionToken (A1, epic #1375)", () => {
 		await fs.rm(tmpDir, { recursive: true, force: true })
 	})
 
-	it("derives the token from the on-disk state (single stat)", async () => {
+	it("derives the token from the on-disk state (single bigint stat)", async () => {
 		const token = await computeVersionToken(file)
-		expect(token).toBe(versionTokenOfStat(await fs.stat(file)))
+		expect(token).toBe(versionTokenOfStat(await fs.stat(file, { bigint: true })))
 	})
 
 	it("changes when the file content changes", async () => {

--- a/src/utils/safeWriteJson.ts
+++ b/src/utils/safeWriteJson.ts
@@ -4,6 +4,8 @@ import * as path from "path"
 import * as lockfile from "proper-lockfile"
 import { JsonStreamStringify } from "json-stream-stringify"
 
+import { resolvePublishTarget, safeWriteText, type SafeWriteTextOptions } from "../services/file-safety/safeWriteText"
+
 /**
  * Options for safeWriteJson function
  */
@@ -31,7 +33,7 @@ export interface SafeWriteJsonOptions {
  * Safely writes JSON data to a file.
  * - Creates parent directories if they don't exist
  * - Uses 'proper-lockfile' for inter-process advisory locking to prevent concurrent writes to the same path.
- * - Writes to a temporary file first.
+ * - Writes to a temporary file first via JsonStreamStringify streaming.
  * - If the target file exists, it's backed up before being replaced.
  * - Attempts to roll back and clean up in case of errors.
  * - Supports pretty-printing with indentation while maintaining streaming efficiency.
@@ -41,7 +43,6 @@ export interface SafeWriteJsonOptions {
  * @param {SafeWriteJsonOptions} options - Optional configuration for JSON formatting.
  * @returns {Promise<void>}
  */
-
 async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJsonOptions): Promise<void> {
 	const absoluteFilePath = path.resolve(filePath)
 	let releaseLock = async () => {} // Initialized to a no-op
@@ -51,10 +52,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 
 	// Ensure directory structure exists with improved reliability
 	try {
-		// Create directory with recursive option
 		await fs.mkdir(dirPath, { recursive: true })
-
-		// Verify directory exists after creation attempt
 		await fs.access(dirPath)
 	} catch (dirError: any) {
 		console.error(`Failed to create or access directory for ${absoluteFilePath}:`, dirError)
@@ -84,13 +82,11 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		// The releaseLock remains a no-op, so the finally block in the main file operations
 		// try-catch-finally won't try to release an unacquired lock if this path is taken.
 		console.error(`Failed to acquire lock for ${absoluteFilePath}:`, lockError)
-		// Propagate the lock acquisition error
 		throw lockError
 	}
 
-	// Variables to hold the actual paths of temp files if they are created.
+	// Variables to hold the actual path of the temp file if it is created.
 	let actualTempNewFilePath: string | null = null
-	let actualTempBackupFilePath: string | null = null
 
 	try {
 		// If a merge callback was provided, read the current file under the lock
@@ -110,79 +106,43 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 			data = options.merge(existing, data)
 		}
 
-		// Step 1: Write data to a new temporary file.
+		// Step 1: Write data to a new temporary file via JSON streaming.
+		// Stage it beside the *resolved* target (the symlink referent when the path is
+		// a symlink): safeWriteText commits by renaming onto that referent, and a
+		// rename across filesystems would fail with EXDEV.
+		const resolvedTargetPath = await resolvePublishTarget(absoluteFilePath)
 		actualTempNewFilePath = path.join(
-			path.dirname(absoluteFilePath),
-			`.${path.basename(absoluteFilePath)}.new_${Date.now()}_${Math.random().toString(36).substring(2)}.tmp`,
+			path.dirname(resolvedTargetPath),
+			".new_" + Date.now() + "_" + Math.random().toString(36).substring(2) + ".tmp",
 		)
 
 		await _streamDataToFile(actualTempNewFilePath, data, options?.prettyPrint)
 
-		// Step 2: Check if the target file exists. If so, rename it to a backup path.
-		try {
-			// Check for target file existence
-			await fs.access(absoluteFilePath)
-			// Target exists, create a backup path and rename.
-			actualTempBackupFilePath = path.join(
-				path.dirname(absoluteFilePath),
-				`.${path.basename(absoluteFilePath)}.bak_${Date.now()}_${Math.random().toString(36).substring(2)}.tmp`,
-			)
-			await fs.rename(absoluteFilePath, actualTempBackupFilePath)
-		} catch (accessError: any) {
-			// Explicitly type accessError
-			if (accessError.code !== "ENOENT") {
-				// An error other than "file not found" occurred during access check.
-				throw accessError
-			}
-			// Target file does not exist, so no backup is made. actualTempBackupFilePath remains null.
+		// Step 2: Delegate backup + commit + rollback to safeWriteText with the
+		// pre-written temp path. backup:true keeps the old safeWriteJson
+		// semantics (target -> backup before commit, rollback on failure) and
+		// keeps the target in place until safeWriteText captures its Windows
+		// DACL (safeWriteText dumps the DACL before its own backup rename and
+		// restores it onto the directory after the commit rename).
+		const textOptions: SafeWriteTextOptions = {
+			tempPath: actualTempNewFilePath,
+			backup: true,
 		}
 
-		// Step 3: Rename the new temporary file to the target file path.
-		// This is the main "commit" step.
-		await fs.rename(actualTempNewFilePath, absoluteFilePath)
+		await safeWriteText(absoluteFilePath, "", textOptions)
 
-		// If we reach here, the new file is successfully in place.
-		// The original actualTempNewFilePath is now the main file, so we shouldn't try to clean it up as "temp".
-		// Mark as "used" or "committed"
+		// If we reach here, the new file is successfully in place and any
+		// backup has already been handled by safeWriteText.
 		actualTempNewFilePath = null
-
-		// Step 4: If a backup was created, attempt to delete it.
-		if (actualTempBackupFilePath) {
-			try {
-				await fs.unlink(actualTempBackupFilePath)
-				// Mark backup as handled
-				actualTempBackupFilePath = null
-			} catch (unlinkBackupError) {
-				// Log this error, but do not re-throw. The main operation was successful.
-				// actualTempBackupFilePath remains set, indicating an orphaned backup.
-				console.error(
-					`Successfully wrote ${absoluteFilePath}, but failed to clean up backup ${actualTempBackupFilePath}:`,
-					unlinkBackupError,
-				)
-			}
-		}
 	} catch (originalError) {
 		console.error(`Operation failed for ${absoluteFilePath}: [Original Error Caught]`, originalError)
 
 		const newFileToCleanupWithinCatch = actualTempNewFilePath
-		const backupFileToRollbackOrCleanupWithinCatch = actualTempBackupFilePath
 
-		// Attempt rollback if a backup was made
-		if (backupFileToRollbackOrCleanupWithinCatch) {
-			try {
-				await fs.rename(backupFileToRollbackOrCleanupWithinCatch, absoluteFilePath)
-				// Mark as handled, prevent later unlink of this path
-				actualTempBackupFilePath = null
-			} catch (rollbackError) {
-				// actualTempBackupFilePath (outer scope) remains pointing to backupFileToRollbackOrCleanupWithinCatch
-				console.error(
-					`[Catch] Failed to restore backup ${backupFileToRollbackOrCleanupWithinCatch} to ${absoluteFilePath}:`,
-					rollbackError,
-				)
-			}
-		}
-
-		// Cleanup the .new file if it exists
+		// A failed safeWriteText already rolled the backup (if any) back to
+		// the target path. Clean up the .new file if it still exists
+		// (safeWriteText also cleans up its tempPath on failure; this is a
+		// safety net in case its cleanup missed it).
 		if (newFileToCleanupWithinCatch) {
 			try {
 				await fs.unlink(newFileToCleanupWithinCatch)
@@ -194,26 +154,12 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 			}
 		}
 
-		// Cleanup the .bak file if it still needs to be (i.e., wasn't successfully restored)
-		if (actualTempBackupFilePath) {
-			try {
-				await fs.unlink(actualTempBackupFilePath)
-			} catch (cleanupError) {
-				console.error(
-					`[Catch] Failed to clean up temporary backup file ${actualTempBackupFilePath}:`,
-					cleanupError,
-				)
-			}
-		}
 		throw originalError // This MUST be the error that rejects the promise.
 	} finally {
 		// Release the lock in the main finally block.
 		try {
-			// releaseLock will be the actual unlock function if lock was acquired,
-			// or the initial no-op if acquisition failed.
 			await releaseLock()
 		} catch (unlockError) {
-			// Do not re-throw here, as the originalError from the try/catch (if any) is more important.
 			console.error(`Failed to release lock for ${absoluteFilePath}:`, unlockError)
 		}
 	}

--- a/src/utils/safeWriteJson.ts
+++ b/src/utils/safeWriteJson.ts
@@ -59,12 +59,22 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		throw dirError
 	}
 
+	// Resolve the publish target BEFORE acquiring the lock: proper-lockfile keys
+	// the lock by the given path (realpath is false below because the file may
+	// not exist yet), so a symlink alias and its referent would otherwise take
+	// two distinct locks for one underlying file — a concurrent merge through
+	// both aliases could then read the same JSON and overwrite one update.
+	// Locking the resolved referent coordinates every alias through one lock.
+	// resolvePublishTarget tolerates a not-yet-existing file (it returns the
+	// given path on ENOENT), preserving the previous create-from-absent flow.
+	const resolvedTargetPath = await resolvePublishTarget(absoluteFilePath)
+
 	// Acquire the lock before any file operations
 	try {
-		releaseLock = await lockfile.lock(absoluteFilePath, {
+		releaseLock = await lockfile.lock(resolvedTargetPath, {
 			stale: LOCK_STALE_MS,
 			update: 10000, // Update mtime every 10 seconds to prevent staleness if operation is long
-			realpath: false, // the file may not exist yet, which is acceptable
+			realpath: false, // resolvedTargetPath is already the referent; the file may still not exist yet, which is acceptable
 			retries: {
 				// Configuration for retrying lock acquisition
 				retries: 5, // Number of retries after the initial attempt
@@ -73,7 +83,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 				maxTimeout: 1000, // Maximum time to wait for any single retry (in ms)
 			},
 			onCompromised: (err) => {
-				console.error(`Lock at ${absoluteFilePath} was compromised:`, err)
+				console.error(`Lock at ${resolvedTargetPath} was compromised:`, err)
 				throw err
 			},
 		})
@@ -81,7 +91,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		// If lock acquisition fails, we throw immediately.
 		// The releaseLock remains a no-op, so the finally block in the main file operations
 		// try-catch-finally won't try to release an unacquired lock if this path is taken.
-		console.error(`Failed to acquire lock for ${absoluteFilePath}:`, lockError)
+		console.error(`Failed to acquire lock for ${resolvedTargetPath}:`, lockError)
 		throw lockError
 	}
 
@@ -95,7 +105,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		if (options?.merge) {
 			let existing: unknown = null
 			try {
-				existing = JSON.parse(await fs.readFile(absoluteFilePath, "utf8"))
+				existing = JSON.parse(await fs.readFile(resolvedTargetPath, "utf8"))
 			} catch (error: unknown) {
 				const code =
 					error && typeof error === "object" && "code" in error ? (error as { code: string }).code : undefined
@@ -108,9 +118,8 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 
 		// Step 1: Write data to a new temporary file via JSON streaming.
 		// Stage it beside the *resolved* target (the symlink referent when the path is
-		// a symlink): safeWriteText commits by renaming onto that referent, and a
-		// rename across filesystems would fail with EXDEV.
-		const resolvedTargetPath = await resolvePublishTarget(absoluteFilePath)
+		// a symlink; resolvedTargetPath above): safeWriteText commits by renaming
+		// onto that referent, and a rename across filesystems would fail with EXDEV.
 		actualTempNewFilePath = path.join(
 			path.dirname(resolvedTargetPath),
 			".new_" + Date.now() + "_" + Math.random().toString(36).substring(2) + ".tmp",
@@ -129,13 +138,13 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 			backup: true,
 		}
 
-		await safeWriteText(absoluteFilePath, "", textOptions)
+		await safeWriteText(resolvedTargetPath, "", textOptions)
 
 		// If we reach here, the new file is successfully in place and any
 		// backup has already been handled by safeWriteText.
 		actualTempNewFilePath = null
 	} catch (originalError) {
-		console.error(`Operation failed for ${absoluteFilePath}: [Original Error Caught]`, originalError)
+		console.error(`Operation failed for ${resolvedTargetPath}: [Original Error Caught]`, originalError)
 
 		const newFileToCleanupWithinCatch = actualTempNewFilePath
 
@@ -160,7 +169,7 @@ async function safeWriteJson(filePath: string, data: any, options?: SafeWriteJso
 		try {
 			await releaseLock()
 		} catch (unlockError) {
-			console.error(`Failed to release lock for ${absoluteFilePath}:`, unlockError)
+			console.error(`Failed to release lock for ${resolvedTargetPath}:`, unlockError)
 		}
 	}
 }

--- a/src/utils/versionToken.ts
+++ b/src/utils/versionToken.ts
@@ -21,8 +21,15 @@ import type { Stats } from "fs"
  * ns field; in practice distinct states differ by at least the OS clock resolution
  * (and no write workload produces mtimes closer than that), so the guard contract
  * holds: same disk state → same token; changed state → a different token in all
- * realistic cases. dev, ino and size are exact integers, so any size or file
- * identity change is always detected regardless of the timestamp quantum.
+ * realistic cases. `dev` and `size` are exact integers. `ino` is Node's
+ * `number` (float64): exact for small POSIX inode numbers, but on modern Windows
+ * the underlying file ID exceeds 2^53, so Node's own value is already rounded —
+ * still deterministic per file (same file → same token), but not guaranteed
+ * injective across distinct files. Change detection therefore rests on size +
+ * mtime/ctime: any size change is always detected regardless of the timestamp
+ * quantum, and a replacement whose size and timestamps are indistinguishable is
+ * undetectable by any scheme reading the same Stats — the detect-and-reread
+ * stance (no lockfile) accepts that.
  */
 
 /** Derive an ns-scale field from Node's float milliseconds (see module docs). */

--- a/src/utils/versionToken.ts
+++ b/src/utils/versionToken.ts
@@ -1,64 +1,48 @@
 import { stat } from "fs/promises"
-import type { Stats } from "fs"
+import type { BigIntStats } from "fs"
 
 /**
  * Version token for the compare-and-swap write guard (upstream epic #1375, phase A1).
  *
  * A token is a pure function of a file's on-disk state, derived from a single
- * `fs.stat`, so every process that observes the same file state (a second VS Code
- * window, the CLI, the user's own editor tooling) computes the same token. The
- * downstream guard phases (A2/A3) compare the token observed at read time with the
- * token recomputed just before a write to detect "the file changed since the read"
- * (stale) or "the file was replaced by a different file" (dev/ino change).
+ * `fs.stat(path, { bigint: true })`, so every process that observes the same file
+ * state (a second VS Code window, the CLI, the user's own editor tooling) computes
+ * the same token. The downstream guard phases (A2/A3) compare the token observed at
+ * read time with the token recomputed just before a write to detect "the file
+ * changed since the read" (stale) or "the file was replaced by a different file"
+ * (dev/ino change).
  *
  * Format: `dev:ino:size:mtimeNs:ctimeNs`
  *
- * Resolution note: Node exposes modification/change times as float milliseconds,
- * so the ns fields are derived as `Math.round(mtimeMs * 1e6)`. The integer-to-double
- * conversion is correctly rounded, so the derivation is deterministic across
- * processes, but it is quantized by double precision (~256 ns at the current epoch).
- * Two file states whose timestamps differ by less than the quantum derive the same
- * ns field; in practice distinct states differ by at least the OS clock resolution
- * (and no write workload produces mtimes closer than that), so the guard contract
- * holds: same disk state → same token; changed state → a different token in all
- * realistic cases. `dev` and `size` are exact integers. `ino` is Node's
- * `number` (float64): exact for small POSIX inode numbers, but on modern Windows
- * the underlying file ID exceeds 2^53, so Node's own value is already rounded —
- * still deterministic per file (same file → same token), but not guaranteed
- * injective across distinct files. Change detection therefore rests on size +
- * mtime/ctime: any size change is always detected regardless of the timestamp
- * quantum, and a replacement whose size and timestamps are indistinguishable is
- * undetectable by any scheme reading the same Stats — the detect-and-reread
- * stance (no lockfile) accepts that.
+ * Precision: the stat is fetched in `bigint` mode, so all five fields are exact
+ * `BigInt` values rendered as decimal strings — no float is involved anywhere.
+ * There is therefore no precision loss for large sizes or inodes (a Windows file ID
+ * exceeds 2^53 and is still exact), and the ns timestamps are the kernel's exact
+ * nanosecond values rather than a ms→ns derivation (no ~256 ns double-precision
+ * quantum). Guarantee: same disk state → same token, deterministic across
+ * processes; any change to size, file identity, or mtime/ctime → a different token.
+ *
+ * Platform note: on POSIX `ctime` is the last file-status change; on Windows it is
+ * the file creation time. The token only requires it to move when the file's
+ * metadata is replaced, which holds on both.
  */
 
-/** Derive an ns-scale field from Node's float milliseconds (see module docs). */
-function nsFromMs(ms: number): string {
-	return Math.round(ms * 1e6).toString()
-}
-
 /**
- * Build the version token from an already-fetched `Stats` — no I/O.
+ * Build the version token from an already-fetched `BigIntStats` — no I/O.
  *
  * Exported separately from {@link computeVersionToken} so tests can pin the exact
  * format against synthetic stats.
  */
-export function versionTokenOfStat(stats: Stats): string {
-	return [
-		stats.dev.toString(),
-		stats.ino.toString(),
-		stats.size.toString(),
-		nsFromMs(stats.mtimeMs),
-		nsFromMs(stats.ctimeMs),
-	].join(":")
+export function versionTokenOfStat(stats: BigIntStats): string {
+	return [stats.dev, stats.ino, stats.size, stats.mtimeNs, stats.ctimeNs].map((value) => value.toString()).join(":")
 }
 
 /**
- * Compute the version token for a file (one `fs.stat`).
+ * Compute the version token for a file (one `fs.stat` in bigint mode).
  *
  * Rejects with the underlying ENOENT (or equivalent) error when the file is absent;
  * how an unobservable target is treated is decided by the guard layer (A3).
  */
 export async function computeVersionToken(filePath: string): Promise<string> {
-	return versionTokenOfStat(await stat(filePath))
+	return versionTokenOfStat(await stat(filePath, { bigint: true }))
 }

--- a/src/utils/versionToken.ts
+++ b/src/utils/versionToken.ts
@@ -1,0 +1,57 @@
+import { stat } from "fs/promises"
+import type { Stats } from "fs"
+
+/**
+ * Version token for the compare-and-swap write guard (upstream epic #1375, phase A1).
+ *
+ * A token is a pure function of a file's on-disk state, derived from a single
+ * `fs.stat`, so every process that observes the same file state (a second VS Code
+ * window, the CLI, the user's own editor tooling) computes the same token. The
+ * downstream guard phases (A2/A3) compare the token observed at read time with the
+ * token recomputed just before a write to detect "the file changed since the read"
+ * (stale) or "the file was replaced by a different file" (dev/ino change).
+ *
+ * Format: `dev:ino:size:mtimeNs:ctimeNs`
+ *
+ * Resolution note: Node exposes modification/change times as float milliseconds,
+ * so the ns fields are derived as `Math.round(mtimeMs * 1e6)`. The integer-to-double
+ * conversion is correctly rounded, so the derivation is deterministic across
+ * processes, but it is quantized by double precision (~256 ns at the current epoch).
+ * Two file states whose timestamps differ by less than the quantum derive the same
+ * ns field; in practice distinct states differ by at least the OS clock resolution
+ * (and no write workload produces mtimes closer than that), so the guard contract
+ * holds: same disk state → same token; changed state → a different token in all
+ * realistic cases. dev, ino and size are exact integers, so any size or file
+ * identity change is always detected regardless of the timestamp quantum.
+ */
+
+/** Derive an ns-scale field from Node's float milliseconds (see module docs). */
+function nsFromMs(ms: number): string {
+	return Math.round(ms * 1e6).toString()
+}
+
+/**
+ * Build the version token from an already-fetched `Stats` — no I/O.
+ *
+ * Exported separately from {@link computeVersionToken} so tests can pin the exact
+ * format against synthetic stats.
+ */
+export function versionTokenOfStat(stats: Stats): string {
+	return [
+		stats.dev.toString(),
+		stats.ino.toString(),
+		stats.size.toString(),
+		nsFromMs(stats.mtimeMs),
+		nsFromMs(stats.ctimeMs),
+	].join(":")
+}
+
+/**
+ * Compute the version token for a file (one `fs.stat`).
+ *
+ * Rejects with the underlying ENOENT (or equivalent) error when the file is absent;
+ * how an unobservable target is treated is decided by the guard layer (A3).
+ */
+export async function computeVersionToken(filePath: string): Promise<string> {
+	return versionTokenOfStat(await stat(filePath))
+}


### PR DESCRIPTION
> Tracking issue: [#1400](https://github.com/ZooCode-Org/Zoo-Code/issues/1400)

Part of the file-write-safety series (#1375) — S4b: wire the guarded writes (S4a CAS core) into the write tools. Stacked on S4a (#1399).

## What

- `write_to_file` / `edit_file` / `apply_patch` (and the remaining write paths per the S4a scope) route their publish through the S4a guard: unobserved writes to an existing file now fail loudly instead of silently overwriting; stale-version writes fail with the re-read-then-retry remediation; the model self-heals through its standard read-retry loop.
- Failures surface as tool-call errors with a step event in chat (loud, recoverable — no silent overwrite path remains).
- `edit_file` keeps its existing literal-match check and adds the version guard on top.

## Tests

- Per-tool guard branches (each tool's spec): unobserved-existing fails, stale fails, observed-success unchanged.
- Concurrency already covered at the core layer (S4a).
- Regression: all existing write-tool suites stay green (normal single-writer flow unchanged).
- Local gates: eslint 0, tsc 0, 100% patch coverage on changed lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards against overwriting unread or modified files.
  * Added file version tracking during tasks.
  * Added atomic file publishing with rollback support, symlink handling, and permission preservation.
  * Updated editing, patching, search/replace, and writing tools to apply appropriate safeguards.
* **Bug Fixes**
  * Improved protection against conflicting concurrent updates.
  * Enhanced backup and recovery for JSON file writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (CodeRabbit-sync from trial #1413):** head `88c935278` — apply_patch hunk read now records the S2 file observation (stat before/after, observe when the version is unchanged) so the guarded in-place publish is not rejected as an unobserved write (trial addendum 178e6f405). Review context: [trial PR #1413](https://github.com/Zoo-Code-Org/Zoo-Code/pull/1413).
---

**Review-gate re-trigger (2026-08-30):** empty commit e96df628a (no code change) re-runs CI and CodeRabbit current-head review under the org new PR review gate; the code head remains 88c935278.
