### PR TITLE
fix: _isGrokXAI() false-positive substring match breaks token usage for domains containing "x.ai"

### DIFF
--- a/.changeset/fix-grok-xai-false-positive.md
+++ b/.changeset/fix-grok-xai-false-positive.md
@@ -1,9 +1,0 @@
----
-"zoo-code": patch
----
-
-Fix `_isGrokXAI()` false-positive substring match that broke token usage for OpenAI-compatible providers whose domain contains "x.ai" as a substring (e.g. box.ai, fox.ai, max.ai).
-
-The `_isGrokXAI()` method in `src/api/providers/openai.ts` used `urlHost.includes("x.ai")` which is a substring match. Any domain containing "x.ai" anywhere in its host (e.g. `box.ai`, `fox.ai`, `max.ai`) was falsely identified as a Grok/xAI endpoint. This caused `stream_options: { include_usage: true }` to be omitted from API requests in both `createMessage()` and `handleO3FamilyMessage()`, so the API never returned usage data and the token bar showed 0 — a silent failure with no error message.
-
-Fixed by using exact host match (`api.x.ai`) or subdomain suffix check (`.x.ai`) instead of substring `includes()`.

--- a/.changeset/fix-grok-xai-false-positive.md
+++ b/.changeset/fix-grok-xai-false-positive.md
@@ -1,0 +1,9 @@
+---
+"zoo-code": patch
+---
+
+Fix `_isGrokXAI()` false-positive substring match that broke token usage for OpenAI-compatible providers whose domain contains "x.ai" as a substring (e.g. box.ai, fox.ai, max.ai).
+
+The `_isGrokXAI()` method in `src/api/providers/openai.ts` used `urlHost.includes("x.ai")` which is a substring match. Any domain containing "x.ai" anywhere in its host (e.g. `box.ai`, `fox.ai`, `max.ai`) was falsely identified as a Grok/xAI endpoint. This caused `stream_options: { include_usage: true }` to be omitted from API requests in both `createMessage()` and `handleO3FamilyMessage()`, so the API never returned usage data and the token bar showed 0 — a silent failure with no error message.
+
+Fixed by using exact host match (`api.x.ai`) or subdomain suffix check (`.x.ai`) instead of substring `includes()`.

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -1060,29 +1060,54 @@ describe("OpenAiHandler", () => {
 				openAiModelId: "gpt-4o",
 			}
 			const handler = new OpenAiHandler(nonGrokOptions)
-			// @ts-expect-error - accessing private method for testing
-			expect(handler._isGrokXAI(nonGrokOptions.openAiBaseUrl)).toBe(false)
+			expect(handler["_isGrokXAI"](nonGrokOptions.openAiBaseUrl)).toBe(false)
 		})
 
 		it("should NOT detect as Grok xAI for other domains containing 'x.ai' substring (e.g. fox.ai, max.ai)", () => {
 			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://fox.ai/v1" })
-			// @ts-expect-error - accessing private method for testing
-			expect(handler._isGrokXAI("https://fox.ai/v1")).toBe(false)
-
-			// @ts-expect-error - accessing private method for testing
-			expect(handler._isGrokXAI("https://max.ai/v1")).toBe(false)
+			expect(handler["_isGrokXAI"]("https://fox.ai/v1")).toBe(false)
+			expect(handler["_isGrokXAI"]("https://max.ai/v1")).toBe(false)
 		})
 
 		it("should detect as Grok xAI for api.x.ai", () => {
 			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://api.x.ai/v1" })
-			// @ts-expect-error - accessing private method for testing
-			expect(handler._isGrokXAI("https://api.x.ai/v1")).toBe(true)
+			expect(handler["_isGrokXAI"]("https://api.x.ai/v1")).toBe(true)
 		})
 
 		it("should detect as Grok xAI for subdomains of x.ai (e.g. custom.x.ai)", () => {
 			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://custom.x.ai/v1" })
-			// @ts-expect-error - accessing private method for testing
-			expect(handler._isGrokXAI("https://custom.x.ai/v1")).toBe(true)
+			expect(handler["_isGrokXAI"]("https://custom.x.ai/v1")).toBe(true)
+		})
+
+		it("should detect as Grok xAI when api.x.ai uses a non-default port", () => {
+			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://api.x.ai:8443/v1" })
+			expect(handler["_isGrokXAI"]("https://api.x.ai:8443/v1")).toBe(true)
+		})
+
+		it("should exclude stream_options when streaming with api.x.ai on a non-default port", async () => {
+			const portOptions = {
+				...mockOptions,
+				openAiBaseUrl: "https://api.x.ai:8443/v1",
+				openAiModelId: "grok-1",
+			}
+			const handler = new OpenAiHandler(portOptions)
+			const systemPrompt = "You are a helpful assistant."
+			const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "Hello!" }]
+
+			const stream = handler.createMessage(systemPrompt, messages)
+			await stream.next()
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: portOptions.openAiModelId,
+					stream: true,
+				}),
+				{},
+			)
+
+			const mockCalls = mockCreate.mock.calls
+			const lastCall = mockCalls[mockCalls.length - 1]
+			expect(lastCall[0]).not.toHaveProperty("stream_options")
 		})
 
 		it("should include stream_options when using a non-Grok provider whose URL contains 'x.ai' substring", async () => {

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -1052,6 +1052,67 @@ describe("OpenAiHandler", () => {
 		})
 	})
 
+	describe("Grok xAI false-positive prevention", () => {
+		it("should NOT detect as Grok xAI when host contains 'x.ai' as a substring but is not x.ai (e.g. box.ai)", () => {
+			const nonGrokOptions = {
+				...mockOptions,
+				openAiBaseUrl: "https://box.ai/v1",
+				openAiModelId: "gpt-4o",
+			}
+			const handler = new OpenAiHandler(nonGrokOptions)
+			// @ts-expect-error - accessing private method for testing
+			expect(handler._isGrokXAI(nonGrokOptions.openAiBaseUrl)).toBe(false)
+		})
+
+		it("should NOT detect as Grok xAI for other domains containing 'x.ai' substring (e.g. fox.ai, max.ai)", () => {
+			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://fox.ai/v1" })
+			// @ts-expect-error - accessing private method for testing
+			expect(handler._isGrokXAI("https://fox.ai/v1")).toBe(false)
+
+			// @ts-expect-error - accessing private method for testing
+			expect(handler._isGrokXAI("https://max.ai/v1")).toBe(false)
+		})
+
+		it("should detect as Grok xAI for api.x.ai", () => {
+			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://api.x.ai/v1" })
+			// @ts-expect-error - accessing private method for testing
+			expect(handler._isGrokXAI("https://api.x.ai/v1")).toBe(true)
+		})
+
+		it("should detect as Grok xAI for subdomains of x.ai (e.g. custom.x.ai)", () => {
+			const handler = new OpenAiHandler({ ...mockOptions, openAiBaseUrl: "https://custom.x.ai/v1" })
+			// @ts-expect-error - accessing private method for testing
+			expect(handler._isGrokXAI("https://custom.x.ai/v1")).toBe(true)
+		})
+
+		it("should include stream_options when using a non-Grok provider whose URL contains 'x.ai' substring", async () => {
+			const nonGrokOptions = {
+				...mockOptions,
+				openAiBaseUrl: "https://box.ai/v1",
+				openAiModelId: "gpt-4o",
+			}
+			const handler = new OpenAiHandler(nonGrokOptions)
+			const systemPrompt = "You are a helpful assistant."
+			const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "Hello!" }]
+
+			const stream = handler.createMessage(systemPrompt, messages)
+			await stream.next()
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: nonGrokOptions.openAiModelId,
+					stream: true,
+				}),
+				{},
+			)
+
+			const mockCalls = mockCreate.mock.calls
+			const lastCall = mockCalls[mockCalls.length - 1]
+			expect(lastCall[0]).toHaveProperty("stream_options")
+			expect(lastCall[0].stream_options).toEqual({ include_usage: true })
+		})
+	})
+
 	describe("O3 Family Models", () => {
 		const o3Options = {
 			...mockOptions,

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -518,7 +518,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 	private _isGrokXAI(baseUrl?: string): boolean {
 		const urlHost = this._getUrlHost(baseUrl)
-		return urlHost.includes("x.ai")
+		return urlHost === "api.x.ai" || urlHost.endsWith(".x.ai")
 	}
 
 	protected _isAzureAiInference(baseUrl?: string): boolean {

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -510,7 +510,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 	protected _getUrlHost(baseUrl?: string): string {
 		try {
-			return new URL(baseUrl ?? "").host
+			return new URL(baseUrl ?? "").hostname
 		} catch (error) {
 			return ""
 		}


### PR DESCRIPTION
### Summary

The `_isGrokXAI()` method in `src/api/providers/openai.ts` used `urlHost.includes("x.ai")` which is a substring match. Any domain containing "x.ai" as a substring (e.g. `box.ai`, `fox.ai`, `max.ai`) was falsely identified as a Grok/xAI endpoint. This caused `stream_options: { include_usage: true }` to be omitted from API requests, so the API never returned usage data and the token bar showed 0 — a silent failure with no error message.

### Root Cause

```typescript
// Before (buggy)
private _isGrokXAI(baseUrl?: string): boolean {
    const urlHost = this._getUrlHost(baseUrl)
    return urlHost.includes("x.ai")  // substring match — false positive for box.ai, fox.ai, etc.
}
```

The bug affects two code paths:
1. `createMessage()` — main message streaming (line 153)
2. `handleO3FamilyMessage()` — O3 family model streaming (line 351)

Both conditionally omit `stream_options` when `_isGrokXAI()` returns true:
```typescript
...(isGrokXAI ? {} : { stream_options: { include_usage: true } })
```

### Fix

```typescript
// After (fixed)
private _isGrokXAI(baseUrl?: string): boolean {
    const urlHost = this._getUrlHost(baseUrl)
    return urlHost === "api.x.ai" || urlHost.endsWith(".x.ai")
}
```

This ensures only `api.x.ai` and subdomains of `x.ai` (e.g. `custom.x.ai`) are detected as Grok/xAI endpoints.

### Changes

- `src/api/providers/openai.ts`: Changed `_isGrokXAI()` to use exact host match or subdomain suffix check instead of substring `includes()`
- `src/api/providers/__tests__/openai.spec.ts`: Added test suite "Grok xAI false-positive prevention" with 5 test cases:
  - `box.ai` should NOT be detected as Grok xAI
  - `fox.ai` and `max.ai` should NOT be detected as Grok xAI
  - `api.x.ai` SHOULD be detected as Grok xAI
  - `custom.x.ai` (subdomain) SHOULD be detected as Grok xAI
  - `stream_options` should be included when using a non-Grok provider whose URL contains "x.ai" substring

### Testing

All existing Grok xAI tests continue to pass. New tests verify the false-positive scenarios are fixed.

### Related Issue

Fixes #1483

### AI Assistance Disclosure

This PR was developed with AI assistance (Roo Code / Zoo Code with GLM-5.2). The contributor has reviewed and understands every meaningful change, can explain the implementation and tradeoffs, and has verified the fix against the actual installed plugin (both VS Code and IntelliJ). The fix is a one-line change to the `_isGrokXAI()` method plus corresponding test cases.
