### PR TITLE
fix(openai-compatible): consistently apply configured reasoning effort

### DIFF
--- a/src/api/providers/__tests__/deepseek.spec.ts
+++ b/src/api/providers/__tests__/deepseek.spec.ts
@@ -148,6 +148,32 @@ describe("DeepSeekHandler", () => {
 		clearAllMocks()
 	})
 
+	describe("completePrompt reasoning", () => {
+		it.each([
+			{ apiModelId: "custom-deepseek-model", enableReasoningEffort: true, expected: undefined },
+			{ apiModelId: "deepseek-v4-flash", enableReasoningEffort: false, expected: undefined },
+			{ apiModelId: "deepseek-v4-flash", enableReasoningEffort: true, expected: "max" },
+		])("respects reasoning support for $apiModelId with enabled=$enableReasoningEffort", async (scenario) => {
+			const completionHandler = new DeepSeekHandler({
+				...mockOptions,
+				apiModelId: scenario.apiModelId,
+				enableReasoningEffort: scenario.enableReasoningEffort,
+				reasoningEffort: "max",
+			})
+
+			await completionHandler.completePrompt("Hello")
+
+			expect(mockCreate).toHaveBeenCalledOnce()
+			const request = mockCreate.mock.calls[0][0]
+			expect(request.model).toBe(scenario.apiModelId)
+			if (scenario.expected === undefined) {
+				expect(request).not.toHaveProperty("reasoning_effort")
+			} else {
+				expect(request.reasoning_effort).toBe(scenario.expected)
+			}
+		})
+	})
+
 	describe("constructor", () => {
 		it("should initialize with provided options", () => {
 			expect(handler).toBeInstanceOf(DeepSeekHandler)

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -8,6 +8,7 @@ import {
 	openAiModelInfoSaneDefaults,
 	DEEP_SEEK_DEFAULT_TEMPERATURE,
 	azureOpenAiDefaultApiVersion,
+	type ModelInfo,
 } from "@roo-code/types"
 import { Package } from "../../../shared/package"
 import { makeApiHandlerOptions } from "../../../test-utils/api"
@@ -950,7 +951,119 @@ describe("OpenAiHandler", () => {
 		})
 	})
 
+	describe.each([
+		{ name: "streaming chat", openAiModelId: "custom-model", streaming: true, singleCompletion: false },
+		{ name: "non-streaming chat", openAiModelId: "custom-model", streaming: false, singleCompletion: false },
+		{ name: "streaming O3", openAiModelId: "o3-mini", streaming: true, singleCompletion: false },
+		{ name: "non-streaming O3", openAiModelId: "o3-mini", streaming: false, singleCompletion: false },
+		{ name: "single completion", openAiModelId: "custom-model", streaming: false, singleCompletion: true },
+	])("reasoning effort consistency: $name", ({ openAiModelId, streaming, singleCompletion }) => {
+		async function requestWithSettings(settings: Partial<ApiHandlerOptions>) {
+			const reasoningHandler = new OpenAiHandler({
+				...mockOptions,
+				openAiModelId,
+				openAiStreamingEnabled: streaming,
+				...settings,
+			})
+
+			if (singleCompletion) {
+				await reasoningHandler.completePrompt("Hello")
+			} else {
+				await collectStream(
+					reasoningHandler.createMessage("System prompt", [{ role: "user", content: "Hello" }]),
+				)
+			}
+		}
+
+		it.each([
+			{ selected: "max", stale: "low" },
+			{ selected: "high", stale: "medium" },
+			{ selected: "xhigh", stale: "medium" },
+			{ selected: "max", stale: "disable" },
+			{ selected: "max", stale: "none" },
+		] as const)(
+			"uses the custom model's $selected effort despite a stale top-level $stale",
+			async ({ selected, stale }) => {
+				await requestWithSettings({
+					enableReasoningEffort: true,
+					reasoningEffort: stale,
+					openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: selected },
+				})
+
+				expect(mockCreate).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ reasoning_effort: selected }),
+					{},
+				)
+			},
+		)
+
+		it.each(["low", "medium", "high", "xhigh", "max"] as const)(
+			"preserves the selected %s effort when the enable flag is unset in a legacy profile",
+			async (reasoningEffort) => {
+				await requestWithSettings({
+					openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort },
+				})
+
+				expect(mockCreate).toHaveBeenCalledExactlyOnceWith(
+					expect.objectContaining({ reasoning_effort: reasoningEffort }),
+					{},
+				)
+			},
+		)
+
+		it("omits reasoning effort when disabled even if custom model metadata retains max", async () => {
+			await requestWithSettings({
+				enableReasoningEffort: false,
+				reasoningEffort: "low",
+				openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: "max" },
+			})
+
+			expect(mockCreate).toHaveBeenCalledOnce()
+			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("reasoning_effort")
+		})
+
+		it("does not use a hidden top-level effort when no custom effort is configured", async () => {
+			await requestWithSettings({
+				enableReasoningEffort: true,
+				reasoningEffort: "low",
+				openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, supportsReasoningEffort: true },
+			})
+
+			expect(mockCreate).toHaveBeenCalledOnce()
+			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("reasoning_effort")
+		})
+	})
+
 	describe("getModel", () => {
+		it.each([
+			{ supportsReasoningEffort: undefined },
+			{ supportsReasoningEffort: true },
+			{ supportsReasoningEffort: ["low", "medium", "high", "xhigh", "max"] },
+		] satisfies Array<Pick<ModelInfo, "supportsReasoningEffort">>)(
+			"resolves custom effort consistently for capability $supportsReasoningEffort without mutating settings",
+			({ supportsReasoningEffort }) => {
+				const options: ApiHandlerOptions = {
+					...mockOptions,
+					enableReasoningEffort: true,
+					reasoningEffort: "low",
+					openAiCustomModelInfo: {
+						...openAiModelInfoSaneDefaults,
+						supportsReasoningEffort,
+						reasoningEffort: "max",
+					},
+				}
+				const reasoningHandler = new OpenAiHandler(options)
+
+				expect(reasoningHandler.getModel()).toMatchObject({
+					info: { reasoningEffort: "max" },
+					reasoningEffort: "max",
+					reasoning: { reasoning_effort: "max" },
+				})
+				expect(options.reasoningEffort).toBe("low")
+				expect(options.openAiCustomModelInfo?.reasoningEffort).toBe("max")
+			},
+		)
+
 		it("should return model info with sane defaults", () => {
 			const model = handler.getModel()
 			expect(model.id).toBe(mockOptions.openAiModelId)

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -104,7 +104,13 @@ export class DeepSeekHandler extends OpenAiHandler {
 			settings: this.options,
 			defaultTemperature: DEEP_SEEK_DEFAULT_TEMPERATURE,
 		})
-		return { id, info, ...params }
+		return {
+			id,
+			info,
+			...params,
+			// Unknown IDs use fallback metadata, but must not inherit its V4 request fields.
+			reasoning: supportsDeepSeekThinkingToggle(id) ? params.reasoning : undefined,
+		}
 	}
 
 	override async *createMessage(

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -236,6 +236,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				messages: deepseekReasoner
 					? convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 					: [systemMessage, ...convertToOpenAiMessages(messages)],
+				...reasoning,
 				// Tools are always present (minimum ALWAYS_AVAILABLE_TOOLS)
 				tools: this.convertToolsForOpenAI(metadata?.tools),
 				tool_choice: metadata?.tool_choice,
@@ -297,7 +298,9 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			format: "openai",
 			modelId: id,
 			model: info,
-			settings: this.options,
+			// OpenAI Compatible edits effort in custom model info. The shared top-level
+			// setting may be left over from another provider and must not override it.
+			settings: { ...this.options, reasoningEffort: info.reasoningEffort },
 			defaultTemperature: 0,
 		})
 		return { id, info, ...params }
@@ -312,6 +315,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			let requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
 				model: model.id,
 				messages: [{ role: "user", content: prompt }],
+				...model.reasoning,
 			}
 
 			// Add max_tokens if needed
@@ -350,7 +354,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		messages: Anthropic.Messages.MessageParam[],
 		metadata?: ApiHandlerCreateMessageMetadata,
 	): ApiStream {
-		const modelInfo = this.getModel().info
+		const { info: modelInfo, reasoning } = this.getModel()
 		const methodIsAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 
 		if (this.options.openAiStreamingEnabled ?? true) {
@@ -367,7 +371,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				],
 				stream: true,
 				...(isGrokXAI ? {} : { stream_options: { include_usage: true } }),
-				reasoning_effort: modelInfo.reasoningEffort as "low" | "medium" | "high" | undefined,
+				...reasoning,
 				temperature: undefined,
 				// Tools are always present (minimum ALWAYS_AVAILABLE_TOOLS)
 				tools: this.convertToolsForOpenAI(metadata?.tools),
@@ -402,7 +406,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 					},
 					...convertToOpenAiMessages(messages),
 				],
-				reasoning_effort: modelInfo.reasoningEffort as "low" | "medium" | "high" | undefined,
+				...reasoning,
 				temperature: undefined,
 				// Tools are always present (minimum ALWAYS_AVAILABLE_TOOLS)
 				tools: this.convertToolsForOpenAI(metadata?.tools),

--- a/src/core/config/__tests__/ProviderSettingsManager.spec.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.spec.ts
@@ -4,6 +4,7 @@ import {
 	OPEN_AI_CODEX_SERVICE_TIER_KEY,
 	OpenAiCodexServiceTier,
 	providerIdentifiers,
+	openAiModelInfoSaneDefaults,
 	retiredProviderIdentifiers,
 	type ProviderSettings,
 } from "@roo-code/types"
@@ -481,6 +482,29 @@ describe("ProviderSettingsManager", () => {
 					apiModelId: "gpt-5.6-sol",
 					[OPEN_AI_CODEX_SERVICE_TIER_KEY]: openAiCodexServiceTier,
 				})
+			},
+		)
+
+		it.each([true, false, undefined])(
+			"round-trips OpenAI-compatible reasoning settings through profile storage when enabled is %s",
+			async (enableReasoningEffort) => {
+				const configuration: ProviderSettings = {
+					apiProvider: providerIdentifiers.openai,
+					openAiModelId: "custom-model",
+					enableReasoningEffort,
+					reasoningEffort: "low",
+					openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: "max" },
+				}
+				await providerSettingsManager.saveConfig("compatible", configuration)
+
+				const serializedProfiles: string = mockSecrets.store.mock.calls.at(-1)![1]
+				mockSecrets.get.mockResolvedValue(serializedProfiles)
+				const reloadedManager = new ProviderSettingsManager(mockContext)
+				const profile = await reloadedManager.getProfile({ name: "compatible" })
+
+				expect(profile.enableReasoningEffort).toBe(enableReasoningEffort)
+				expect(profile.reasoningEffort).toBe("low")
+				expect(profile.openAiCustomModelInfo).toEqual(configuration.openAiCustomModelInfo)
 			},
 		)
 

--- a/src/core/webview/__tests__/ClineProvider.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.spec.ts
@@ -9,6 +9,7 @@ import axios from "axios"
 
 import {
 	type ProviderSettingsEntry,
+	type ProviderSettings,
 	type ClineMessage,
 	type ExtensionMessage,
 	type ExtensionState,
@@ -18,6 +19,7 @@ import {
 	DEFAULT_DIFF_FUZZY_THRESHOLD,
 	DEFAULT_WRITE_DELAY_MS,
 	providerIdentifiers,
+	openAiModelInfoSaneDefaults,
 } from "@roo-code/types"
 import { TelemetryService } from "@roo-code/telemetry"
 
@@ -1478,6 +1480,25 @@ describe("ClineProvider", () => {
 		expect(state.apiConfiguration).toMatchObject(expectedConfiguration)
 		expect(postedState.apiConfiguration).toMatchObject(expectedConfiguration)
 	})
+
+	test.each([true, false, undefined])(
+		"returns saved OpenAI-compatible reasoning settings to the webview when enabled is %s",
+		async (enableReasoningEffort) => {
+			await provider.resolveWebviewView(mockWebviewView)
+			const configuration: ProviderSettings = {
+				apiProvider: providerIdentifiers.openai,
+				openAiModelId: "custom-model",
+				enableReasoningEffort,
+				reasoningEffort: "low",
+				openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: "max" },
+			}
+			await provider.contextProxy.setProviderSettings(configuration)
+
+			expect(provider.contextProxy.getProviderSettings()).toMatchObject(configuration)
+			expect((await provider.getState()).apiConfiguration).toMatchObject(configuration)
+			expect((await provider.getStateToPostToWebview()).apiConfiguration).toMatchObject(configuration)
+		},
+	)
 
 	test("getState returns the saved destructive command guard setting", async () => {
 		await provider.contextProxy.setValue("destructiveCommandGuardEnabled", true)

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.spec.tsx
@@ -194,9 +194,14 @@ vi.mock("../ThinkingBudget", () => ({
 						value={apiConfiguration?.reasoningEffort || ""}
 						onChange={(e) => setApiConfigurationField("reasoningEffort", e.target.value)}>
 						<option value="">Select...</option>
-						<option value="low">Low</option>
-						<option value="medium">Medium</option>
-						<option value="high">High</option>
+						{(Array.isArray(modelInfo.supportsReasoningEffort)
+							? modelInfo.supportsReasoningEffort
+							: ["low", "medium", "high"]
+						).map((effort: string) => (
+							<option key={effort} value={effort}>
+								{effort}
+							</option>
+						))}
 					</select>
 				</div>
 			)
@@ -521,11 +526,12 @@ describe("ApiOptions", () => {
 			// However, we've tested the state update call.
 		})
 
-		it("updates reasoningEffort in openAiCustomModelInfo when select value changes", () => {
+		it("selects max in custom model info even when a top-level low effort remains", () => {
 			const mockSetApiConfigurationField = vi.fn()
 			const initialConfig = {
 				apiProvider: providerIdentifiers.openai,
 				enableReasoningEffort: true, // Initially enabled
+				reasoningEffort: "low" as const,
 				openAiCustomModelInfo: {
 					...openAiModelInfoSaneDefaults,
 					reasoningEffort: "low" as const,
@@ -537,25 +543,18 @@ describe("ApiOptions", () => {
 				setApiConfigurationField: mockSetApiConfigurationField,
 			})
 
-			// Find the reasoning effort select among all comboboxes by its current value
-			// const allSelects = screen.getAllByRole("combobox") as HTMLSelectElement[]
-			// const reasoningSelect = allSelects.find(
-			// 	(el) => el.value === initialConfig.openAiCustomModelInfo.reasoningEffort,
-			// )
-			// expect(reasoningSelect).toBeDefined()
 			const selectContainer = screen.getByTestId("reasoning-effort")
 			expect(selectContainer).toBeInTheDocument()
 
 			const reasoningSelect = within(selectContainer).getByRole("combobox")
 			expect(reasoningSelect).toHaveValue("low")
 
-			// Simulate changing the reasoning effort to 'high'
-			fireEvent.change(reasoningSelect, { target: { value: "high" } })
+			fireEvent.change(reasoningSelect, { target: { value: "max" } })
 
 			// Check if setApiConfigurationField was called correctly for openAiCustomModelInfo
 			expect(mockSetApiConfigurationField).toHaveBeenCalledWith(
 				"openAiCustomModelInfo",
-				expect.objectContaining({ reasoningEffort: "high" }),
+				expect.objectContaining({ reasoningEffort: "max" }),
 			)
 
 			// Check that other properties were preserved

--- a/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.unsaved-changes.spec.tsx
@@ -1,4 +1,4 @@
-import { providerIdentifiers } from "@roo-code/types"
+import { providerIdentifiers, openAiModelInfoSaneDefaults, type ProviderSettings } from "@roo-code/types"
 import { screen, fireEvent, waitFor } from "@testing-library/react"
 
 import { renderWithExtensionState } from "@/utils/test-utils"
@@ -268,7 +268,7 @@ describe("SettingsView - Unsaved Changes Detection", () => {
 		deniedCommands: [],
 		allowedMaxRequests: undefined,
 		allowedMaxCost: undefined,
-		language: "en",
+		language: "en" as const,
 		alwaysAllowExecute: false,
 		alwaysAllowMcp: false,
 		alwaysAllowModeSwitch: false,
@@ -287,7 +287,7 @@ describe("SettingsView - Unsaved Changes Detection", () => {
 		ttsEnabled: false,
 		ttsSpeed: 1.0,
 		soundVolume: 0.5,
-		telemetrySetting: "unset",
+		telemetrySetting: "unset" as const,
 		terminalOutputLineLimit: 500,
 		terminalOutputCharacterLimit: 50000,
 		terminalShellIntegrationTimeout: 3000,
@@ -678,6 +678,57 @@ describe("SettingsView - Unsaved Changes Detection", () => {
 				nanoGptApiKey: "unsaved-key",
 				nanoGptModelId: "openai/next",
 				nanoGptRoutingPreference: "tools",
+			},
+		})
+	})
+
+	it("keeps OpenAI-compatible reasoning edits cached until Save despite a live state refresh", async () => {
+		const configuration: ProviderSettings = {
+			apiProvider: providerIdentifiers.openai,
+			openAiModelId: "custom-model",
+			enableReasoningEffort: false,
+			reasoningEffort: "low",
+			openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: "low" },
+		}
+		vi.mocked(useExtensionState, { partial: true }).mockReturnValue({
+			...defaultExtensionState,
+			apiConfiguration: configuration,
+		})
+		vi.mocked(ApiOptions).mockImplementation(({ apiConfiguration, setApiConfigurationField }) => (
+			<button
+				data-testid="select-compatible-max"
+				onClick={() => {
+					setApiConfigurationField("enableReasoningEffort", true)
+					setApiConfigurationField("openAiCustomModelInfo", {
+						...(apiConfiguration.openAiCustomModelInfo ?? openAiModelInfoSaneDefaults),
+						reasoningEffort: "max",
+					})
+				}}>
+				{apiConfiguration.openAiCustomModelInfo?.reasoningEffort}
+			</button>
+		))
+		const view = renderWithExtensionState(<SettingsView onDone={vi.fn()} />, { queryClient })
+		fireEvent.click(await screen.findByTestId("select-compatible-max"))
+
+		vi.mocked(useExtensionState, { partial: true }).mockReturnValue({
+			...defaultExtensionState,
+			apiConfiguration: { ...configuration },
+		})
+		view.rerender(<SettingsView onDone={vi.fn()} />)
+
+		expect(screen.getByTestId("select-compatible-max")).toHaveTextContent("max")
+		expect(configuration.enableReasoningEffort).toBe(false)
+		expect(configuration.openAiCustomModelInfo?.reasoningEffort).toBe("low")
+		expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "upsertApiConfiguration" }))
+
+		fireEvent.click(screen.getByTestId("save-button"))
+		expect(postMessage).toHaveBeenCalledWith({
+			type: "upsertApiConfiguration",
+			text: "default",
+			apiConfiguration: {
+				...configuration,
+				enableReasoningEffort: true,
+				openAiCustomModelInfo: { ...openAiModelInfoSaneDefaults, reasoningEffort: "max" },
 			},
 		})
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #993 #1524 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

OpenAI Compatible could display a selected reasoning effort such as `max` while sending a stale top-level value such as `low` or `medium`. The settings UI stores its selection in `openAiCustomModelInfo.reasoningEffort`, but request construction previously gave the shared top-level `reasoningEffort` priority.

- Resolve effort from the custom model setting so requests use the value shown in the UI. Preserve explicit disable behavior and compatibility with profiles whose enable flag is unset.
- Apply the resolved reasoning parameters consistently to streaming and non-streaming chat, the o1/o3/o4 request path, and single completions.
- Restrict DeepSeek's resolved request parameters to known supported models. This prevents inherited single completions from applying V4 reasoning fields to an unknown model ID that uses fallback metadata.
- Cover request construction, cached edits before Save, profile persistence, and saved settings returned to the webview with regression tests.

This improves provider reliability without changing the settings UI, storage format, or the shared reasoning resolver's precedence for other providers.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

Validated locally on macOS with Node.js `22.23.1` and pnpm `10.8.1`.

The request tests inspect the arguments passed to the OpenAI SDK. They cover conflicting settings (`max` versus `low`, and `high`/`xhigh` versus `medium`), stale `none`/`disable` values, explicit disable, an unset enable flag, and missing custom effort across all five request paths. DeepSeek tests also verify omission for unknown models and disabled reasoning, and `max` for a supported model.

Settings tests verify that selecting `max` updates custom model metadata, unsaved edits survive a live state refresh, Save sends the cached value, and persistence preserves the settings for enabled, disabled, and unset states.

After installing dependencies, reproduce the full package checks from the repository root. Finish bundling before running the test suites:

```sh
pnpm bundle
VITEST_MAX_WORKERS=4 pnpm --dir src exec vitest run
VITEST_MAX_WORKERS=4 pnpm --dir webview-ui exec vitest run
pnpm --dir src check-types
pnpm --dir webview-ui check-types
pnpm lint
```

Results:

| Check                                                     | Result                          |
| --------------------------------------------------------- | ------------------------------- |
| OpenAI Compatible and four inheriting providers           | 260 passed, 1 existing skip     |
| Full extension test suite                                 | 8,349 passed, 39 existing skips |
| Full webview test suite                                   | 1,859 passed                    |
| Type checks, repository lint, and changed-file formatting | Passed                          |

Coverage from the five provider suites is 95.40% lines / 88.19% branches for `openai.ts` and 100% lines / 84.37% branches for `deepseek.ts`. The added DeepSeek condition is exercised in both directions. The core OpenAI request tests also detected all five independently reverted fix variants.



### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->
- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above). The issues are linked; maintainer approval and assignment have not been verified.
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes.
- [x] **Visual Snapshot** (UI changes only): Not applicable; there are no changes to rendered UI, layout, or styling.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).


### Visual Snapshots

<!--
For UI changes to static rendered state, the primary artifact is a committed
Playwright Story Gallery snapshot (`*.visual.tsx` in `webview-ui/`) — that baseline
becomes durable regression coverage for the surface. See
`webview-ui/AGENTS.md` for what deserves a snapshot.

Before/after screenshots pasted here are welcome as a review aid but are not a
substitute for the committed baseline. If a snapshot is possible, prefer the
snapshot.
-->
Not applicable. The UI changes in this PR are limited to tests.

### Videos (interaction / animation only)

<!--
Snapshots cannot capture motion or multi-step flows. Attach a short screen
recording here when reviewers need to see:
  - A new interactive flow (dropdown, form, dialog progression)
  - Animation, transition, or timing behavior
  - A regression that only manifests during interaction

Videos are a review aid, not regression coverage. If the *result* of the
interaction has a distinct rendered state worth protecting, still commit a
`*.visual.tsx` snapshot of that end-state alongside the video.
-->
Not applicable. No new interaction or animation is introduced.


### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->
- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
