### PR TITLE
fix(activate): target title-bar commands to their click-origin instance

### DIFF
--- a/packages/types/src/vscode.ts
+++ b/packages/types/src/vscode.ts
@@ -35,6 +35,14 @@ export const commandIds = [
 	"popoutButtonClicked",
 	"settingsButtonClicked",
 
+	// Editor-tab (popped-out) surface variants of the title-bar buttons. The
+	// shared ids above target the sidebar click origin, so the tab surface
+	// needs its own ids (see registerCommands.ts getTabProvider).
+	"plusButtonClickedInTab",
+	"settingsButtonClickedInTab",
+	"marketplaceButtonClickedInTab",
+	"historyButtonClickedInTab",
+
 	"openInNewTab",
 
 	"newTask",

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -1,5 +1,7 @@
 import type { Mock } from "vitest"
 import * as vscode from "vscode"
+import { TelemetryService } from "@roo-code/telemetry"
+
 import { ClineProvider } from "../../core/webview/ClineProvider"
 
 import { getVisibleProviderOrLog, openClineInNewTab, registerCommands, setPanel } from "../registerCommands"
@@ -192,44 +194,104 @@ describe("registerCommands handlers", () => {
 		expect(mockContext.subscriptions).toContain(disposable)
 	})
 
-	it("settingsButtonClicked posts both settingsButtonClicked and didBecomeVisible actions", () => {
+	// The sidebar title-bar handlers target the registered provider (the
+	// sidebar click origin) directly, not the visible-instance heuristic.
+	it("settingsButtonClicked posts both settingsButtonClicked and didBecomeVisible actions on the registered provider", () => {
 		handlers["zoo-code.settingsButtonClicked"]()
 
-		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("settings")
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",
 			action: "settingsButtonClicked",
 		})
-		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",
 			action: "didBecomeVisible",
 		})
-		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledTimes(2)
-	})
-
-	it("settingsButtonClicked is a no-op when no visible provider", () => {
-		;(ClineProvider.getVisibleInstance as Mock).mockReturnValue(undefined)
-
-		handlers["zoo-code.settingsButtonClicked"]()
-
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledTimes(2)
 		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 
-	it("historyButtonClicked posts historyButtonClicked action", () => {
+	it("historyButtonClicked posts historyButtonClicked action on the registered provider", () => {
 		handlers["zoo-code.historyButtonClicked"]()
 
-		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("history")
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",
 			action: "historyButtonClicked",
 		})
+		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 
-	it("marketplaceButtonClicked posts marketplaceButtonClicked action", () => {
+	it("marketplaceButtonClicked posts marketplaceButtonClicked action on the registered provider", () => {
 		handlers["zoo-code.marketplaceButtonClicked"]()
 
-		expect(mockVisibleProvider.postMessageToWebview).toHaveBeenCalledWith({
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
 			type: "action",
 			action: "marketplaceButtonClicked",
 		})
+		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
+	})
+
+	// The `*InTab` handlers serve the `editor/title` menu: they target the
+	// instance that owns the tracked tab panel, resolved via
+	// ClineProvider.getInstanceForView.
+	const tabHandlerCases: { command: string; actions: string[]; telemetry?: string }[] = [
+		{
+			command: "zoo-code.settingsButtonClickedInTab",
+			actions: ["settingsButtonClicked", "didBecomeVisible"],
+			telemetry: "settings",
+		},
+		{ command: "zoo-code.historyButtonClickedInTab", actions: ["historyButtonClicked"], telemetry: "history" },
+		{ command: "zoo-code.marketplaceButtonClickedInTab", actions: ["marketplaceButtonClicked"] },
+	]
+	it.each(tabHandlerCases)(
+		"$command targets the tab instance for the tracked tab panel",
+		({ command, actions, telemetry }) => {
+			const mockTabProvider = { postMessageToWebview: vi.fn().mockResolvedValue(undefined) }
+			setPanel({} as vscode.WebviewPanel, "tab")
+			;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
+
+			handlers[command]()
+
+			for (const action of actions) {
+				expect(mockTabProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action })
+			}
+			expect(mockTabProvider.postMessageToWebview).toHaveBeenCalledTimes(actions.length)
+			if (telemetry) {
+				expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith(telemetry)
+			}
+			expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+		},
+	)
+
+	// The `*InTab` handlers must no-op when there is no live tab instance: a
+	// missing or disposed tab must not crash the handler or fall back to
+	// another instance. Every handler is awaited, so an async handler that
+	// slipped past its guard (rejecting on the missing instance) fails the
+	// test instead of settling as an unhandled rejection.
+	const inTabNoOpCommands = [
+		"zoo-code.plusButtonClickedInTab",
+		"zoo-code.settingsButtonClickedInTab",
+		"zoo-code.historyButtonClickedInTab",
+		"zoo-code.marketplaceButtonClickedInTab",
+	]
+	it.each(inTabNoOpCommands)("$command is a no-op when no tab panel is tracked", async (command) => {
+		await handlers[command]()
+
+		expect(ClineProvider.getInstanceForView as Mock).not.toHaveBeenCalled()
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
+	})
+
+	it.each(inTabNoOpCommands)("$command is a no-op when the tab instance is disposed", async (command) => {
+		setPanel({} as vscode.WebviewPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(undefined)
+
+		await handlers[command]()
+
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 
 	it("acceptInput posts acceptInput message", () => {
@@ -302,43 +364,137 @@ describe("registerCommands handlers", () => {
 		})
 	})
 
-	it("focusInput does not post when no sidebar panel is active", async () => {
+	it("focusInput does not post when no sidebar panel is tracked", async () => {
 		await handlers["zoo-code.focusInput"]()
 
 		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 
-	// Representative coverage for the .catch arm on all five void-prefixed
-	// postMessageToWebview sites in registerCommands.ts (settingsButtonClicked
-	// posts twice, plus historyButtonClicked, marketplaceButtonClicked, and
-	// acceptInput). Each handler is synchronous, so the .catch arm runs on a
-	// microtask; setImmediate ensures all microtasks are flushed before we assert. The
+	it("focusInput does not post when a tab panel is tracked alongside the sidebar", async () => {
+		setPanel({} as vscode.WebviewView, "sidebar")
+		setPanel({} as vscode.WebviewPanel, "tab")
+
+		await handlers["zoo-code.focusInput"]()
+
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+	})
+
+	it("setPanel keeps independent refs: clearing only the tab ref re-enables the sidebar post", async () => {
+		setPanel({} as vscode.WebviewView, "sidebar")
+		setPanel({} as vscode.WebviewPanel, "tab")
+
+		// The tab ref does not wipe the sidebar ref...
+		await handlers["zoo-code.focusInput"]()
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+
+		// ...and clearing only the tab ref re-enables the sidebar post.
+		setPanel(undefined, "tab")
+		await handlers["zoo-code.focusInput"]()
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "focusInput" })
+	})
+
+	// Coverage for the .catch arm on the sidebar title-bar post sites
+	// (settingsButtonClicked posts twice, plus historyButtonClicked and
+	// marketplaceButtonClicked) and acceptInput (the visible-provider path).
+	// Each handler is synchronous, so the .catch arm runs on a microtask;
+	// setImmediate ensures all microtasks are flushed before we assert. The
 	// log messages carry a `[<handlerName>]` prefix so multi-failure logs
 	// remain unambiguous; the prefix is per-handler, not per-call (both of
-	// settingsButtonClicked's posts share the same prefix).
+	// settingsButtonClicked's posts share the same prefix). Each post rejects
+	// with its own error and call N is pinned to post N, so a mutant that
+	// alters one catch's message cannot hide behind the other post's
+	// identical log.
 	it.each([
-		{ command: "zoo-code.settingsButtonClicked", prefix: "settingsButtonClicked", expectedCalls: 2 },
-		{ command: "zoo-code.historyButtonClicked", prefix: "historyButtonClicked", expectedCalls: 1 },
-		{ command: "zoo-code.marketplaceButtonClicked", prefix: "marketplaceButtonClicked", expectedCalls: 1 },
-		{ command: "zoo-code.acceptInput", prefix: "acceptInput", expectedCalls: 1 },
+		{
+			command: "zoo-code.settingsButtonClicked",
+			prefix: "settingsButtonClicked",
+			errorLabels: ["first post", "second post"],
+			target: "sidebar" as const,
+		},
+		{
+			command: "zoo-code.historyButtonClicked",
+			prefix: "historyButtonClicked",
+			errorLabels: ["post"],
+			target: "sidebar" as const,
+		},
+		{
+			command: "zoo-code.marketplaceButtonClicked",
+			prefix: "marketplaceButtonClicked",
+			errorLabels: ["post"],
+			target: "sidebar" as const,
+		},
+		{ command: "zoo-code.acceptInput", prefix: "acceptInput", errorLabels: ["post"], target: "visible" as const },
 	])(
 		"$command logs to outputChannel when postMessageToWebview rejects",
-		async ({ command, prefix, expectedCalls }) => {
-			const boom = new Error("boom")
-			mockVisibleProvider.postMessageToWebview.mockReset()
-			mockVisibleProvider.postMessageToWebview.mockRejectedValue(boom)
+		async ({ command, prefix, errorLabels, target }) => {
+			const post =
+				target === "sidebar" ? mockProvider.postMessageToWebview : mockVisibleProvider.postMessageToWebview
+			post.mockReset()
+			const booms = errorLabels.map((label) => new Error(label))
+			booms.forEach((boom) => post.mockRejectedValueOnce(boom))
 
 			handlers[command]()
 
-			// Flush microtasks so the chained .catch arm runs.
+			// Flush microtasks so the chained .catch arms run.
 			await new Promise((resolve) => setImmediate(resolve))
 
-			expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(expectedCalls)
-			expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-				`[${prefix}] postMessageToWebview failed: ${boom}`,
-			)
+			expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(booms.length)
+			booms.forEach((boom, index) => {
+				expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(
+					index + 1,
+					`[${prefix}] postMessageToWebview failed: ${boom}`,
+				)
+			})
 		},
 	)
+
+	// The two posts reject with distinct errors and the nth-call assertions
+	// pin each catch's message, so neither template literal can survive
+	// behind the other post's identical log.
+	it("settingsButtonClickedInTab logs to outputChannel when postMessageToWebview rejects", async () => {
+		const booms = [new Error("first post"), new Error("second post")]
+		const mockTabProvider = {
+			postMessageToWebview: vi.fn().mockRejectedValueOnce(booms[0]).mockRejectedValueOnce(booms[1]),
+		}
+		setPanel({} as vscode.WebviewPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
+
+		handlers["zoo-code.settingsButtonClickedInTab"]()
+
+		// Flush microtasks so the chained .catch arms run.
+		await new Promise((resolve) => setImmediate(resolve))
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(2)
+		expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(
+			1,
+			`[settingsButtonClickedInTab] postMessageToWebview failed: ${booms[0]}`,
+		)
+		expect(mockOutputChannel.appendLine).toHaveBeenNthCalledWith(
+			2,
+			`[settingsButtonClickedInTab] postMessageToWebview failed: ${booms[1]}`,
+		)
+	})
+
+	// The history and marketplace InTab catch sites share the identical
+	// single-post pattern (their sidebar equivalents are covered by the
+	// it.each above); pin their exact messages too.
+	it.each([
+		{ command: "zoo-code.historyButtonClickedInTab", prefix: "historyButtonClickedInTab" },
+		{ command: "zoo-code.marketplaceButtonClickedInTab", prefix: "marketplaceButtonClickedInTab" },
+	])("$command logs to outputChannel when the tab postMessageToWebview rejects", async ({ command, prefix }) => {
+		const boom = new Error("post")
+		const mockTabProvider = { postMessageToWebview: vi.fn().mockRejectedValue(boom) }
+		setPanel({} as vscode.WebviewPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
+
+		handlers[command]()
+
+		// Flush microtasks so the chained .catch arm runs.
+		await new Promise((resolve) => setImmediate(resolve))
+
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledTimes(1)
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(`[${prefix}] postMessageToWebview failed: ${boom}`)
+	})
 
 	it("toggleAutoApprove logs to outputChannel when postMessageToWebview rejects", async () => {
 		// toggleAutoApprove is `async` and awaits postMessageToWebview inside a
@@ -357,22 +513,40 @@ describe("registerCommands handlers", () => {
 		)
 	})
 
-	it("plusButtonClicked calls evictCurrentTask on the visible provider", async () => {
+	it("plusButtonClicked calls evictCurrentTask on the registered sidebar provider", async () => {
 		const evictCurrentTask = vi.fn().mockResolvedValue(undefined)
 		const refreshWorkspace = vi.fn().mockResolvedValue(undefined)
-		;(mockVisibleProvider as any).evictCurrentTask = evictCurrentTask
-		;(mockVisibleProvider as any).refreshWorkspace = refreshWorkspace
+		;(mockProvider as any).evictCurrentTask = evictCurrentTask
+		;(mockProvider as any).refreshWorkspace = refreshWorkspace
 
 		await handlers["zoo-code.plusButtonClicked"]()
 
+		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("plus")
 		expect(evictCurrentTask).toHaveBeenCalledTimes(1)
+		expect(refreshWorkspace).toHaveBeenCalledTimes(1)
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "chatButtonClicked" })
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "focusInput" })
 	})
 
-	it("plusButtonClicked is a no-op when no visible provider", async () => {
-		;(ClineProvider.getVisibleInstance as Mock).mockReturnValue(undefined)
+	it("plusButtonClickedInTab evicts and posts on the tab instance for the tracked tab panel", async () => {
+		const mockTabProvider = {
+			postMessageToWebview: vi.fn().mockResolvedValue(undefined),
+			evictCurrentTask: vi.fn().mockResolvedValue(undefined),
+			refreshWorkspace: vi.fn().mockResolvedValue(undefined),
+		}
+		setPanel({} as vscode.WebviewPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
 
-		// Should not throw even with no visible provider
-		await handlers["zoo-code.plusButtonClicked"]()
+		await handlers["zoo-code.plusButtonClickedInTab"]()
+
+		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("plus")
+		expect(mockTabProvider.evictCurrentTask).toHaveBeenCalledTimes(1)
+		expect(mockTabProvider.refreshWorkspace).toHaveBeenCalledTimes(1)
+		expect(mockTabProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "chatButtonClicked",
+		})
+		expect(mockTabProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "focusInput" })
 	})
 })
 
@@ -414,6 +588,9 @@ describe("openClineInNewTab", () => {
 	it("creates a webview panel with title 'Zoo Code'", async () => {
 		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
 
+		// No tab was tracked, so the reuse path (and its instance lookup)
+		// must not run.
+		expect(ClineProvider.getInstanceForView as Mock).not.toHaveBeenCalled()
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
 			"zoo-code.TabPanelProvider",
 			"Zoo Code",
@@ -423,5 +600,43 @@ describe("openClineInNewTab", () => {
 				retainContextWhenHidden: true,
 			}),
 		)
+	})
+
+	it("reveals the existing tab instead of creating a second panel", async () => {
+		const mockExistingProvider = { postMessageToWebview: vi.fn().mockResolvedValue(undefined) }
+		const mockPanel = {
+			webview: { postMessage: vi.fn() },
+			onDidChangeViewState: vi.fn(),
+			onDidDispose: vi.fn(),
+			reveal: vi.fn().mockResolvedValue(undefined),
+		} as unknown as vscode.WebviewPanel
+		setPanel(mockPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockExistingProvider)
+
+		const result = await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		expect(result).toBe(mockExistingProvider)
+		expect(mockPanel.reveal).toHaveBeenCalledTimes(1)
+		expect(vscode.window.createWebviewPanel).not.toHaveBeenCalled()
+		expect(mockExistingProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "didBecomeVisible",
+		})
+	})
+
+	it("creates a new tab panel when the tracked tab's provider has been disposed", async () => {
+		const mockPanel = {
+			webview: { postMessage: vi.fn() },
+			onDidChangeViewState: vi.fn(),
+			onDidDispose: vi.fn(),
+			reveal: vi.fn().mockResolvedValue(undefined),
+		} as unknown as vscode.WebviewPanel
+		setPanel(mockPanel, "tab")
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(undefined)
+
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		expect(mockPanel.reveal).not.toHaveBeenCalled()
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -2,6 +2,7 @@ import type { Mock } from "vitest"
 import * as vscode from "vscode"
 import { TelemetryService } from "@roo-code/telemetry"
 
+import { ContextProxy } from "../../core/config/ContextProxy"
 import { ClineProvider } from "../../core/webview/ClineProvider"
 import { MdmService } from "../../services/mdm/MdmService"
 
@@ -283,7 +284,7 @@ describe("registerCommands handlers", () => {
 		"zoo-code.historyButtonClickedInTab",
 		"zoo-code.marketplaceButtonClickedInTab",
 	]
-	it.each(inTabNoOpCommands)("$command is a no-op when no tab panel is tracked", async (command) => {
+	it.each(inTabNoOpCommands)("%s is a no-op when no tab panel is tracked", async (command) => {
 		await handlers[command]()
 
 		expect(ClineProvider.getInstanceForView as Mock).not.toHaveBeenCalled()
@@ -291,12 +292,14 @@ describe("registerCommands handlers", () => {
 		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 
-	it.each(inTabNoOpCommands)("$command is a no-op when the tab instance is disposed", async (command) => {
-		setPanel({} as vscode.WebviewPanel, "tab")
+	it.each(inTabNoOpCommands)("%s is a no-op when the tab instance is disposed", async (command) => {
+		const disposedPanel = {} as vscode.WebviewPanel
+		setPanel(disposedPanel, "tab")
 		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(undefined)
 
 		await handlers[command]()
 
+		expect(ClineProvider.getInstanceForView as Mock).toHaveBeenCalledWith(disposedPanel)
 		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
 		expect(mockVisibleProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
@@ -657,6 +660,11 @@ describe("openClineInNewTab", () => {
 		expect(ctor).toHaveBeenCalledWith(mockContext, mockOutputChannel, "editor", undefined, undefined)
 		expect(provider).toBe(ctor.mock.instances[0])
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+
+		// The fallback is observable in the output channel.
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+			"[openClineInNewTab] MDM service unavailable, continuing without it: Error: MDM service not initialized",
+		)
 	})
 
 	it("opens a new group to the right and targets ViewColumn.Two when no editors are visible", async () => {
@@ -704,6 +712,27 @@ describe("openClineInNewTab", () => {
 			"zoo-code.TabPanelProvider",
 			"Zoo Code",
 			1,
+			expect.objectContaining({ enableScripts: true }),
+		)
+	})
+
+	it("places the tab panel one column right of the rightmost visible editor", async () => {
+		// openClineInNewTab only reads viewColumn from each editor, so the
+		// fixtures keep that single field.
+		;(vscode.window as unknown as { visibleTextEditors: vscode.TextEditor[] }).visibleTextEditors = [
+			{ viewColumn: 1 } as unknown as vscode.TextEditor,
+			{ viewColumn: 3 } as unknown as vscode.TextEditor,
+		]
+
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		// lastCol is 3, so the panel lands on column 4 without opening a new
+		// editor group.
+		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith("workbench.action.newGroupRight")
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+			"zoo-code.TabPanelProvider",
+			"Zoo Code",
+			4,
 			expect.objectContaining({ enableScripts: true }),
 		)
 	})
@@ -766,5 +795,122 @@ describe("openClineInNewTab", () => {
 		expect(first).toBe(constructed)
 		expect(second).toBe(constructed)
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+	})
+
+	it("shares one in-flight creation when openInNewTab and popoutButtonClicked start before it resolves", async () => {
+		// Defer the first creation at ContextProxy.getInstance so both command
+		// handlers can start while the creation is still in flight.
+		let resolveContextProxy!: () => void
+		;(ContextProxy.getInstance as Mock).mockReturnValue(
+			new Promise<void>((resolve) => {
+				resolveContextProxy = resolve
+			}),
+		)
+
+		const commandHandlers: Record<string, (...args: unknown[]) => unknown> = {}
+		;(vscode.commands.registerCommand as Mock).mockImplementation(
+			(id: string, cb: (...args: unknown[]) => unknown) => {
+				commandHandlers[id] = cb
+				return { dispose: vi.fn() }
+			},
+		)
+		const sidebarProvider = { postMessageToWebview: vi.fn().mockResolvedValue(undefined) }
+		registerCommands({
+			context: mockContext,
+			outputChannel: mockOutputChannel,
+			provider: sidebarProvider as unknown as ClineProvider,
+		})
+
+		const started = [commandHandlers["zoo-code.openInNewTab"](), commandHandlers["zoo-code.popoutButtonClicked"]()]
+
+		// While the shared creation is suspended at ContextProxy.getInstance,
+		// neither caller has created a panel yet.
+		expect(vscode.window.createWebviewPanel).not.toHaveBeenCalled()
+
+		resolveContextProxy()
+		const [first, second] = await Promise.all(started)
+
+		// Both command entry points await the shared in-flight creation:
+		// exactly one tab panel is created and both results are the same
+		// constructed provider.
+		const ctor = ClineProvider as unknown as Mock
+		const constructed = ctor.mock.instances[0]
+		expect(constructed).toBeDefined()
+		expect(first).toBe(constructed)
+		expect(second).toBe(constructed)
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+	})
+
+	it("creates a fresh panel for a new call once the previous creation settled and its provider disposed", async () => {
+		// The first open settles and tracks its panel.
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+
+		// The tracked provider is disposed, so the next open cannot reuse the
+		// existing tab: the settled (and cleared) in-flight promise must not
+		// be returned, and a fresh panel is created.
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(undefined)
+
+		const secondProvider = await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		const ctor = ClineProvider as unknown as Mock
+		const second = ctor.mock.instances[1]
+		expect(second).toBeDefined()
+		expect(secondProvider).toBe(second)
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(2)
+	})
+
+	it("keeps the replacement panel tracked when a stale panel's disposal fires late", async () => {
+		// Capture each created panel so the first panel's (stale) dispose
+		// handler can fire after the replacement is already tracked.
+		const createdPanels: { onDidDispose: Mock }[] = []
+		;(vscode.window.createWebviewPanel as Mock).mockImplementation(() => {
+			const panel = {
+				webview: { postMessage: vi.fn() },
+				onDidChangeViewState: vi.fn(),
+				onDidDispose: vi.fn(),
+			}
+			createdPanels.push(panel)
+			return panel
+		})
+
+		// First open creates and tracks panel A.
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+		expect(getPanel()).toBe(createdPanels[0])
+
+		// Panel A's provider is disposed before the second open, so the
+		// second open creates the replacement panel B.
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(undefined)
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(2)
+		expect(getPanel()).toBe(createdPanels[1])
+
+		// Panel A's stale dispose handler fires after the replacement is
+		// tracked; it must not clobber the replacement's ref.
+		createdPanels[0].onDidDispose.mock.calls[0][0]()
+
+		expect(getPanel()).toBe(createdPanels[1])
+
+		// Tab-surface commands still reach the provider that owns the
+		// replacement panel after the stale disposal.
+		const replacementProvider = { postMessageToWebview: vi.fn().mockResolvedValue(undefined) }
+		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(replacementProvider)
+		const commandHandlers: Record<string, (...args: unknown[]) => unknown> = {}
+		;(vscode.commands.registerCommand as Mock).mockImplementation(
+			(id: string, cb: (...args: unknown[]) => unknown) => {
+				commandHandlers[id] = cb
+				return { dispose: vi.fn() }
+			},
+		)
+		registerCommands({
+			context: mockContext,
+			outputChannel: mockOutputChannel,
+			provider: {} as ClineProvider,
+		})
+		await commandHandlers["zoo-code.historyButtonClickedInTab"]()
+		expect(replacementProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "action",
+			action: "historyButtonClicked",
+		})
 	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -3,8 +3,9 @@ import * as vscode from "vscode"
 import { TelemetryService } from "@roo-code/telemetry"
 
 import { ClineProvider } from "../../core/webview/ClineProvider"
+import { MdmService } from "../../services/mdm/MdmService"
 
-import { getVisibleProviderOrLog, openClineInNewTab, registerCommands, setPanel } from "../registerCommands"
+import { getPanel, getVisibleProviderOrLog, openClineInNewTab, registerCommands, setPanel } from "../registerCommands"
 
 vi.mock("execa", () => ({
 	execa: vi.fn(),
@@ -641,6 +642,113 @@ describe("openClineInNewTab", () => {
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
 	})
 
+	it("falls back to an undefined MdmService when MdmService.getInstance throws", async () => {
+		;(MdmService.getInstance as Mock).mockImplementation(() => {
+			throw new Error("MDM service not initialized")
+		})
+
+		const provider = await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		// The creation must survive the MDM lookup failure: the provider is
+		// constructed with an undefined MDM service and the tab panel is
+		// still created.
+		const ctor = ClineProvider as unknown as Mock
+		expect(ctor.mock.instances[0]).toBeDefined()
+		expect(ctor).toHaveBeenCalledWith(mockContext, mockOutputChannel, "editor", undefined, undefined)
+		expect(provider).toBe(ctor.mock.instances[0])
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+	})
+
+	it("opens a new group to the right and targets ViewColumn.Two when no editors are visible", async () => {
+		;(vscode.window as unknown as { visibleTextEditors: vscode.TextEditor[] }).visibleTextEditors = []
+
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		expect(vscode.commands.executeCommand).toHaveBeenCalledWith("workbench.action.newGroupRight")
+		expect(vscode.commands.executeCommand).toHaveBeenCalledWith("workbench.action.lockEditorGroup")
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+			"zoo-code.TabPanelProvider",
+			"Zoo Code",
+			vscode.ViewColumn.Two,
+			{
+				enableScripts: true,
+				retainContextWhenHidden: true,
+				localResourceRoots: [mockContext.extensionUri],
+			},
+		)
+
+		// The panel icon points at the extension's asset files.
+		const panel = (vscode.window.createWebviewPanel as Mock).mock.results[0].value as {
+			iconPath?: { light: { path: string }; dark: { path: string } }
+		}
+		expect(panel.iconPath).toEqual({
+			light: { path: "assets/icons/panel_light.png" },
+			dark: { path: "assets/icons/panel_dark.png" },
+		})
+	})
+
+	it("treats editors without a viewColumn as column 0 when computing the target column", async () => {
+		// openClineInNewTab only reads viewColumn from each editor, so the
+		// fixture keeps that single field.
+		const editorWithoutColumn = { viewColumn: undefined } as unknown as vscode.TextEditor
+		;(vscode.window as unknown as { visibleTextEditors: vscode.TextEditor[] }).visibleTextEditors = [
+			editorWithoutColumn,
+		]
+
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		// lastCol falls back to 0, so the panel lands on column 1 instead of
+		// opening a new editor group.
+		expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith("workbench.action.newGroupRight")
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledWith(
+			"zoo-code.TabPanelProvider",
+			"Zoo Code",
+			1,
+			expect.objectContaining({ enableScripts: true }),
+		)
+	})
+
+	it("constructs the tab provider with the 'editor' context and the live MdmService instance", async () => {
+		const mockMdm = { name: "mock-mdm" }
+		// MdmService has a private constructor, so pin a sentinel stand-in.
+		;(MdmService.getInstance as Mock).mockReturnValue(mockMdm as unknown as MdmService)
+
+		const provider = await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		const ctor = ClineProvider as unknown as Mock
+		expect(ctor).toHaveBeenCalledTimes(1)
+		expect(ctor).toHaveBeenCalledWith(mockContext, mockOutputChannel, "editor", undefined, mockMdm)
+		expect(provider).toBe(ctor.mock.instances[0])
+	})
+
+	it("posts didBecomeVisible only for visible state changes and clears the tracked tab on dispose", async () => {
+		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
+
+		expect(getPanel()).toBeDefined()
+
+		const panel = (vscode.window.createWebviewPanel as Mock).mock.results[0].value as {
+			onDidChangeViewState: Mock
+			onDidDispose: Mock
+		}
+		const stateHandler = panel.onDidChangeViewState.mock.calls[0][0] as (event: {
+			webviewPanel: { visible: boolean; webview: { postMessage: (message: unknown) => void } }
+		}) => void
+		const visibleEvent = { webviewPanel: { visible: true, webview: { postMessage: vi.fn() } } }
+		stateHandler(visibleEvent)
+		expect(visibleEvent.webviewPanel.webview.postMessage).toHaveBeenCalledWith({
+			type: "action",
+			action: "didBecomeVisible",
+		})
+
+		const hiddenEvent = { webviewPanel: { visible: false, webview: { postMessage: vi.fn() } } }
+		stateHandler(hiddenEvent)
+		expect(hiddenEvent.webviewPanel.webview.postMessage).not.toHaveBeenCalled()
+
+		const disposeHandler = panel.onDidDispose.mock.calls[0][0] as () => void
+		disposeHandler()
+		expect(getPanel()).toBeUndefined()
+	})
+
 	it("serializes concurrent opens so overlapping calls create one panel and share one provider", async () => {
 		const [first, second] = await Promise.all([
 			openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel }),
@@ -648,9 +756,15 @@ describe("openClineInNewTab", () => {
 		])
 
 		// Overlapping "Open in editor" calls must share the in-flight
-		// creation: exactly one tab panel is created and both callers
-		// receive the same provider.
-		expect(first).toBe(second)
+		// creation: exactly one tab panel is created and both callers receive
+		// the same constructed provider. Pinning both results against the
+		// mocked constructor (not just against each other) keeps the test
+		// failing if the shared result is undefined.
+		const ctor = ClineProvider as unknown as Mock
+		const constructed = ctor.mock.instances[0]
+		expect(constructed).toBeDefined()
+		expect(first).toBe(constructed)
+		expect(second).toBe(constructed)
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -136,7 +136,11 @@ describe("registerCommands handlers", () => {
 	let mockOutputChannel: vscode.OutputChannel
 	let mockContext: vscode.ExtensionContext
 	let mockVisibleProvider: { postMessageToWebview: Mock }
-	let mockProvider: { postMessageToWebview: Mock }
+	let mockProvider: {
+		postMessageToWebview: Mock
+		evictCurrentTask: Mock
+		refreshWorkspace: Mock
+	}
 	let handlers: Record<string, (...args: unknown[]) => unknown>
 
 	beforeEach(() => {
@@ -164,6 +168,8 @@ describe("registerCommands handlers", () => {
 
 		mockProvider = {
 			postMessageToWebview: vi.fn().mockResolvedValue(undefined),
+			evictCurrentTask: vi.fn().mockResolvedValue(undefined),
+			refreshWorkspace: vi.fn().mockResolvedValue(undefined),
 		}
 		;(ClineProvider.getVisibleInstance as Mock).mockReturnValue(mockVisibleProvider)
 		;(vscode.commands.registerCommand as Mock).mockImplementation(
@@ -514,16 +520,11 @@ describe("registerCommands handlers", () => {
 	})
 
 	it("plusButtonClicked calls evictCurrentTask on the registered sidebar provider", async () => {
-		const evictCurrentTask = vi.fn().mockResolvedValue(undefined)
-		const refreshWorkspace = vi.fn().mockResolvedValue(undefined)
-		;(mockProvider as any).evictCurrentTask = evictCurrentTask
-		;(mockProvider as any).refreshWorkspace = refreshWorkspace
-
 		await handlers["zoo-code.plusButtonClicked"]()
 
 		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("plus")
-		expect(evictCurrentTask).toHaveBeenCalledTimes(1)
-		expect(refreshWorkspace).toHaveBeenCalledTimes(1)
+		expect(mockProvider.evictCurrentTask).toHaveBeenCalledTimes(1)
+		expect(mockProvider.refreshWorkspace).toHaveBeenCalledTimes(1)
 		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "chatButtonClicked" })
 		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action: "focusInput" })
 	})
@@ -637,6 +638,19 @@ describe("openClineInNewTab", () => {
 		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
 
 		expect(mockPanel.reveal).not.toHaveBeenCalled()
+		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
+	})
+
+	it("serializes concurrent opens so overlapping calls create one panel and share one provider", async () => {
+		const [first, second] = await Promise.all([
+			openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel }),
+			openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel }),
+		])
+
+		// Overlapping "Open in editor" calls must share the in-flight
+		// creation: exactly one tab panel is created and both callers
+		// receive the same provider.
+		expect(first).toBe(second)
 		expect(vscode.window.createWebviewPanel).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -257,11 +257,17 @@ describe("registerCommands handlers", () => {
 		"$command targets the tab instance for the tracked tab panel",
 		({ command, actions, telemetry }) => {
 			const mockTabProvider = { postMessageToWebview: vi.fn().mockResolvedValue(undefined) }
-			setPanel({} as vscode.WebviewPanel, "tab")
+			// Retain the tracked tab panel and pin the instance lookup
+			// against its identity: a handler that resolved the sidebar view
+			// or any other view must fail instead of passing on the stubbed
+			// provider result alone.
+			const tabPanel = {} as vscode.WebviewPanel
+			setPanel(tabPanel, "tab")
 			;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
 
 			handlers[command]()
 
+			expect(ClineProvider.getInstanceForView as Mock).toHaveBeenCalledWith(tabPanel)
 			for (const action of actions) {
 				expect(mockTabProvider.postMessageToWebview).toHaveBeenCalledWith({ type: "action", action })
 			}
@@ -539,11 +545,15 @@ describe("registerCommands handlers", () => {
 			evictCurrentTask: vi.fn().mockResolvedValue(undefined),
 			refreshWorkspace: vi.fn().mockResolvedValue(undefined),
 		}
-		setPanel({} as vscode.WebviewPanel, "tab")
+		// Same identity pin as the other InTab cases: the eviction must run
+		// against the provider resolved from the exact tracked tab panel.
+		const tabPanel = {} as vscode.WebviewPanel
+		setPanel(tabPanel, "tab")
 		;(ClineProvider.getInstanceForView as Mock).mockReturnValue(mockTabProvider)
 
 		await handlers["zoo-code.plusButtonClickedInTab"]()
 
+		expect(ClineProvider.getInstanceForView as Mock).toHaveBeenCalledWith(tabPanel)
 		expect(TelemetryService.instance.captureTitleButtonClicked).toHaveBeenCalledWith("plus")
 		expect(mockTabProvider.evictCurrentTask).toHaveBeenCalledTimes(1)
 		expect(mockTabProvider.refreshWorkspace).toHaveBeenCalledTimes(1)

--- a/src/activate/__tests__/registerCommands.spec.ts
+++ b/src/activate/__tests__/registerCommands.spec.ts
@@ -753,12 +753,15 @@ describe("openClineInNewTab", () => {
 	it("posts didBecomeVisible only for visible state changes and clears the tracked tab on dispose", async () => {
 		await openClineInNewTab({ context: mockContext, outputChannel: mockOutputChannel })
 
-		expect(getPanel()).toBeDefined()
-
+		// Retain the panel returned during creation and pin the tracked tab
+		// against it with identity (not a weak defined check), so a wrong or
+		// duplicated tracked panel fails before the dispose assertions.
 		const panel = (vscode.window.createWebviewPanel as Mock).mock.results[0].value as {
 			onDidChangeViewState: Mock
 			onDidDispose: Mock
 		}
+		expect(getPanel()).toBe(panel)
+
 		const stateHandler = panel.onDidChangeViewState.mock.calls[0][0] as (event: {
 			webviewPanel: { visible: boolean; webview: { postMessage: (message: unknown) => void } }
 		}) => void

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -41,7 +41,12 @@ export function getPanel(): vscode.WebviewPanel | vscode.WebviewView | undefined
 }
 
 /**
- * Set panel references
+ * Set panel references.
+ *
+ * The two refs are independent: each surface keeps its own ref for its whole
+ * lifetime, so resolving the sidebar view never wipes a live tab panel (and
+ * vice versa). Callers pass `undefined` only when the surface itself is
+ * disposed (see the `onDidDispose` wiring in `openClineInNewTab`).
  */
 export function setPanel(
 	newPanel: vscode.WebviewPanel | vscode.WebviewView | undefined,
@@ -49,11 +54,20 @@ export function setPanel(
 ): void {
 	if (type === "sidebar") {
 		sidebarPanel = newPanel as vscode.WebviewView
-		tabPanel = undefined
 	} else {
 		tabPanel = newPanel as vscode.WebviewPanel
-		sidebarPanel = undefined
 	}
+}
+
+/**
+ * The instance that owns the tracked tab panel, if it is still alive.
+ *
+ * Title-bar commands on the editor-tab surface use this instead of the
+ * visible-instance heuristic, so a click on the tab's title bar always
+ * targets that tab even when the sidebar is visible side-by-side.
+ */
+function getTabProvider(): ClineProvider | undefined {
+	return tabPanel ? ClineProvider.getInstanceForView(tabPanel) : undefined
 }
 
 export type RegisterCommandOptions = {
@@ -91,21 +105,35 @@ const getCommandsMap = ({
 	provider,
 }: RegisterCommandOptions): Record<Exclude<CommandId, "showRipgrepDiagnostic">, CommandCallback> => ({
 	activationCompleted: () => {},
+	// The `view/title` menu is scoped to the sidebar view, so the click
+	// origin of these handlers is the sidebar provider wired in at
+	// activation (`provider`). Target it directly instead of the
+	// visible-instance heuristic, which would follow the user's focus to a
+	// tab instance when both surfaces are open side-by-side. The `*InTab`
+	// variants serve the `editor/title` menu and target the tab instance
+	// through `getTabProvider()` instead.
 	plusButtonClicked: async () => {
-		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		TelemetryService.instance.captureTitleButtonClicked("plus")
 
-		if (!visibleProvider) {
+		await provider.evictCurrentTask()
+		await provider.refreshWorkspace()
+		await provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
+		// Send focusInput action immediately after chatButtonClicked
+		// This ensures the focus happens after the view has switched
+		await provider.postMessageToWebview({ type: "action", action: "focusInput" })
+	},
+	plusButtonClickedInTab: async () => {
+		const tabProvider = getTabProvider()
+		if (!tabProvider) {
 			return
 		}
 
 		TelemetryService.instance.captureTitleButtonClicked("plus")
 
-		await visibleProvider.evictCurrentTask()
-		await visibleProvider.refreshWorkspace()
-		await visibleProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
-		// Send focusInput action immediately after chatButtonClicked
-		// This ensures the focus happens after the view has switched
-		await visibleProvider.postMessageToWebview({ type: "action", action: "focusInput" })
+		await tabProvider.evictCurrentTask()
+		await tabProvider.refreshWorkspace()
+		await tabProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
+		await tabProvider.postMessageToWebview({ type: "action", action: "focusInput" })
 	},
 	popoutButtonClicked: () => {
 		TelemetryService.instance.captureTitleButtonClicked("popout")
@@ -114,42 +142,72 @@ const getCommandsMap = ({
 	},
 	openInNewTab: () => openClineInNewTab({ context, outputChannel }),
 	settingsButtonClicked: () => {
-		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		if (!visibleProvider) {
+		void provider
+			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
+			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
+		// Also explicitly post the visibility message to trigger scroll reliably
+		void provider
+			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
+	},
+	settingsButtonClickedInTab: () => {
+		const tabProvider = getTabProvider()
+		if (!tabProvider) {
 			return
 		}
 
 		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		void visibleProvider
+		void tabProvider
 			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
-		// Also explicitly post the visibility message to trigger scroll reliably
-		void visibleProvider
+			.catch((error) =>
+				outputChannel.appendLine(`[settingsButtonClickedInTab] postMessageToWebview failed: ${error}`),
+			)
+		void tabProvider
 			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
+			.catch((error) =>
+				outputChannel.appendLine(`[settingsButtonClickedInTab] postMessageToWebview failed: ${error}`),
+			)
 	},
 	historyButtonClicked: () => {
-		const visibleProvider = getVisibleProviderOrLog(outputChannel)
+		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		if (!visibleProvider) {
+		void provider
+			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
+			.catch((error) => outputChannel.appendLine(`[historyButtonClicked] postMessageToWebview failed: ${error}`))
+	},
+	historyButtonClickedInTab: () => {
+		const tabProvider = getTabProvider()
+		if (!tabProvider) {
 			return
 		}
 
 		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		void visibleProvider
+		void tabProvider
 			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`[historyButtonClicked] postMessageToWebview failed: ${error}`))
+			.catch((error) =>
+				outputChannel.appendLine(`[historyButtonClickedInTab] postMessageToWebview failed: ${error}`),
+			)
 	},
 	marketplaceButtonClicked: () => {
-		const visibleProvider = getVisibleProviderOrLog(outputChannel)
-		if (!visibleProvider) return
-		void visibleProvider
+		void provider
 			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
 			.catch((error) =>
 				outputChannel.appendLine(`[marketplaceButtonClicked] postMessageToWebview failed: ${error}`),
+			)
+	},
+	marketplaceButtonClickedInTab: () => {
+		const tabProvider = getTabProvider()
+		if (!tabProvider) {
+			return
+		}
+		void tabProvider
+			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
+			.catch((error) =>
+				outputChannel.appendLine(`[marketplaceButtonClickedInTab] postMessageToWebview failed: ${error}`),
 			)
 	},
 	newTask: handleNewTask,
@@ -177,8 +235,11 @@ const getCommandsMap = ({
 		try {
 			await focusPanel(tabPanel, sidebarPanel)
 
-			// Send focus input message only for sidebar panels
-			if (sidebarPanel && getPanel() === sidebarPanel) {
+			// Send focus input message only when the sidebar panel was
+			// focused: the tab takes selection priority in focusPanel, so
+			// the sidebar receives the message only when no tab panel is
+			// tracked.
+			if (sidebarPanel && !tabPanel) {
 				await provider.postMessageToWebview({ type: "action", action: "focusInput" })
 			}
 		} catch (error) {
@@ -222,6 +283,17 @@ const getCommandsMap = ({
 })
 
 export const openClineInNewTab = async ({ context, outputChannel }: Omit<RegisterCommandOptions, "provider">) => {
+	// Reuse the tracked tab instead of opening a second one: a repeated
+	// "Open in editor" click reveals the existing tab's panel.
+	if (tabPanel) {
+		const existingProvider = ClineProvider.getInstanceForView(tabPanel)
+		if (existingProvider) {
+			await tabPanel.reveal()
+			await existingProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+			return existingProvider
+		}
+	}
+
 	// (This example uses webviewProvider activation event which is necessary to
 	// deserialize cached webview, but since we use retainContextWhenHidden, we
 	// don't need to use that event).

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -32,6 +32,12 @@ export function getVisibleProviderOrLog(outputChannel: vscode.OutputChannel): Cl
 let sidebarPanel: vscode.WebviewView | undefined = undefined
 let tabPanel: vscode.WebviewPanel | undefined = undefined
 
+// In-flight "open in editor" creation shared by overlapping calls: a
+// double-click starts before the first call tracks its new panel, so
+// concurrent callers must share one creation instead of racing to create
+// two tab panels.
+let pendingTabPanelCreation: Promise<ClineProvider> | undefined
+
 /**
  * Get the currently active panel
  * @returns WebviewPanel或WebviewView
@@ -283,88 +289,109 @@ const getCommandsMap = ({
 })
 
 export const openClineInNewTab = async ({ context, outputChannel }: Omit<RegisterCommandOptions, "provider">) => {
-	// Reuse the tracked tab instead of opening a second one: a repeated
-	// "Open in editor" click reveals the existing tab's panel.
-	if (tabPanel) {
-		const existingProvider = ClineProvider.getInstanceForView(tabPanel)
-		if (existingProvider) {
-			await tabPanel.reveal()
-			await existingProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-			return existingProvider
-		}
+	// Serialize overlapping "Open in editor" calls: a double-click starts
+	// before the first call tracks its new panel, so without a shared
+	// in-flight creation both calls would race to create two tab panels.
+	// Concurrent callers await the same promise: exactly one panel is
+	// created and every caller receives the same provider.
+	if (pendingTabPanelCreation) {
+		return pendingTabPanelCreation
 	}
 
-	// (This example uses webviewProvider activation event which is necessary to
-	// deserialize cached webview, but since we use retainContextWhenHidden, we
-	// don't need to use that event).
-	// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
-	const contextProxy = await ContextProxy.getInstance(context)
-	const codeIndexManager = CodeIndexManager.getInstance(context)
-
-	// Get the existing MDM service instance to ensure consistent policy enforcement
-	let mdmService: MdmService | undefined
-	try {
-		mdmService = MdmService.getInstance()
-	} catch (error) {
-		// MDM service not initialized, which is fine - extension can work without it
-		mdmService = undefined
-	}
-
-	const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, mdmService)
-	const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
-
-	// Check if there are any visible text editors, otherwise open a new group
-	// to the right.
-	const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
-
-	if (!hasVisibleEditors) {
-		await vscode.commands.executeCommand("workbench.action.newGroupRight")
-	}
-
-	const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
-
-	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Zoo Code", targetCol, {
-		enableScripts: true,
-		retainContextWhenHidden: true,
-		localResourceRoots: [context.extensionUri],
-	})
-
-	// Save as tab type panel.
-	setPanel(newPanel, "tab")
-
-	// TODO: Use better svg icon with light and dark variants (see
-	// https://stackoverflow.com/questions/58365687/vscode-extension-iconpath).
-	newPanel.iconPath = {
-		light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_light.png"),
-		dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_dark.png"),
-	}
-
-	await tabProvider.resolveWebviewView(newPanel)
-
-	// Add listener for visibility changes to notify webview
-	newPanel.onDidChangeViewState(
-		(e) => {
-			const panel = e.webviewPanel
-			if (panel.visible) {
-				panel.webview.postMessage({ type: "action", action: "didBecomeVisible" }) // Use the same message type as in SettingsView.tsx
+	const creation = (async () => {
+		// Reuse the tracked tab instead of opening a second one: a repeated
+		// "Open in editor" click reveals the existing tab's panel.
+		if (tabPanel) {
+			const existingProvider = ClineProvider.getInstanceForView(tabPanel)
+			if (existingProvider) {
+				await tabPanel.reveal()
+				await existingProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+				return existingProvider
 			}
-		},
-		null, // First null is for `thisArgs`
-		context.subscriptions, // Register listener for disposal
-	)
+		}
 
-	// Handle panel closing events.
-	newPanel.onDidDispose(
-		() => {
-			setPanel(undefined, "tab")
-		},
-		null,
-		context.subscriptions, // Also register dispose listener
-	)
+		// (This example uses webviewProvider activation event which is necessary to
+		// deserialize cached webview, but since we use retainContextWhenHidden, we
+		// don't need to use that event).
+		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
+		const contextProxy = await ContextProxy.getInstance(context)
+		const codeIndexManager = CodeIndexManager.getInstance(context)
 
-	// Lock the editor group so clicking on files doesn't open them over the panel.
-	await delay(100)
-	await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
+		// Get the existing MDM service instance to ensure consistent policy enforcement
+		let mdmService: MdmService | undefined
+		try {
+			mdmService = MdmService.getInstance()
+		} catch (error) {
+			// MDM service not initialized, which is fine - extension can work without it
+			mdmService = undefined
+		}
 
-	return tabProvider
+		const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, mdmService)
+		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
+
+		// Check if there are any visible text editors, otherwise open a new group
+		// to the right.
+		const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
+
+		if (!hasVisibleEditors) {
+			await vscode.commands.executeCommand("workbench.action.newGroupRight")
+		}
+
+		const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
+
+		const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Zoo Code", targetCol, {
+			enableScripts: true,
+			retainContextWhenHidden: true,
+			localResourceRoots: [context.extensionUri],
+		})
+
+		// Save as tab type panel.
+		setPanel(newPanel, "tab")
+
+		// TODO: Use better svg icon with light and dark variants (see
+		// https://stackoverflow.com/questions/58365687/vscode-extension-iconpath).
+		newPanel.iconPath = {
+			light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_light.png"),
+			dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_dark.png"),
+		}
+
+		await tabProvider.resolveWebviewView(newPanel)
+
+		// Add listener for visibility changes to notify webview
+		newPanel.onDidChangeViewState(
+			(e) => {
+				const panel = e.webviewPanel
+				if (panel.visible) {
+					panel.webview.postMessage({ type: "action", action: "didBecomeVisible" }) // Use the same message type as in SettingsView.tsx
+				}
+			},
+			null, // First null is for `thisArgs`
+			context.subscriptions, // Register listener for disposal
+		)
+
+		// Handle panel closing events.
+		newPanel.onDidDispose(
+			() => {
+				setPanel(undefined, "tab")
+			},
+			null,
+			context.subscriptions, // Also register dispose listener
+		)
+
+		// Lock the editor group so clicking on files doesn't open them over the panel.
+		await delay(100)
+		await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
+
+		return tabProvider
+	})()
+
+	pendingTabPanelCreation = creation
+
+	try {
+		return await creation
+	} finally {
+		// Clear once settled (success or failure) so the next call starts
+		// fresh: the reuse path above then takes over for the tracked panel.
+		pendingTabPanelCreation = undefined
+	}
 }

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import delay from "delay"
 
-import type { CommandId } from "@roo-code/types"
+import type { CommandId, ExtensionMessage } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
 
 import { Package } from "../shared/package"
@@ -105,6 +105,23 @@ export const registerCommands = (options: RegisterCommandOptions) => {
 // `filePath?: string`, others take none) and VS Code dispatches positional
 // args dynamically.
 type CommandCallback = (...args: any[]) => unknown
+
+// Posts each action in order to the target instance. Failures are logged
+// (not thrown) with the handler-specific prefix so a failed post stays
+// attributable in the output channel.
+const postActions = (
+	outputChannel: vscode.OutputChannel,
+	target: ClineProvider,
+	actions: readonly NonNullable<ExtensionMessage["action"]>[],
+	logPrefix: string,
+) => {
+	for (const action of actions) {
+		void target
+			.postMessageToWebview({ type: "action", action })
+			.catch((error) => outputChannel.appendLine(`[${logPrefix}] postMessageToWebview failed: ${error}`))
+	}
+}
+
 const getCommandsMap = ({
 	context,
 	outputChannel,
@@ -150,13 +167,8 @@ const getCommandsMap = ({
 	settingsButtonClicked: () => {
 		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		void provider
-			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
-		// Also explicitly post the visibility message to trigger scroll reliably
-		void provider
-			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-			.catch((error) => outputChannel.appendLine(`[settingsButtonClicked] postMessageToWebview failed: ${error}`))
+		// Also explicitly post the visibility message to trigger scroll reliably.
+		postActions(outputChannel, provider, ["settingsButtonClicked", "didBecomeVisible"], "settingsButtonClicked")
 	},
 	settingsButtonClickedInTab: () => {
 		const tabProvider = getTabProvider()
@@ -166,23 +178,17 @@ const getCommandsMap = ({
 
 		TelemetryService.instance.captureTitleButtonClicked("settings")
 
-		void tabProvider
-			.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
-			.catch((error) =>
-				outputChannel.appendLine(`[settingsButtonClickedInTab] postMessageToWebview failed: ${error}`),
-			)
-		void tabProvider
-			.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-			.catch((error) =>
-				outputChannel.appendLine(`[settingsButtonClickedInTab] postMessageToWebview failed: ${error}`),
-			)
+		postActions(
+			outputChannel,
+			tabProvider,
+			["settingsButtonClicked", "didBecomeVisible"],
+			"settingsButtonClickedInTab",
+		)
 	},
 	historyButtonClicked: () => {
 		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		void provider
-			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
-			.catch((error) => outputChannel.appendLine(`[historyButtonClicked] postMessageToWebview failed: ${error}`))
+		postActions(outputChannel, provider, ["historyButtonClicked"], "historyButtonClicked")
 	},
 	historyButtonClickedInTab: () => {
 		const tabProvider = getTabProvider()
@@ -192,29 +198,17 @@ const getCommandsMap = ({
 
 		TelemetryService.instance.captureTitleButtonClicked("history")
 
-		void tabProvider
-			.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
-			.catch((error) =>
-				outputChannel.appendLine(`[historyButtonClickedInTab] postMessageToWebview failed: ${error}`),
-			)
+		postActions(outputChannel, tabProvider, ["historyButtonClicked"], "historyButtonClickedInTab")
 	},
 	marketplaceButtonClicked: () => {
-		void provider
-			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
-			.catch((error) =>
-				outputChannel.appendLine(`[marketplaceButtonClicked] postMessageToWebview failed: ${error}`),
-			)
+		postActions(outputChannel, provider, ["marketplaceButtonClicked"], "marketplaceButtonClicked")
 	},
 	marketplaceButtonClickedInTab: () => {
 		const tabProvider = getTabProvider()
 		if (!tabProvider) {
 			return
 		}
-		void tabProvider
-			.postMessageToWebview({ type: "action", action: "marketplaceButtonClicked" })
-			.catch((error) =>
-				outputChannel.appendLine(`[marketplaceButtonClickedInTab] postMessageToWebview failed: ${error}`),
-			)
+		postActions(outputChannel, tabProvider, ["marketplaceButtonClicked"], "marketplaceButtonClickedInTab")
 	},
 	newTask: handleNewTask,
 	setCustomStoragePath: async () => {
@@ -292,106 +286,128 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	// Serialize overlapping "Open in editor" calls: a double-click starts
 	// before the first call tracks its new panel, so without a shared
 	// in-flight creation both calls would race to create two tab panels.
-	// Concurrent callers await the same promise: exactly one panel is
-	// created and every caller receives the same provider.
+	// The shared promise is stored before the creation body awaits
+	// ContextProxy.getInstance, so every caller started while the creation
+	// is in flight — openInNewTab and popoutButtonClicked both dispatch
+	// through here — awaits it instead of creating a second panel: exactly
+	// one panel is created and every caller receives the same provider.
 	if (pendingTabPanelCreation) {
 		return pendingTabPanelCreation
 	}
 
-	const creation = (async () => {
-		// Reuse the tracked tab instead of opening a second one: a repeated
-		// "Open in editor" click reveals the existing tab's panel.
-		if (tabPanel) {
-			const existingProvider = ClineProvider.getInstanceForView(tabPanel)
-			if (existingProvider) {
-				await tabPanel.reveal()
-				await existingProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
-				return existingProvider
-			}
-		}
-
-		// (This example uses webviewProvider activation event which is necessary to
-		// deserialize cached webview, but since we use retainContextWhenHidden, we
-		// don't need to use that event).
-		// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
-		const contextProxy = await ContextProxy.getInstance(context)
-		const codeIndexManager = CodeIndexManager.getInstance(context)
-
-		// Get the existing MDM service instance to ensure consistent policy enforcement
-		let mdmService: MdmService | undefined
-		try {
-			mdmService = MdmService.getInstance()
-		} catch (error) {
-			// MDM service not initialized, which is fine - extension can work without it
-			mdmService = undefined
-		}
-
-		const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, mdmService)
-		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
-
-		// Check if there are any visible text editors, otherwise open a new group
-		// to the right.
-		const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
-
-		if (!hasVisibleEditors) {
-			await vscode.commands.executeCommand("workbench.action.newGroupRight")
-		}
-
-		const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
-
-		const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Zoo Code", targetCol, {
-			enableScripts: true,
-			retainContextWhenHidden: true,
-			localResourceRoots: [context.extensionUri],
-		})
-
-		// Save as tab type panel.
-		setPanel(newPanel, "tab")
-
-		// TODO: Use better svg icon with light and dark variants (see
-		// https://stackoverflow.com/questions/58365687/vscode-extension-iconpath).
-		newPanel.iconPath = {
-			light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_light.png"),
-			dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_dark.png"),
-		}
-
-		await tabProvider.resolveWebviewView(newPanel)
-
-		// Add listener for visibility changes to notify webview
-		newPanel.onDidChangeViewState(
-			(e) => {
-				const panel = e.webviewPanel
-				if (panel.visible) {
-					panel.webview.postMessage({ type: "action", action: "didBecomeVisible" }) // Use the same message type as in SettingsView.tsx
-				}
-			},
-			null, // First null is for `thisArgs`
-			context.subscriptions, // Register listener for disposal
-		)
-
-		// Handle panel closing events.
-		newPanel.onDidDispose(
-			() => {
-				setPanel(undefined, "tab")
-			},
-			null,
-			context.subscriptions, // Also register dispose listener
-		)
-
-		// Lock the editor group so clicking on files doesn't open them over the panel.
-		await delay(100)
-		await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
-
-		return tabProvider
-	})()
-
+	const creation = createTabPanelUnlocked({ context, outputChannel })
 	pendingTabPanelCreation = creation
 
 	try {
 		return await creation
 	} finally {
 		// Clear once settled (success or failure) so the next call starts
-		// fresh: the reuse path above then takes over for the tracked panel.
-		pendingTabPanelCreation = undefined
+		// fresh: the reuse path in createTabPanelUnlocked then takes over
+		// for the tracked panel. Guard the clear so this settlement cannot
+		// clobber a replacement already stored in the slot. That clobber is
+		// unreachable in single-threaded settlement order: while the slot
+		// holds this in-flight creation, every other caller receives that
+		// same promise (guard above), so no replacement can be stored before
+		// this finally block runs — the equality check pins the invariant.
+		// Stryker disable next-line ConditionalExpression: defensive clobber guard, unreachable per the ordering argument above.
+		if (pendingTabPanelCreation === creation) {
+			pendingTabPanelCreation = undefined
+		}
 	}
+}
+
+// The unserialized tab-creation body. Only openClineInNewTab may call it,
+// after it has stored the shared in-flight promise.
+const createTabPanelUnlocked = async ({ context, outputChannel }: Omit<RegisterCommandOptions, "provider">) => {
+	// Reuse the tracked tab instead of opening a second one: a repeated
+	// "Open in editor" click reveals the existing tab's panel.
+	if (tabPanel) {
+		const existingProvider = ClineProvider.getInstanceForView(tabPanel)
+		if (existingProvider) {
+			await tabPanel.reveal()
+			await existingProvider.postMessageToWebview({ type: "action", action: "didBecomeVisible" })
+			return existingProvider
+		}
+	}
+
+	// (This example uses webviewProvider activation event which is necessary to
+	// deserialize cached webview, but since we use retainContextWhenHidden, we
+	// don't need to use that event).
+	// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
+	const contextProxy = await ContextProxy.getInstance(context)
+	const codeIndexManager = CodeIndexManager.getInstance(context)
+
+	// Get the existing MDM service instance to ensure consistent policy enforcement
+	let mdmService: MdmService | undefined
+	try {
+		mdmService = MdmService.getInstance()
+	} catch (error) {
+		// MDM service unavailable: log the fallback and continue without it.
+		outputChannel.appendLine(`[openClineInNewTab] MDM service unavailable, continuing without it: ${error}`)
+		mdmService = undefined
+	}
+
+	const tabProvider = new ClineProvider(context, outputChannel, "editor", contextProxy, mdmService)
+	const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
+
+	// Check if there are any visible text editors, otherwise open a new group
+	// to the right.
+	const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
+
+	if (!hasVisibleEditors) {
+		await vscode.commands.executeCommand("workbench.action.newGroupRight")
+	}
+
+	const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
+
+	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Zoo Code", targetCol, {
+		enableScripts: true,
+		retainContextWhenHidden: true,
+		localResourceRoots: [context.extensionUri],
+	})
+
+	// Save as tab type panel.
+	// Stryker disable next-line StringLiteral: setPanel branches only on type === "sidebar", so any other literal routes to the identical tab-ref assignment
+	setPanel(newPanel, "tab")
+
+	// TODO: Use better svg icon with light and dark variants (see
+	// https://stackoverflow.com/questions/58365687/vscode-extension-iconpath).
+	newPanel.iconPath = {
+		light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_light.png"),
+		dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "panel_dark.png"),
+	}
+
+	await tabProvider.resolveWebviewView(newPanel)
+
+	// Add listener for visibility changes to notify webview
+	newPanel.onDidChangeViewState(
+		(e) => {
+			const panel = e.webviewPanel
+			if (panel.visible) {
+				panel.webview.postMessage({ type: "action", action: "didBecomeVisible" }) // Use the same message type as in SettingsView.tsx
+			}
+		},
+		null, // First null is for `thisArgs`
+		context.subscriptions, // Register listener for disposal
+	)
+
+	// Handle panel closing events: clear the tracked ref only if this panel
+	// is still the tracked one, so a late disposal of an already-replaced
+	// panel cannot clobber the replacement's ref.
+	newPanel.onDidDispose(
+		() => {
+			if (tabPanel === newPanel) {
+				// Stryker disable next-line StringLiteral: setPanel branches only on type === "sidebar", so any other literal routes to the identical tab-ref assignment
+				setPanel(undefined, "tab")
+			}
+		},
+		null,
+		context.subscriptions, // Also register dispose listener
+	)
+
+	// Lock the editor group so clicking on files doesn't open them over the panel.
+	await delay(100)
+	await vscode.commands.executeCommand("workbench.action.lockEditorGroup")
+
+	return tabProvider
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -903,6 +903,16 @@ export class ClineProvider
 		return Array.from(this.activeInstances)
 	}
 
+	/**
+	 * Returns the live instance whose current view is the given view or panel,
+	 * if any. Title-bar commands on a specific surface use this to target the
+	 * instance that owns that surface rather than the visible-instance
+	 * heuristic (which picks whichever surface the user last focused).
+	 */
+	public static getInstanceForView(view: vscode.WebviewView | vscode.WebviewPanel): ClineProvider | undefined {
+		return Array.from(this.activeInstances).find((instance) => instance.view === view)
+	}
+
 	public static async getInstance(): Promise<ClineProvider | undefined> {
 		let visibleProvider = ClineProvider.getVisibleInstance()
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -567,6 +567,19 @@ describe("ClineProvider", () => {
 		expect(ClineProvider.getVisibleInstance()).toBe(provider)
 	})
 
+	describe("getInstanceForView", () => {
+		it("returns the instance that owns the given view", () => {
+			// @ts-ignore - accessing private property for testing
+			provider.view = mockWebviewView
+
+			expect(ClineProvider.getInstanceForView(mockWebviewView)).toBe(provider)
+		})
+
+		it("returns undefined when no live instance owns the view", () => {
+			expect(ClineProvider.getInstanceForView({} as vscode.WebviewView)).toBeUndefined()
+		})
+	})
+
 	test("loads full model details when preparing an LM Studio task", async () => {
 		await provider.performPreparationTasks({
 			apiConfiguration: {

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -568,9 +568,8 @@ describe("ClineProvider", () => {
 	})
 
 	describe("getInstanceForView", () => {
-		it("returns the instance that owns the given view", () => {
-			// @ts-ignore - accessing private property for testing
-			provider.view = mockWebviewView
+		it("returns the instance that owns the given view", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
 
 			expect(ClineProvider.getInstanceForView(mockWebviewView)).toBe(provider)
 		})

--- a/src/eslint-suppressions.json
+++ b/src/eslint-suppressions.json
@@ -64,11 +64,6 @@
 			"count": 14
 		}
 	},
-	"activate/__tests__/registerCommands.spec.ts": {
-		"@typescript-eslint/no-explicit-any": {
-			"count": 2
-		}
-	},
 	"activate/registerCodeActions.ts": {
 		"@typescript-eslint/no-explicit-any": {
 			"count": 2

--- a/src/package.json
+++ b/src/package.json
@@ -96,6 +96,26 @@
 				"icon": "$(settings-gear)"
 			},
 			{
+				"command": "zoo-code.plusButtonClickedInTab",
+				"title": "%command.newTask.title%",
+				"icon": "$(edit)"
+			},
+			{
+				"command": "zoo-code.settingsButtonClickedInTab",
+				"title": "%command.settings.title%",
+				"icon": "$(settings-gear)"
+			},
+			{
+				"command": "zoo-code.marketplaceButtonClickedInTab",
+				"title": "%command.marketplace.title%",
+				"icon": "$(extensions)"
+			},
+			{
+				"command": "zoo-code.historyButtonClickedInTab",
+				"title": "%command.history.title%",
+				"icon": "$(history)"
+			},
+			{
 				"command": "zoo-code.openInNewTab",
 				"title": "%command.openInNewTab.title%",
 				"category": "%configuration.title%"
@@ -241,22 +261,22 @@
 			],
 			"editor/title": [
 				{
-					"command": "zoo-code.plusButtonClicked",
+					"command": "zoo-code.plusButtonClickedInTab",
 					"group": "navigation@1",
 					"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
 				},
 				{
-					"command": "zoo-code.settingsButtonClicked",
+					"command": "zoo-code.settingsButtonClickedInTab",
 					"group": "navigation@2",
 					"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
 				},
 				{
-					"command": "zoo-code.marketplaceButtonClicked",
+					"command": "zoo-code.marketplaceButtonClickedInTab",
 					"group": "navigation@3",
 					"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
 				},
 				{
-					"command": "zoo-code.historyButtonClicked",
+					"command": "zoo-code.historyButtonClickedInTab",
 					"group": "overflow@1",
 					"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
 				},

--- a/src/package.json
+++ b/src/package.json
@@ -287,6 +287,24 @@
 				}
 			]
 		},
+		"commandPalette": [
+			{
+				"command": "zoo-code.plusButtonClickedInTab",
+				"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
+			},
+			{
+				"command": "zoo-code.settingsButtonClickedInTab",
+				"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
+			},
+			{
+				"command": "zoo-code.marketplaceButtonClickedInTab",
+				"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
+			},
+			{
+				"command": "zoo-code.historyButtonClickedInTab",
+				"when": "activeWebviewPanelId == zoo-code.TabPanelProvider"
+			}
+		],
 		"keybindings": [
 			{
 				"command": "zoo-code.addToContext",


### PR DESCRIPTION
Part of the vps2 durable per-view state series — tracked in easonLiangWorldedtech/Zoo-Code#41 (cross-repo: this PR is standalone against upstream/main @ 0d937c050).

Issue (created at PR-open time): #1529

## What
All title-bar commands (+ / Settings / History / Marketplace / popout / focus) resolve to a single surface-blind "visible" ClineProvider instance, and setPanel's mutual wipe of the sidebar/tab slots leaves stale references once a tab and the sidebar coexist. This PR makes each title-bar command target the instance its click originated from:

- setPanel no longer wipes the other slot (each branch assigns only its own slot); the exported setPanel / getPanel signatures are kept.
- The four sidebar title-bar handlers target the click-origin provider that registerCommands was handed.
- Four new \*InTab command ids (packages/types/src/vscode.ts) rewire the editor/title menu, reusing the existing i18n keys/icons (zero new strings); the tab handlers resolve the owning instance via the new static ClineProvider.getInstanceForView(panel) (identity match over activeInstances) instead of the surface-blind getVisibleInstance.
- openClineInNewTab reuses the live tracked tab panel (reveal + didBecomeVisible post) instead of unconditionally creating a new provider + panel.
- The focusInput post condition is sidebarPanel && !tabPanel.

## Design decisions
- D1 (mutual wipe): fixed by the no-wipe setPanel. The sidebar onDidDispose asymmetry (the sidebar slot is never cleared) is pre-existing and retained; with no-wipe a stale slot resolves to a disposed instance via getInstanceForView, and the InTab handlers then no-op safely.
- D2 (no tab reuse): fixed by the panel reuse via getInstanceForView.
- D3 (surface-blind targeting): the five title-bar commands are contributed to **both** view/title and editor/title in package.json (verified by the Phase-0 A6 audit); the editor/title entries are rewired to the \*InTab ids.
- D4 (focusPanel tab-first resolution): self-resolves once the no-wipe lands — focusPanel.ts is deliberately unchanged (no spec exists for it).
- zoo-code.newTask (command-palette only) intentionally stays on the visible-provider path (focus-sidebar fallback); documented as a known limitation below.
- Webview-originated actions are per-instance by construction (setWebviewMessageListener wires this); the single leak (focusPanelRequest) is out of scope here.

## Measurements
- a+d vs upstream/main @ 0d937c050: **484** (411+/73−) — over the 400 soft budget by 112: the mutation gate required per-post distinct-error catch pinning, an awaited InTab no-op matrix (all four commands), and real-class getInstanceForView coverage (registerCommands.spec auto-mocks ClineProvider, so the real find callback had no coverage). Under the 600 hard cap. Composition: ~372 first-cut (impl + spec) + ~112 mutation-killing tests.
- src executable lines: 144 a+d (registerCommands.ts 99+/27−, ClineProvider.ts 10+, packages/types 8+) — inside the ~300 mutation preflight.

## Gates
- eslint --prune-suppressions: pass (suppression counts unchanged; prune-only reindent reverted)
- check-types: pass (13 packages)
- vitest: registerCommands.spec.ts 36 pass; ClineProvider.spec.ts 155 pass; packages/types 5 pass
- stryker-diff ci @ 0d937c050: **72/72 killed, 0 surviving, 0 uncovered, 0 blocking** (registerCommands.ts + ClineProvider.ts)
- e2e / i18n / visual: n/a (zero new i18n strings; no webview-ui changes)

## Parked / documented
- zoo-code.newTask stays on the visible-provider path (palette-only surface; focus-sidebar fallback).
- The A6 audit's alternate minimal-fix design (public renderContext / getSurfaceProviderOrLog / active-surface-first getVisibleInstance) was considered and **not adopted**.

## Porting notes
None — new fix (F0) identified by the Phase-0 A6 button-targeting audit; no hunks ported from the closed draft PRs.