### PR TITLE
fix(dev): use 127.0.0.1 instead of localhost for dev server (IPv6 resolution)

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1532,7 +1532,7 @@ export class ClineProvider
 			console.error("[ClineProvider:Vite] Failed to read Vite port file:", err)
 		}
 
-		const localServerUrl = `localhost:${localPort}`
+		const localServerUrl = `127.0.0.1:${localPort}`
 
 		// Check if local dev server is running.
 		try {
@@ -1571,7 +1571,7 @@ export class ClineProvider
 
 		const reactRefresh = /*html*/ `
 			<script nonce="${nonce}" type="module">
-				import RefreshRuntime from "http://localhost:${localPort}/@react-refresh"
+				import RefreshRuntime from "http://127.0.0.1:${localPort}/@react-refresh"
 				RefreshRuntime.injectIntoGlobalHook(window)
 				window.$RefreshReg$ = () => {}
 				window.$RefreshSig$ = () => (type) => type

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -121,8 +121,10 @@ export default defineConfig(({ mode }) => {
 			},
 		},
 		server: {
-			hmr: {
-				host: "localhost",
+			hmr: true,
+			host: "127.0.0.1",
+			port: 5173,
+			ws: {
 				protocol: "ws",
 			},
 			cors: {


### PR DESCRIPTION
Closes: #1588

### Description

On systems where `localhost` resolves to `::1` before `127.0.0.1`, the dev-mode webview fails to load: the `axios.get("http://localhost:<port>")` health check in `getHMRHtmlContent()` never reaches the Vite dev server, so Zoo Code shows "Local development server is not running..." even though the server is up.

Fix is to stop relying on the ambiguous `localhost` name in the dev loop and pin both sides to IPv4:

- `src/core/webview/ClineProvider.ts`: `localServerUrl` and the injected `@react-refresh` import URL now use `127.0.0.1` instead of `localhost`. This also keeps the CSP entries (`script-src`/`connect-src`/`style-src`, which are derived from `localServerUrl`) consistent with what the webview actually loads.
- `webview-ui/vite.config.ts`: bind the dev server explicitly with `host: "127.0.0.1"`, keep `hmr: true` (HMR now derives host/port from the server config instead of a separate `hmr.host: "localhost"`), pin `port: 5173`, and move the `ws.protocol: "ws"` setting under `server.ws` since HMR is no longer an object.

Design note: choosing `127.0.0.1` over `::1` matches the existing `0.0.0.0` fallback already present in the CSP and is deterministic on Windows where Node 17+ uses `verbatim` DNS ordering.

### Test Procedure

- `pnpm --dir src exec eslint --max-warnings=0 core/webview/ClineProvider.ts` and webview lint — clean.
- `tsc -b` in `webview-ui` — clean.
- Full `pnpm lint` and `pnpm check-types` (turbo, all packages) via pre-commit/pre-push hooks — pass.
- Manual: on an affected machine (`Resolve-DnsName localhost` returns AAAA `::1` first), run `pnpm dev` + launch the extension host, open the sidebar — the webview loads with working HMR and no "server is not running" error. Also verified the normal IPv4-first path still works.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [ ] **Visual Snapshot** (UI changes only): N/A — dev-server wiring only, no rendered UI change.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

N/A — no user-facing rendered state changes; this only affects the dev-mode bootstrap.

### Videos (interaction / animation only)

N/A.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

No unit test added: the touched code path is dev-only bootstrap (`getHMRHtmlContent` + Vite server config) with no existing test harness around it; coverage is the manual repro in #1588.

### Get in Touch

hnbdr
