### PR TITLE
fix: yield reasoning chunks before content chunks in providers

### DIFF
--- a/src/api/providers/__tests__/base-openai-compatible-provider.spec.ts
+++ b/src/api/providers/__tests__/base-openai-compatible-provider.spec.ts
@@ -236,6 +236,25 @@ describe("BaseOpenAiCompatibleProvider", () => {
 			// Should yield reasoning with spaces (only pure whitespace is filtered)
 			expect(chunks).toEqual([{ type: "reasoning", text: "  content with spaces  " }])
 		})
+
+		it("should yield reasoning chunks BEFORE text chunks when both are present in the exact same delta", async () => {
+			mockCreate.mockImplementationOnce(() =>
+				asyncStreamFrom([
+					{
+						choices: [{ delta: { reasoning_content: "thinking...", content: "answer" } }],
+					},
+				]),
+			)
+
+			const stream = handler.createMessage("system prompt", [])
+			const chunks = await collectStream(stream)
+
+			const contentChunks = chunks.filter((c) => c.type === "reasoning" || c.type === "text")
+			expect(contentChunks).toEqual([
+				{ type: "reasoning", text: "thinking..." },
+				{ type: "text", text: "answer" },
+			])
+		})
 	})
 
 	describe("Basic functionality", () => {

--- a/src/api/providers/__tests__/lite-llm.spec.ts
+++ b/src/api/providers/__tests__/lite-llm.spec.ts
@@ -731,6 +731,31 @@ describe("LiteLLMHandler", () => {
 			expect(textChunk).toMatchObject({ type: "text", text: "The answer is 42." })
 		})
 
+		it("should yield reasoning chunks BEFORE text chunks when both are present in the exact same delta", async () => {
+			const mockStream = asyncStreamFrom([
+				{
+					choices: [{ delta: { reasoning_content: "thinking...", content: "answer" } }],
+					usage: { prompt_tokens: 10, completion_tokens: 10 },
+				},
+			])
+
+			mockCreate.mockReturnValue({
+				withResponse: vi.fn().mockResolvedValue({ data: mockStream }),
+			})
+
+			const generator = handler.createMessage("system", [{ role: "user", content: "Test simultaneous." }])
+			const results = await collectStream(generator)
+
+			// Filter out usage chunks to focus on ordering of content
+			const contentResults = results.filter((r) => r.type === "reasoning" || r.type === "text")
+
+			// The order is strictly enforced here
+			expect(contentResults).toEqual([
+				{ type: "reasoning", text: "thinking..." },
+				{ type: "text", text: "answer" },
+			])
+		})
+
 		it("should yield reasoning chunks from reasoning delta field", async () => {
 			const mockStream = asyncStreamFrom([
 				{

--- a/src/api/providers/__tests__/nanogpt.spec.ts
+++ b/src/api/providers/__tests__/nanogpt.spec.ts
@@ -123,8 +123,8 @@ describe("NanoGptHandler", () => {
 			new NanoGptHandler({ nanoGptModelId: "model:thinking" }).createMessage("sys", messages),
 		)
 		expect(chunks).toEqual([
-			{ type: "text", text: "answer" },
 			{ type: "reasoning", text: "modern" },
+			{ type: "text", text: "answer" },
 			{ type: "reasoning", text: "legacy" },
 			{ type: "tool_call_partial", index: 0, id: "call-1", name: "read_file", arguments: '{"path":' },
 			{ type: "tool_call_partial", index: 1, id: "call-2", name: "search_files", arguments: '{"query":' },

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -658,6 +658,26 @@ describe("OpenAiHandler", () => {
 			expect(callArgs.max_completion_tokens).toBe(4096)
 		})
 
+		it("should yield reasoning chunks BEFORE text chunks when both are present in the exact same delta", async () => {
+			mockCreate.mockImplementationOnce(() =>
+				asyncStreamFrom([
+					{
+						choices: [{ delta: { reasoning_content: "thinking...", content: "answer" } }],
+						usage: { prompt_tokens: 10, completion_tokens: 10 },
+					},
+				]),
+			)
+
+			const stream = handler.createMessage("system prompt", [])
+			const chunks = await collectStream(stream)
+
+			const contentChunks = chunks.filter((c) => c.type === "reasoning" || c.type === "text")
+			expect(contentChunks).toEqual([
+				{ type: "reasoning", text: "thinking..." },
+				{ type: "text", text: "answer" },
+			])
+		})
+
 		describe("TagMatcher reasoning tags", () => {
 			it("should treat stray closing tag as plain text when no tag is open", async () => {
 				mockCreate.mockImplementationOnce(() =>

--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -141,15 +141,15 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 			const delta = chunk.choices?.[0]?.delta
 			const finishReason = chunk.choices?.[0]?.finish_reason
 
+			const reasoningText = extractReasoningFromDelta(delta)
+			if (reasoningText) {
+				yield { type: "reasoning", text: reasoningText }
+			}
+
 			if (delta?.content) {
 				for (const processedChunk of matcher.update(delta.content)) {
 					yield processedChunk
 				}
-			}
-
-			const reasoningText = extractReasoningFromDelta(delta)
-			if (reasoningText) {
-				yield { type: "reasoning", text: reasoningText }
 			}
 
 			// Emit raw tool call chunks - NativeToolCallParser handles state management

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -165,19 +165,19 @@ export class DeepSeekHandler extends OpenAiHandler {
 		for await (const chunk of stream) {
 			const delta = chunk.choices?.[0]?.delta ?? {}
 
+			// Handle reasoning_content from DeepSeek's interleaved thinking
+			// This is the proper way DeepSeek sends thinking content in streaming
+			const reasoningText = extractReasoningFromDelta(delta)
+			if (reasoningText) {
+				yield { type: "reasoning", text: reasoningText }
+			}
+
 			// Handle regular text content
 			if (delta.content) {
 				yield {
 					type: "text",
 					text: delta.content,
 				}
-			}
-
-			// Handle reasoning_content from DeepSeek's interleaved thinking
-			// This is the proper way DeepSeek sends thinking content in streaming
-			const reasoningText = extractReasoningFromDelta(delta)
-			if (reasoningText) {
-				yield { type: "reasoning", text: reasoningText }
 			}
 
 			// Handle tool calls

--- a/src/api/providers/kenari.ts
+++ b/src/api/providers/kenari.ts
@@ -82,15 +82,15 @@ export class KenariHandler extends RouterProvider implements SingleCompletionHan
 		for await (const chunk of completion) {
 			const delta = chunk.choices[0]?.delta
 
-			if (delta?.content) {
-				yield { type: "text", text: delta.content }
-			}
-
 			// Several Kenari models (GLM, DeepSeek) stream reasoning via reasoning_content,
 			// with an OpenRouter-style `reasoning` fallback; the shared helper handles both.
 			const reasoningText = extractReasoningFromDelta(delta)
 			if (reasoningText) {
 				yield { type: "reasoning", text: reasoningText }
+			}
+
+			if (delta?.content) {
+				yield { type: "text", text: delta.content }
 			}
 
 			// Emit raw tool call chunks - NativeToolCallParser handles state management.

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -257,13 +257,13 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 				const delta = chunk.choices[0]?.delta
 				const usage = chunk.usage as LiteLLMUsage
 
-				if (delta?.content) {
-					yield { type: "text", text: delta.content }
-				}
-
 				const reasoningText = extractReasoningFromDelta(delta)
 				if (reasoningText) {
 					yield { type: "reasoning", text: reasoningText }
+				}
+
+				if (delta?.content) {
+					yield { type: "text", text: delta.content }
 				}
 
 				// Handle tool calls in stream - emit partial chunks for NativeToolCallParser

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -123,13 +123,6 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 				const delta = chunk.choices[0]?.delta
 				const finishReason = chunk.choices[0]?.finish_reason
 
-				if (delta?.content) {
-					assistantText += delta.content
-					for (const processedChunk of matcher.update(delta.content)) {
-						yield processedChunk
-					}
-				}
-
 				// Reasoning models served by LM Studio (Qwen3, DeepSeek-R1, QwQ, ...) stream
 				// their thinking in a dedicated `reasoning_content`/`reasoning` delta field
 				// rather than as <think> tags inside `content`, so TagMatcher never sees it.
@@ -137,6 +130,13 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 				if (reasoningText) {
 					reasoningOutput += reasoningText
 					yield { type: "reasoning", text: reasoningText }
+				}
+
+				if (delta?.content) {
+					assistantText += delta.content
+					for (const processedChunk of matcher.update(delta.content)) {
+						yield processedChunk
+					}
 				}
 
 				// Handle tool calls in stream - emit partial chunks for NativeToolCallParser

--- a/src/api/providers/mimo.ts
+++ b/src/api/providers/mimo.ts
@@ -122,16 +122,16 @@ export class MimoHandler extends OpenAiHandler {
 					}
 				: delta
 
+			const reasoningText = extractReasoningFromDelta(delta)
+			if (reasoningText) {
+				yield { type: "reasoning", text: reasoningText }
+			}
+
 			if (delta.content) {
 				yield {
 					type: "text",
 					text: delta.content,
 				}
-			}
-
-			const reasoningText = extractReasoningFromDelta(delta)
-			if (reasoningText) {
-				yield { type: "reasoning", text: reasoningText }
 			}
 
 			yield* this.processToolCalls(sanitizedDelta, finishReason, activeToolCallIds)

--- a/src/api/providers/nanogpt.ts
+++ b/src/api/providers/nanogpt.ts
@@ -123,13 +123,13 @@ export class NanoGptHandler extends RouterProvider implements SingleCompletionHa
 			const completion = await this.client.chat.completions.create(body, { signal: metadata?.abortSignal })
 			for await (const chunk of completion) {
 				const delta = chunk.choices[0]?.delta
-				if (delta?.content) {
-					yield { type: "text", text: delta.content }
-				}
-
 				const reasoning = extractReasoningFromDelta(delta)
 				if (reasoning) {
 					yield { type: "reasoning", text: reasoning }
+				}
+
+				if (delta?.content) {
+					yield { type: "text", text: delta.content }
 				}
 
 				for (const toolCall of delta?.tool_calls ?? []) {

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -201,15 +201,15 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				const delta = chunk.choices?.[0]?.delta ?? {}
 				const finishReason = chunk.choices?.[0]?.finish_reason
 
+				const reasoningText = extractReasoningFromDelta(delta)
+				if (reasoningText) {
+					yield { type: "reasoning", text: reasoningText }
+				}
+
 				if (delta.content) {
 					for (const chunk of matcher.update(delta.content)) {
 						yield chunk
 					}
-				}
-
-				const reasoningText = extractReasoningFromDelta(delta)
-				if (reasoningText) {
-					yield { type: "reasoning", text: reasoningText }
 				}
 
 				yield* this.processToolCalls(delta, finishReason, activeToolCallIds)

--- a/src/api/providers/opencode-go.ts
+++ b/src/api/providers/opencode-go.ts
@@ -252,14 +252,14 @@ export class OpencodeGoHandler extends RouterProvider implements SingleCompletio
 		for await (const chunk of completion) {
 			const delta = chunk.choices[0]?.delta
 
-			if (delta?.content) {
-				yield { type: "text", text: delta.content }
-			}
-
 			// Several Go-plan models (GLM, DeepSeek) stream reasoning via this field.
 			const reasoningText = extractReasoningFromDelta(delta)
 			if (reasoningText) {
 				yield { type: "reasoning", text: reasoningText }
+			}
+
+			if (delta?.content) {
+				yield { type: "text", text: delta.content }
 			}
 
 			// Emit raw tool call chunks - NativeToolCallParser handles state management.

--- a/src/api/providers/qwen-code.ts
+++ b/src/api/providers/qwen-code.ts
@@ -247,6 +247,11 @@ export class QwenCodeHandler extends BaseProvider implements SingleCompletionHan
 			const delta = apiChunk.choices[0]?.delta ?? {}
 			const finishReason = apiChunk.choices[0]?.finish_reason
 
+			const reasoningText = extractReasoningFromDelta(delta)
+			if (reasoningText) {
+				yield { type: "reasoning", text: reasoningText }
+			}
+
 			if (delta.content) {
 				let newText = delta.content
 				if (newText.startsWith(fullContent)) {
@@ -283,11 +288,6 @@ export class QwenCodeHandler extends BaseProvider implements SingleCompletionHan
 						}
 					}
 				}
-			}
-
-			const reasoningText = extractReasoningFromDelta(delta)
-			if (reasoningText) {
-				yield { type: "reasoning", text: reasoningText }
 			}
 
 			// Handle tool calls in stream - emit partial chunks for NativeToolCallParser

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -178,13 +178,13 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 		for await (const chunk of stream) {
 			const delta = chunk.choices[0]?.delta
 
-			if (delta?.content) {
-				yield { type: "text", text: delta.content }
-			}
-
 			const reasoningText = extractReasoningFromDelta(delta)
 			if (reasoningText) {
 				yield { type: "reasoning", text: reasoningText }
+			}
+
+			if (delta?.content) {
+				yield { type: "text", text: delta.content }
 			}
 
 			// Handle native tool calls

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -169,13 +169,13 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 		for await (const chunk of stream) {
 			const delta = chunk.choices[0]?.delta
 
-			if (delta?.content) {
-				yield { type: "text", text: delta.content }
-			}
-
 			const reasoningText = extractReasoningFromDelta(delta)
 			if (reasoningText) {
 				yield { type: "reasoning", text: reasoningText }
+			}
+
+			if (delta?.content) {
+				yield { type: "text", text: delta.content }
 			}
 
 			// Handle native tool calls


### PR DESCRIPTION
### Related GitHub Issue

Closes: #1461 

### Description

This PR fixes a critical bug where the assistant's message text gets truncated in the UI when an LLM provider streams both `reasoning_content` (or thinking tags) and final `content` simultaneously in the exact same delta chunk. 

**Key implementation details:**
- Modified the `for await (const chunk of stream)` logic across all OpenAI-compatible providers (`lite-llm`, `qwen-code`, `mimo`, `nanogpt`, `requesty`, `kenari`, `unbound`, `lm-studio`, `opencode-go`, `openai`, `deepseek`, and the `base-openai-compatible-provider`).
- Reordered the yield sequence so that `extractReasoningFromDelta(delta)` is always yielded and processed *before* `delta.content`.
- This ensures the UI accurately renders the complete reasoning process before starting the text rendering, which resolves the internal task truncation issue.

### Test Procedure

- **Unit Tests added:** Added explicit edge-case tests in `lite-llm.spec.ts`, `openai.spec.ts`, and `base-openai-compatible-provider.spec.ts`.
  - These tests mock an `asyncStreamFrom` where `reasoning_content` and `content` are tightly packed in the exact same `delta` object.
  - Asserted strictly that `expect(contentChunks)` yields the `reasoning` object before the `text` object.
- **Run tests:** `pnpm test` (Verified that all 7,935 tests pass with 100% success rate across the repository).

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Visual Snapshot** (UI changes only): If a user would notice this change at a glance (layout, theme tokens, brand elements, empty/error states), I've added or updated a `*.visual.tsx` snapshot in `webview-ui/`. See `webview-ui/AGENTS.md` → "When a UI change needs a snapshot".
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Get in Touch

hehegwk_23849
