### PR TITLE
feat(mcp): add ToolRouter to the MCP marketplace

### DIFF
--- a/src/assets/marketplace/mcps.yml
+++ b/src/assets/marketplace/mcps.yml
@@ -2888,6 +2888,49 @@ items:
           - name: Local Timezone
             key: LOCAL_TIMEZONE
             placeholder: America/New_York
+  - id: toolrouter
+    name: ToolRouter
+    description: The OpenRouter for tools. One connection gives an agent a hosted catalog of 250+ specialist tools for
+      web search, scraping, image and video generation, SEO, finance, property and compliance, discovered at runtime
+      and billed per call.
+    author: Humanleap
+    url: https://github.com/Humanleap/toolrouter-mcp
+    tags:
+      - tool-gateway
+      - web-search
+      - web-scraping
+      - image-generation
+      - video-generation
+      - seo
+    content:
+      - name: Remote Server
+        content: |
+          {
+            "type": "streamable-http",
+            "url": "https://api.toolrouter.com/mcp"
+          }
+      - name: Remote Server with API Key
+        content: |
+          {
+            "type": "streamable-http",
+            "url": "https://api.toolrouter.com/mcp",
+            "headers": {
+              "Authorization": "Bearer {{TOOLROUTER_API_KEY}}"
+            }
+          }
+        parameters:
+          - name: ToolRouter API Key
+            key: TOOLROUTER_API_KEY
+            placeholder: your_toolrouter_api_key
+            optional: true
+      - name: NPX
+        prerequisites:
+          - Node.js
+        content: |
+          {
+            "command": "npx",
+            "args": ["-y", "toolrouter-mcp"]
+          }
   - id: verodat
     name: Verodat
     description: Enables AI systems to interact with Verodat's data management platform, providing capabilities for dataset


### PR DESCRIPTION
Adds ToolRouter to `src/assets/marketplace/mcps.yml`, inserted alphabetically between `time` and `verodat` and following the existing schema (`Remote Server` / `Remote Server with API Key` / `NPX`, same shape as the context7 and git-mcp entries).

**ToolRouter** is the OpenRouter for tools: one MCP connection gives an agent a hosted catalog of 250+ specialist tools — web search, scraping, image and video generation, SEO, finance, property, compliance and more. The agent finds what it needs with `discover` and runs it with `use_tool`, so the whole catalog costs roughly 9,000 tokens of context instead of one tool definition per skill.

- Endpoint: `https://api.toolrouter.com/mcp` (streamable-http), verified today with a live `initialize` at protocol version `2025-06-18`
- Source (MIT): https://github.com/Humanleap/toolrouter-mcp
- Website: https://toolrouter.com · Docs: https://toolrouter.com/docs
- Official MCP Registry: `io.github.Humanleap/toolrouter` (active)

The default **Remote Server** option needs no credentials at all — the endpoint provisions a free account on first connect and free tools run immediately, so a user can install it and it works. The API key variant is optional and passed as a `{{TOOLROUTER_API_KEY}}` parameter in an `Authorization` header. The YAML parses and the rest of the file is byte-identical.
