### PR TITLE
fix(openai-native): use canonical default model

### DIFF
--- a/packages/types/src/__tests__/provider-default-model.test.ts
+++ b/packages/types/src/__tests__/provider-default-model.test.ts
@@ -19,6 +19,7 @@ import {
 	internationalZAiDefaultModelId,
 	kimiCodeDefaultModelId,
 	mainlandZAiDefaultModelId,
+	openAiNativeDefaultModelId,
 	openRouterDefaultModelId,
 	vscodeLlmDefaultModelId,
 	zooGatewayDefaultModelId,
@@ -31,6 +32,10 @@ describe("getProviderDefaultModelId", () => {
 
 	it("triangulates static selection with another provider category", () => {
 		expect(getProviderDefaultModelId(providerIdentifiers.vscodeLm)).toBe(vscodeLlmDefaultModelId)
+	})
+
+	it("uses the canonical OpenAI Native default model", () => {
+		expect(getProviderDefaultModelId(providerIdentifiers.openaiNative)).toBe(openAiNativeDefaultModelId)
 	})
 
 	it.each([

--- a/packages/types/src/providers/index.ts
+++ b/packages/types/src/providers/index.ts
@@ -42,6 +42,7 @@ import { geminiDefaultModelId } from "./gemini.js"
 import { litellmDefaultModelId } from "./lite-llm.js"
 import { mistralDefaultModelId } from "./mistral.js"
 import { moonshotDefaultModelId } from "./moonshot.js"
+import { openAiNativeDefaultModelId } from "./openai.js"
 import { openAiCodexDefaultModelId } from "./openai-codex.js"
 import { openRouterDefaultModelId } from "./openrouter.js"
 import { poeDefaultModelId } from "./poe.js"
@@ -105,8 +106,7 @@ export function getProviderDefaultModelId(
 		case providerIdentifiers.zai:
 			return options?.isChina ? mainlandZAiDefaultModelId : internationalZAiDefaultModelId
 		case providerIdentifiers.openaiNative:
-			// TODO(#992): Replace this stale fallback with openAiNativeDefaultModelId.
-			return "gpt-4o" // Based on openai-native patterns
+			return openAiNativeDefaultModelId
 		case providerIdentifiers.openaiCodex:
 			return openAiCodexDefaultModelId
 		case providerIdentifiers.mistral:

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -18,6 +18,8 @@ import {
 	nanoGptDefaultModelId,
 	nanoGptDefaultModelInfo,
 	openAiModelInfoSaneDefaults,
+	openAiNativeDefaultModelId,
+	openAiNativeModels,
 	minimaxDefaultModelId,
 	minimaxModels,
 	friendliDefaultModelId,
@@ -108,6 +110,35 @@ describe("useSelectedModel", () => {
 		[providerIdentifiers.zooGateway, "zooGatewayModelId"],
 	] as const
 	const configuredModelInfo: ModelInfo = { contextWindow: 1, supportsPromptCache: false }
+
+	describe("OpenAI Native model selection", () => {
+		beforeEach(() => {
+			mockUseRouterModels.mockReturnValue(createRouterModelsResult({}))
+			mockUseOpenRouterModelProviders.mockReturnValue(createOpenRouterModelProvidersResult({}))
+		})
+
+		it.each([false, true])("uses the canonical default with router loading=%s", (isLoading) => {
+			mockUseRouterModels.mockReturnValue(createRouterModelsResult(isLoading ? undefined : {}, { isLoading }))
+
+			const { result } = renderHook(() => useSelectedModel({ apiProvider: providerIdentifiers.openaiNative }), {
+				wrapper: createWrapper(),
+			})
+
+			expect(result.current.id).toBe(openAiNativeDefaultModelId)
+			expect(result.current.info).toEqual(openAiNativeModels[openAiNativeDefaultModelId])
+			expect(result.current.isLoading).toBe(false)
+		})
+
+		it("preserves an explicitly configured model even when it is the former fallback", () => {
+			const { result } = renderHook(
+				() => useSelectedModel({ apiProvider: providerIdentifiers.openaiNative, apiModelId: "gpt-4o" }),
+				{ wrapper: createWrapper() },
+			)
+
+			expect(result.current.id).toBe("gpt-4o")
+			expect(result.current.info).toEqual(openAiNativeModels["gpt-4o"])
+		})
+	})
 
 	it.each(dynamicProviderCases)("uses router data for %s", (provider, modelIdKey) => {
 		const modelInfo: ModelInfo = { contextWindow: 42_000, supportsPromptCache: false }


### PR DESCRIPTION
<!--
Thank you for contributing to Zoo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #992 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->
OpenAI Native could select `gpt-4o` when no `apiModelId` was configured, even though its canonical default is `gpt-5.6-sol`. Update `getProviderDefaultModelId()` to import and return `openAiNativeDefaultModelId` instead of a hardcoded model ID. This keeps fallback selection aligned with future provider default changes and improves provider reliability.

The existing `useSelectedModel()` logic now receives the canonical default. Explicitly configured models, including `gpt-4o`, remain selected. Add focused shared-types and hook regression tests for default selection, loading router data, and explicit model preservation.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->
```sh
pnpm --dir packages/types exec vitest run src/__tests__/provider-default-model.test.ts src/__tests__/openai-models.test.ts
pnpm --dir webview-ui exec vitest run src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
pnpm --dir packages/types check-types
pnpm --dir webview-ui check-types
pnpm lint
```

The four added test cases verify that:

- The shared OpenAI Native default equals `openAiNativeDefaultModelId`.
- Without an explicit model, the hook returns the canonical model ID and metadata when router data is available.
- The same default resolves while router data is loading, without marking the static provider as loading.
- An explicitly configured `gpt-4o` retains its model ID and metadata.

Before the fix, the three new default-selection cases failed with `gpt-4o` instead of the canonical default. All four pass with the fix.


### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Visual Snapshots

<!--
For UI changes to static rendered state, the primary artifact is a committed
Playwright Story Gallery snapshot (`*.visual.tsx` in `webview-ui/`) — that baseline
becomes durable regression coverage for the surface. See
`webview-ui/AGENTS.md` for what deserves a snapshot.

Before/after screenshots pasted here are welcome as a review aid but are not a
substitute for the committed baseline. If a snapshot is possible, prefer the
snapshot.
-->

### Videos (interaction / animation only)

<!--
Snapshots cannot capture motion or multi-step flows. Attach a short screen
recording here when reviewers need to see:
  - A new interactive flow (dropdown, form, dialog progression)
  - Animation, transition, or timing behavior
  - A regression that only manifests during interaction

Videos are a review aid, not regression coverage. If the *result* of the
interaction has a distinct rendered state worth protecting, still commit a
`*.visual.tsx` snapshot of that end-state alongside the video.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->
- [ ] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
