### PR TITLE
fix(nanogpt): preserve optional tool parameters

### DIFF
--- a/src/api/providers/__tests__/nanogpt.spec.ts
+++ b/src/api/providers/__tests__/nanogpt.spec.ts
@@ -9,6 +9,7 @@ import { nanoGptDefaultModelId, providerIdentifiers } from "@roo-code/types"
 
 import { buildApiHandler } from "../../index"
 import { asyncStreamFrom, collectStream } from "../../../test-utils/stream"
+import { createReadFileTool } from "../../../core/prompts/tools/native-tools/read_file"
 import { NanoGptHandler } from "../nanogpt"
 import { getModels } from "../fetchers/modelCache"
 
@@ -169,6 +170,101 @@ describe("NanoGptHandler", () => {
 			{ signal },
 		)
 		expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("max_completion_tokens")
+	})
+
+	it.each(["auto", "tools"] as const)("preserves read_file optionality with %s routing", async (routing) => {
+		const tool = createReadFileTool()
+		if (tool.type !== "function") throw new Error("read_file must be a function tool")
+		const original = structuredClone(tool)
+		const handler = new NanoGptHandler({ nanoGptModelId: "model:thinking", nanoGptRoutingPreference: routing })
+
+		await collectStream(
+			handler.createMessage("sys", messages, { taskId: "task", tools: [tool], tool_choice: "auto" }),
+		)
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tool_choice: "auto",
+				tools: [{ ...original, function: { ...original.function, strict: false } }],
+			}),
+			expect.anything(),
+		)
+		expect(tool).toEqual(original)
+		expect(tool.function.parameters?.required).toEqual(["path"])
+	})
+
+	it.each(["custom_read", "mcp--files--read"])(
+		"preserves nested, nullable, and required fields for %s",
+		async (name) => {
+			const tool: OpenAI.Chat.ChatCompletionTool = {
+				type: "function",
+				function: {
+					name,
+					strict: true,
+					parameters: {
+						type: "object",
+						required: ["path"],
+						additionalProperties: false,
+						properties: {
+							path: { type: "string" },
+							label: { type: ["string", "null"] },
+							options: {
+								type: "object",
+								required: ["offset"],
+								properties: { offset: { type: "integer", minimum: 1 }, limit: { type: "integer" } },
+							},
+							ranges: {
+								type: "array",
+								items: {
+									type: "object",
+									required: ["start"],
+									properties: { start: { type: "integer" }, end: { type: "integer" } },
+								},
+							},
+						},
+					},
+				},
+			}
+			const original = structuredClone(tool)
+			await collectStream(
+				new NanoGptHandler({ nanoGptModelId: "model:thinking" }).createMessage("sys", messages, {
+					taskId: "task",
+					tools: [tool],
+					tool_choice: { type: "function", function: { name } },
+				}),
+			)
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					tools: [{ ...original, function: { ...original.function, strict: false } }],
+					tool_choice: { type: "function", function: { name } },
+				}),
+				expect.anything(),
+			)
+			expect(tool).toEqual(original)
+		},
+	)
+
+	it.each([undefined, []])("preserves an absent or empty tool catalog (%j)", async (tools) => {
+		await collectStream(
+			new NanoGptHandler({ nanoGptModelId: "model:thinking" }).createMessage("sys", messages, {
+				taskId: "task",
+				tools,
+			}),
+		)
+		expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ tools }), expect.anything())
+	})
+
+	it("passes non-function tools through unchanged", async () => {
+		const tools: OpenAI.Chat.ChatCompletionTool[] = [
+			{ type: "custom", custom: { name: "custom_tool", format: { type: "text" } } },
+		]
+		await collectStream(
+			new NanoGptHandler({ nanoGptModelId: "model:thinking" }).createMessage("sys", messages, {
+				taskId: "task",
+				tools,
+			}),
+		)
+		expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ tools }), expect.anything())
 	})
 
 	it.each([

--- a/src/api/providers/nanogpt.ts
+++ b/src/api/providers/nanogpt.ts
@@ -132,7 +132,12 @@ export class NanoGptHandler extends RouterProvider implements SingleCompletionHa
 			stream: true,
 			stream_options: { include_usage: true },
 			max_tokens: info.maxTokens ?? undefined,
-			tools: this.convertToolsForOpenAI(metadata?.tools),
+			// Preserve the declared schema instead of making every optional field
+			// required for OpenAI strict mode (e.g. read_file's indentation options).
+			// Non-strict generation still retains every original required constraint.
+			tools: metadata?.tools?.map((tool) =>
+				tool.type === "function" ? { ...tool, function: { ...tool.function, strict: false } } : tool,
+			),
 			tool_choice: metadata?.tool_choice,
 			parallel_tool_calls: isAstra ? false : (metadata?.parallelToolCalls ?? true),
 			...(this.options.nanoGptRoutingPreference === "caching" ? { caching: true } : {}),


### PR DESCRIPTION
### Related GitHub Issue

Issue approval and assignment are pending. Opening this as a draft for maintainer feedback, not as ready for review.

### Description

The NanoGPT handler uses the shared OpenAI strict-schema converter, which makes every tool property required and removes nullability.

For `read_file`, this changes the required fields from just `path` to `path`, `mode`, `offset`, `limit`, and `indentation`, including every nested indentation option. Valid slice reads can then fail because they omit indentation settings they do not need.

This change preserves the original parameter schemas and sets function tools to `strict: false`. Genuine required fields, types, bounds, nullability, and additional-property constraints remain unchanged. Caller-owned definitions are not mutated, and non-function tools pass through unchanged.

The change is limited to NanoGPT. It does not modify the shared converter, repair arguments, bypass validation, or change routing or reasoning controls. This supports the project's reliability and API compatibility goals.

Tradeoff: this stops requesting strict constrained generation. It preserves the tool's actual contract but does not guarantee that every model response will satisfy it.

### Test Procedure

From the repository root:

```sh
pnpm --dir src exec vitest run api/providers/__tests__/nanogpt.spec.ts api/providers/__tests__/base-provider.spec.ts core/prompts/tools/native-tools/__tests__/read_file.spec.ts core/tools/__tests__/ReadFileTool.spec.ts
pnpm --dir src exec tsc --noEmit
pnpm --dir src exec eslint --prune-suppressions --max-warnings=0 api/providers/nanogpt.ts api/providers/__tests__/nanogpt.spec.ts
git diff --check
```

- 148 tests passed across the NanoGPT handler, shared converter, native read_file schema, and ReadFileTool suites.
- Seven added regression cases cover Auto/Tools routing, native/custom/MCP schemas, nested optional and nullable fields, genuine required fields, no mutation, absent/empty catalogs, and non-function tools. Three new cases failed before the patch.
- TypeScript, scoped ESLint, formatting, and diff checks passed.
- Live tests reproduced the missing-indentation failure with the old schema.
- With the patch, seven conversations completed and two returned HTTP 429 overload responses. No patched schema failures occurred. All four combinations completed: Auto/Tools routing and slice/indentation reads.
- Old-schema controls produced two completions, three malformed-tool stream errors, one nested-required validation failure, and two overloads. Failed attempts were retained rather than counted as passes.

The separate local live harness used the actual handler, streaming parser, 13 native tool definitions, real fixture-file execution, and tool-result continuation with `alibaba/qwen3.8-flash`. Completion required returning values obtained from both files. Requests used `tool_choice=auto`, a 4096-token cap, and no sampling/reasoning overrides or SDK retries. No missing arguments were invented. The live harness and private request artifacts are not included in this two-file diff.

These were synthetic conversations, not a replay of the customer's full history or a complete VS Code UI test. The small sample does not establish a general failure rate or fix overload errors. Local tests used Node 26.0.0 and pnpm 10.8.1; CI on the pinned Node 22.23.1 remains necessary. Dependencies were installed from the frozen lockfile with install scripts disabled; no full extension build or complete workspace test run was performed.

### Pre-Submission Checklist

- [ ] Issue approval and assignment completed.
- [x] Focused change limited to NanoGPT request construction.
- [x] Regression tests added and local checks passed.
- [x] Documentation impact considered; no user-facing documentation change required.
- [ ] Human author verification and maintainer review completed before ready-for-review status.
- [ ] Required CI passes on the pinned toolchain.

### Additional Notes

No UI changes. AI assistance was used for investigation, implementation, tests, and this description. This draft contains no private support identifiers, customer arguments, credentials, or internal routing details.
